### PR TITLE
Fixed related to converter util refactoring

### DIFF
--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -742,6 +742,8 @@ public class DataColumn extends DisplayColumn
     private void renderSelectFormInput(HtmlWriter out, String formFieldName, Object value, List<String> strValues, boolean disabledInput, NamedObjectList entryList)
     {
         boolean isMultiple = "select.multiple".equalsIgnoreCase(_inputType);
+        if (isMultiple && !formFieldName.startsWith(MultiChoice.ARRAY_MARKER))
+            formFieldName = MultiChoice.ARRAY_MARKER + formFieldName;
         SelectBuilder select = new SelectBuilder()
             .disabled(disabledInput)
             .multiple(isMultiple)

--- a/api/src/org/labkey/api/util/SubstitutionFormat.java
+++ b/api/src/org/labkey/api/util/SubstitutionFormat.java
@@ -82,8 +82,17 @@ public class SubstitutionFormat
                 return defaultTimeFormat.format(value);
             else if (value instanceof java.sql.Date)
                 return date.format(value);
-            else if (value instanceof Date)
-                return defaultDateTimeFormat.format(value).replace('T', ' '); // replace T with whitespace for human readability
+            else if (value instanceof Date dateVal)
+            {
+                // both date and datetime column type are of type Date, format based on time portion of the date value
+                LocalDateTime ldt = LocalDateTime.ofInstant(dateVal.toInstant(), ZoneId.systemDefault());
+                boolean isDateOnly = ldt.toLocalTime().equals(java.time.LocalTime.MIDNIGHT);
+
+                if (isDateOnly)
+                    return date.format(value);
+                else
+                    return defaultDateTimeFormat.format(value).replace('T', ' '); // replace T with whitespace for human readability
+            }
 
             return value;
         }

--- a/query/src/org/labkey/query/sql/CalculatedExpressionColumn.java
+++ b/query/src/org/labkey/query/sql/CalculatedExpressionColumn.java
@@ -1,5 +1,6 @@
 package org.labkey.query.sql;
 
+import org.apache.commons.beanutils.ConversionException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.AbstractTableInfo;
@@ -371,6 +372,11 @@ public class CalculatedExpressionColumn extends BaseColumnInfo
         return _boundExpr;
     }
 
+    @Override
+    public Object convert(Object o) throws ConversionException
+    {
+        return o;
+    }
 
     /*
      * TESTS


### PR DESCRIPTION
#### Rationale
The refactoring of ConvertUtils usages caused a few test failures:

- This one is due to calculated expression column value being converted when it shouldn't:
[BiologicsAPITest](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_NightlyBiologicsPostgres/3834869?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests.biologics&class=BiologicsAPITest).[setVectorAliasViaLegacyUI](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_NightlyBiologicsPostgres/3834869?buildTab=tests&status=failed&expandedTest=build%3A%28id%3A3834846%29%2Cid%3A2000000322), [BiologicsDataClassTest](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_NightlyBiologicsPostgres/3836319?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests.biologics.registry&class=BiologicsDataClassTest).[testAliasMultiValueDisplayColumn](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_NightlyBiologicsPostgres/3836319?buildTab=tests&status=failed)

- This one is due to both date and datetime fields are now converted to java.util.Date type. In the past, one is converted to java.sql.Date and the other java.util.Date. 
[End Point Test: Name expressions field name](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_WorkflowEndpoints/3834925?buildTab=tests&status=failed&name=Name+expressions+field+name)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7348
- https://github.com/LabKey/platform/pull/7395
- https://github.com/LabKey/limsModules/pull/1974
- https://github.com/LabKey/testAutomation/pull/2878

#### Changes
- Skip convert for CalculatedExpressionColumn
- Format date value used in naming expression based on its time portion

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->