### PR TITLE
Use all-caps label for metadata PK name

### DIFF
--- a/api/src/org/labkey/api/data/dialect/PkMetaDataReader.java
+++ b/api/src/org/labkey/api/data/dialect/PkMetaDataReader.java
@@ -44,6 +44,6 @@ public class PkMetaDataReader
 
     public String getKeyName() throws SQLException
     {
-        return _rsCols.getString("pk_name");
+        return _rsCols.getString("PK_NAME");
     }
 }


### PR DESCRIPTION
#### Rationale
Contrary to `java.sql.ResultSet`'s [specification](https://docs.oracle.com/en/java/javase/25/docs/api/java.sql/java/sql/ResultSet.html#:~:text=Column%20names%20used%20as%20input%20to%20getter%20methods%20are%20case%20insensitive), the Snowflake JDBC driver's ResultSet implementation has case-sensitive getters. Calling `ResultSet.getString("pk_name")` on Snowflake metadata thows an error but `ResultSet.getString("PK_NAME")` works.
The `nameKey` and `seqKey` values used for all of our `PkMetaDataReader` implementations are in all caps and `PK_NAME` works for postgres and SQL Server so I'm thinking it is a fine option here.

#### Related Pull Requests
- #7016 

#### Changes
- Use all-caps label for metadata PK name

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->