### PR TITLE
HTML-encode the JSON response based on the content type

### DIFF
--- a/api/src/org/labkey/api/action/ApiJsonWriter.java
+++ b/api/src/org/labkey/api/action/ApiJsonWriter.java
@@ -169,11 +169,21 @@ public class ApiJsonWriter extends ApiResponseWriter
         writeObject(value);
     }
 
+    /** Let subclasses have a chance to do special handling on String values in the response */
+    protected void writeString(String value) throws IOException
+    {
+        jg.writeString(value);
+    }
+
     @Override
     protected void writeObject(Object value) throws IOException
     {
         ensureNotClosed();
-        if (value instanceof String || value instanceof Number || value instanceof Boolean || value == null)
+        if (value instanceof String s)
+        {
+            writeString(value);
+        }
+        else if (value instanceof Number || value instanceof Boolean || value == null)
         {
             jg.writeObject(value);
         }
@@ -224,9 +234,9 @@ public class ApiJsonWriter extends ApiResponseWriter
                 jg.writeEndArray();
             }
         }
-        else if (value instanceof Date)
+        else if (value instanceof Date d)
         {
-            jg.writeString(DateUtil.formatJsonDateTime((Date) value));
+            writeString(DateUtil.formatJsonDateTime(d));
         }
         // Always use Jackson serialization for SimpleResponse, Issue 47216
         else if (isSerializeViaJacksonAnnotations() || value instanceof SimpleResponse<?>)
@@ -239,7 +249,7 @@ public class ApiJsonWriter extends ApiResponseWriter
         }
         else
         {
-            jg.writeString(value.toString());
+            writeString(value.toString());
         }
     }
 

