### PR TITLE
Keep schema browser link at the top of the Developer menu

### DIFF
--- a/api/src/org/labkey/api/view/DeveloperMenu.java
+++ b/api/src/org/labkey/api/view/DeveloperMenu.java
@@ -54,7 +54,7 @@ public class DeveloperMenu
         registerMenuProvider((c, user, items) -> {
             if (c.hasPermission(user, ReadPermission.class))
             {
-                items.add(DeveloperMenuNavTrees.Section.tools, new NavTree("Schema Browser", PageFlowUtil.urlProvider(QueryUrls.class).urlSchemaBrowser(c)));
+                items.add(DeveloperMenuNavTrees.Section.query, new NavTree("Schema Browser", PageFlowUtil.urlProvider(QueryUrls.class).urlSchemaBrowser(c)));
             }
 
             if (user.isPlatformDeveloper())

--- a/api/src/org/labkey/api/view/DeveloperMenuNavTrees.java
+++ b/api/src/org/labkey/api/view/DeveloperMenuNavTrees.java
@@ -13,6 +13,7 @@ public class DeveloperMenuNavTrees
     /** Groupings for menu items, ordered based on their desired sequence (roughly in terms of usage) */
     public enum Section
     {
+        query,
         tools,
         monitoring,
         referenceDocs,


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/813

Stick "Schema Browser" in its own category that's always first so (for example) RStudio or other tools don't sort on top of it.

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Verify Fix
-->