### PR TITLE
Collect CachedResultSet creation stack traces

### DIFF
--- a/api/src/org/labkey/api/data/CachedResultSet.java
+++ b/api/src/org/labkey/api/data/CachedResultSet.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.RowMap;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.miniprofiler.MiniProfiler;
+import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.ResultSetUtil;
@@ -173,7 +174,7 @@ public class CachedResultSet implements ResultSet, TableResultSet
 
         String url = null;
         String threadName = null;
-        if (true) //MiniProfiler.isCollectTroubleshootingStackTraces()) // TODO: Restore check before 26.3
+        if (AppProps.getInstance().isDevMode()) //MiniProfiler.isCollectTroubleshootingStackTraces()) // TODO: Restore check before 26.3
         {
             // Stash stack trace that created this CachedRowSet
             if (null == stackTrace)

--- a/api/src/org/labkey/api/data/CachedResultSet.java
+++ b/api/src/org/labkey/api/data/CachedResultSet.java
@@ -17,9 +17,7 @@
 package org.labkey.api.data;
 
 import org.apache.commons.beanutils.ConvertUtils;
-import java.lang.ref.Cleaner;
 import org.apache.commons.collections4.IteratorUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -29,11 +27,13 @@ import org.labkey.api.miniprofiler.MiniProfiler;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.ResultSetUtil;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewServlet;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.lang.ref.Cleaner;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Array;
@@ -68,7 +68,7 @@ import static org.labkey.api.util.IntegerUtils.asInteger;
  */
 public class CachedResultSet implements ResultSet, TableResultSet
 {
-    private static final Logger _log = LogManager.getLogger(CachedResultSet.class);
+    private static final Logger _log = LogHelper.getLogger(CachedResultSet.class, "Unclosed CachedResultSets");
 
     // metadata
     private final ResultSetMetaData _md;
@@ -173,12 +173,12 @@ public class CachedResultSet implements ResultSet, TableResultSet
 
         String url = null;
         String threadName = null;
-        if (MiniProfiler.isCollectTroubleshootingStackTraces())
+        if (true) //MiniProfiler.isCollectTroubleshootingStackTraces()) // TODO: Restore check before 26.3
         {
             // Stash stack trace that created this CachedRowSet
             if (null == stackTrace)
             {
-                stackTrace = MiniProfiler.getTroubleshootingStackTrace();
+                stackTrace = MiniProfiler.getTroubleshootingStackTraceUnconditionally(); // TODO: Switch to conditional method before 26.3
             }
 
             threadName = Thread.currentThread().getName();

--- a/api/src/org/labkey/api/miniprofiler/MiniProfiler.java
+++ b/api/src/org/labkey/api/miniprofiler/MiniProfiler.java
@@ -269,20 +269,25 @@ public class MiniProfiler
     @Nullable
     public static StackTraceElement[] getTroubleshootingStackTrace()
     {
-        if (isCollectTroubleshootingStackTraces())
+        return isCollectTroubleshootingStackTraces() ? getTroubleshootingStackTraceUnconditionally() : null;
+    }
+
+    /**
+     * @return the stack of the calling thread regardless of the state of the "enable stack traces" setting.
+     */
+    @NotNull
+    public static StackTraceElement[] getTroubleshootingStackTraceUnconditionally()
+    {
+        StackTraceElement[] fullStack = Thread.currentThread().getStackTrace();
+        if (fullStack.length > 0)
         {
-            StackTraceElement[] fullStack = Thread.currentThread().getStackTrace();
-            if (fullStack.length > 0)
-            {
-                // Automatically omit this method from the stack
-                int callerFramesToOmit = 2;
-                StackTraceElement[] result = new StackTraceElement[fullStack.length - callerFramesToOmit];
-                System.arraycopy(fullStack, 1, result, 0, result.length);
-                return result;
-            }
-            return fullStack;
+            // Automatically omit this method from the stack
+            int callerFramesToOmit = 2;
+            StackTraceElement[] result = new StackTraceElement[fullStack.length - callerFramesToOmit];
+            System.arraycopy(fullStack, 1, result, 0, result.length);
+            return result;
         }
-        return null;
+        return fullStack;
     }
 
     /** This setting will be retained only for the current instance of the web app. Once the server is restarted, it will default to false again */

--- a/devtools/src/org/labkey/devtools/TestController.java
+++ b/devtools/src/org/labkey/devtools/TestController.java
@@ -28,7 +28,6 @@ import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.SimpleResponse;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
-import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.mcp.AbstractAgentAction;
@@ -1292,7 +1291,7 @@ public class TestController extends SpringActionController
     public static class ChatAction extends SimpleViewAction<Object>
     {
         @Override
-        public ModelAndView getView(Object o, BindException errors) throws Exception
+        public ModelAndView getView(Object o, BindException errors)
         {
             if (null == McpService.get() || !McpService.get().isReady())
                 return HtmlView.of("Service is not ready yet.");
@@ -1331,14 +1330,14 @@ public class TestController extends SpringActionController
         AtomicInteger count = new AtomicInteger();
 
         @Override
-        public ModelAndView getConfirmView(Object o, BindException errors) throws Exception
+        public ModelAndView getConfirmView(Object o, BindException errors)
         {
             var db = FileUtil.getTempDirectoryFileLike().resolveChild("VectorStore.database");
             HtmlStringBuilder message = HtmlStringBuilder.of();
             message.append("This will add the contents of /Documention wikis to the vector store.").append(HtmlString.BR);
             message.append("This may take a few minutes.");
             if (db.exists())
-                message.unsafeAppend("<p/><p/>").append("I see a vector store file already exists.  Just FYI.");
+                message.unsafeAppend("<p/><p/>").append("I see a vector store file already exists. Just FYI.");
             return new HtmlView(message);
         }
 
@@ -1355,20 +1354,21 @@ public class TestController extends SpringActionController
 
 
         // not usually used but some actions return views that close the current window etc...
+        @Override
         public ModelAndView getSuccessView(Object form)
         {
             return HtmlView.of(count.get() + " documents added to vector store");
         }
 
         @Override
-        public boolean handlePost(Object o, BindException errors) throws Exception
+        public boolean handlePost(Object o, BindException errors)
         {
             Container documentsContainer = ContainerManager.getForPath("/Documentation");
             if (null == documentsContainer)
                 throw new NotFoundException();
             VectorStore vs = McpService.get().getVectorStore();
             if (null == vs)
-                throw new NotFoundException();
+                throw new NotFoundException("/Documentation project was not found");
 
             ActionURL wikiBase = new ActionURL("wiki","page",documentsContainer);
 


### PR DESCRIPTION
#### Rationale
We want to track down code paths that aren't closing CachedResultSets; that's nearly impossible without stack traces. This change collects CachedResultSet creation stack traces in dev mode. We'll likely revert this after we've fixed the issue(s) showing up on TeamCity.