--- a/api/src/org/labkey/api/action/ApiJsonWriter.java
+++ b/api/src/org/labkey/api/action/ApiJsonWriter.java
@@ -77,9 +77,9 @@ public class ApiJsonWriter extends ApiResponseWriter
 
     public ApiJsonWriter(HttpServletResponse response, String contentTypeOverride, ObjectMapper mapper, boolean prettyPrint) throws IOException
     {
-        super(response);
         response.setContentType(null == contentTypeOverride ? CONTENT_TYPE_JSON : contentTypeOverride);
         response.setCharacterEncoding("utf-8");
+        super(response);
         if (prettyPrint)
         {
             jg.useDefaultPrettyPrinter();

--- a/api/src/org/labkey/api/action/ApiJsonWriter.java
+++ b/api/src/org/labkey/api/action/ApiJsonWriter.java
@@ -181,7 +181,7 @@ public class ApiJsonWriter extends ApiResponseWriter
         ensureNotClosed();
         if (value instanceof String s)
         {
-            writeString(value);
+            writeString(s);
         }
         else if (value instanceof Number || value instanceof Boolean || value == null)
         {

--- a/api/src/org/labkey/api/action/ExtFormResponseWriter.java
+++ b/api/src/org/labkey/api/action/ExtFormResponseWriter.java
@@ -64,7 +64,6 @@ import java.io.Writer;
  */
 public class ExtFormResponseWriter extends ApiJsonWriter
 {
-    boolean htmlWriterInitialized;
     private Writer _encodingWriter;
     private boolean _closed;
 
@@ -167,7 +166,6 @@ public class ExtFormResponseWriter extends ApiJsonWriter
             Writer w = super.getWriter();
             if (w != null)
             {
-                w.write("</textarea></body></html>");
                 w.flush();
             }
         }
@@ -180,17 +178,11 @@ public class ExtFormResponseWriter extends ApiJsonWriter
         Writer w = super.getWriter();
         if (null == w)
             return null;
-        if (isHtml() && !htmlWriterInitialized)
+        if (isHtml() && _encodingWriter == null)
         {
-            htmlWriterInitialized = true;
-            try
-            {
-                w.write("<html><body><textarea>");
-            }
-            catch (IOException _) {}
             _encodingWriter = new HtmlEncodingWriter(w);
         }
-        return isHtml() && _encodingWriter != null ? _encodingWriter : w;
+        return _encodingWriter != null ? _encodingWriter : w;
     }
 
     /** Wraps a Writer to HTML-encode all output, so JSON can be safely embedded inside a &lt;textarea&gt; element. */

--- a/api/src/org/labkey/api/action/ExtFormResponseWriter.java
+++ b/api/src/org/labkey/api/action/ExtFormResponseWriter.java
@@ -19,7 +19,7 @@ import org.json.JSONObject;
 import org.labkey.api.query.PropertyValidationError;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
-import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.MimeMap;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
@@ -27,6 +27,7 @@ import org.springframework.web.multipart.MultipartHttpServletRequest;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.FilterWriter;
 import java.io.IOException;
 import java.io.Writer;
 
@@ -63,41 +64,28 @@ import java.io.Writer;
  */
 public class ExtFormResponseWriter extends ApiJsonWriter
 {
-    boolean sendHtmlJsonResponse = false;
-    boolean startResponse = true;
-    
-    public ExtFormResponseWriter(HttpServletResponse response) throws IOException
-    {
-        super(response);
-        setErrorResponseStatus(HttpServletResponse.SC_OK);
-    }
+    boolean htmlWriterInitialized;
+    private Writer _encodingWriter;
+    private boolean _closed;
 
     public ExtFormResponseWriter(HttpServletRequest request, HttpServletResponse response) throws IOException
     {
-        this(response);
-        if (!"XMLHttpRequest".equals(request.getHeader("X-Requested-With")) && (request instanceof MultipartHttpServletRequest))
-            sendHtmlJsonResponse = true;
-        response.setContentType(sendHtmlJsonResponse ? "text/html" : CONTENT_TYPE_JSON);
+        boolean sendHtml = !"XMLHttpRequest".equals(request.getHeader("X-Requested-With")) &&
+                request instanceof MultipartHttpServletRequest;
+        super(response, sendHtml ? MimeMap.MimeType.HTML.getContentType() : CONTENT_TYPE_JSON);
+        setErrorResponseStatus(HttpServletResponse.SC_OK);
+    }
+
+    private boolean isHtml()
+    {
+        return getResponse().getContentType().startsWith(MimeMap.MimeType.HTML.getContentType());
     }
 
     public ExtFormResponseWriter(HttpServletRequest request, HttpServletResponse response, String contentTypeOverride) throws IOException
     {
         this(request, response);
-        if (!sendHtmlJsonResponse && null != contentTypeOverride)
+        if (!isHtml() && null != contentTypeOverride)
             response.setContentType(contentTypeOverride);
-    }
-
-    @Override
-    public void writeProperty(String name, Object value) throws IOException
-    {
-        // writeObject() will have a chance to encode the value
-        super.writeProperty(sendHtmlJsonResponse ? PageFlowUtil.filter(name) : name, value);
-    }
-
-    @Override
-    protected void writeString(String value) throws IOException
-    {
-        super.writeString(sendHtmlJsonResponse ? PageFlowUtil.filter(value) : value);
     }
 
     @Override
@@ -170,20 +158,75 @@ public class ExtFormResponseWriter extends ApiJsonWriter
     }
 
     @Override
+    public void close() throws IOException
+    {
+        super.close();
+        if (isHtml() && !_closed)
+        {
+            _encodingWriter.flush();
+            Writer w = super.getWriter();
+            if (w != null)
+            {
+                w.write("</textarea></body></html>");
+                w.flush();
+            }
+        }
+        _closed = true;
+    }
+
+    @Override
     protected Writer getWriter()
     {
         Writer w = super.getWriter();
         if (null == w)
             return null;
-        if (sendHtmlJsonResponse && startResponse)
+        if (isHtml() && !htmlWriterInitialized)
         {
-            startResponse = false;
+            htmlWriterInitialized = true;
             try
             {
-            w.write("<html><body><textarea>");
+                w.write("<html><body><textarea>");
             }
-            catch (IOException ignored) {}
+            catch (IOException _) {}
+            _encodingWriter = new HtmlEncodingWriter(w);
         }
-        return w;
+        return isHtml() && _encodingWriter != null ? _encodingWriter : w;
+    }
+
+    /** Wraps a Writer to HTML-encode all output, so JSON can be safely embedded inside a &lt;textarea&gt; element. */
+    private static class HtmlEncodingWriter extends FilterWriter
+    {
+        HtmlEncodingWriter(Writer out)
+        {
+            super(out);
+        }
+
+        @Override
+        public void write(int c) throws IOException
+        {
+            switch (c)
+            {
+                case '&' -> out.write("&amp;");
+                case '<' -> out.write("&lt;");
+                case '>' -> out.write("&gt;");
+                case '"' -> out.write("&quot;");
+                case '\'' -> out.write("&#39;");
+                default -> out.write(c);
+            }
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) throws IOException
+        {
+            for (int i = off; i < off + len; i++)
+                write(cbuf[i]);
+        }
+
+        @Override
+        public void write(String str, int off, int len) throws IOException
+        {
+            for (int i = off; i < off + len; i++)
+                write(str.charAt(i));
+        }
     }
 }

--- a/api/src/org/labkey/api/action/ExtFormResponseWriter.java
+++ b/api/src/org/labkey/api/action/ExtFormResponseWriter.java
@@ -90,20 +90,14 @@ public class ExtFormResponseWriter extends ApiJsonWriter
     @Override
     public void writeProperty(String name, Object value) throws IOException
     {
+        // writeObject() will have a chance to encode the value
         super.writeProperty(sendHtmlJsonResponse ? PageFlowUtil.filter(name) : name, value);
     }
 
     @Override
-    protected void writeObject(Object value) throws IOException
+    protected void writeString(String value) throws IOException
     {
-        if (value instanceof String s && sendHtmlJsonResponse)
-        {
-            super.writeObject(PageFlowUtil.filter(s));
-        }
-        else
-        {
-            super.writeObject(value);
-        }
+        super.writeString(sendHtmlJsonResponse ? PageFlowUtil.filter(value) : value);
     }
 
     @Override

--- a/api/src/org/labkey/api/action/ExtFormResponseWriter.java
+++ b/api/src/org/labkey/api/action/ExtFormResponseWriter.java
@@ -19,6 +19,7 @@ import org.json.JSONObject;
 import org.labkey.api.query.PropertyValidationError;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.util.PageFlowUtil;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
@@ -28,12 +29,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Writer;
-
-/*
-* User: Dave
-* Date: Sep 3, 2008
-* Time: 11:03:32 AM
-*/
 
 /**
  * This writer extends ApiJsonWriter by writing validation errors in the format
@@ -93,6 +88,25 @@ public class ExtFormResponseWriter extends ApiJsonWriter
     }
 
     @Override
+    public void writeProperty(String name, Object value) throws IOException
+    {
+        super.writeProperty(sendHtmlJsonResponse ? PageFlowUtil.filter(name) : name, value);
+    }
+
+    @Override
+    protected void writeObject(Object value) throws IOException
+    {
+        if (value instanceof String s && sendHtmlJsonResponse)
+        {
+            super.writeObject(PageFlowUtil.filter(s));
+        }
+        else
+        {
+            super.writeObject(value);
+        }
+    }
+
+    @Override
     public JSONObject toJSON(ValidationException e)
     {
         String message = null;
@@ -121,8 +135,8 @@ public class ExtFormResponseWriter extends ApiJsonWriter
     {
         String msg = error.getMessage();
         String key = "_form";
-        if (error instanceof PropertyValidationError)
-            key = ((PropertyValidationError)error).getProperty();
+        if (error instanceof PropertyValidationError pve)
+            key = pve.getProperty();
         if (jsonErrors.has(key))
             msg = jsonErrors.get(key) + "; " + msg;
         jsonErrors.put(key, msg);
@@ -139,8 +153,8 @@ public class ExtFormResponseWriter extends ApiJsonWriter
             if (message == null)
                 message = msg;
             String key = "_form";
-            if (error instanceof FieldError)
-                key = ((FieldError)error).getField();
+            if (error instanceof FieldError fieldError)
+                key = fieldError.getField();
             if (jsonErrors.has(key))
                 msg = jsonErrors.get(key) + "; " + msg;
             jsonErrors.put(key, msg);
@@ -174,10 +188,7 @@ public class ExtFormResponseWriter extends ApiJsonWriter
             {
             w.write("<html><body><textarea>");
             }
-            catch (IOException x)
-            {
-                
-            }
+            catch (IOException ignored) {}
         }
         return w;
     }


### PR DESCRIPTION
#### Rationale
A certain combination of HTTP headers can cause mixup in terms of `Content-Type` and encoding. I don't think this will happen in real-world scenarios, but can be hit by security scanners.

The reported scenario is doing a POST to `query-import` without the `X-Requested-With=XMLHttpRequest` HTTP request header. The actual form submission sends that header, so the server responds with `application/json`. Without the header, the server returns JSON with as `text/html` but fails to HTML encode.

#### Changes
- HTML encode the JSON, per the pre-existing comment

#### Tasks 📍
- [x] Try HTML encoding the whole stream @labkey-jeckels 📍 
- Manual Testing - N/A
- Needs Automation - N/A