### PR TITLE
GitHub Issue 827: Cannot aliquot samples using lineage search naming pattern

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -78,6 +78,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.labkey.api.exp.api.ExpMaterial.ALIQUOTED_FROM_INPUT;
+import static org.labkey.api.exp.api.ExpMaterial.ALIQUOTED_FROM_INPUT_LABEL;
 import static org.labkey.api.exp.api.ExpRunItem.INPUT_PARENT;
 import static org.labkey.api.exp.api.ExperimentJSONConverter.DATA_INPUTS;
 import static org.labkey.api.exp.api.ExperimentJSONConverter.MATERIAL_INPUTS;
@@ -738,6 +739,17 @@ public class NameGenerator
             String valueStr = value instanceof String ? (String) value : value.toString();
             if (StringUtils.isEmpty((valueStr).trim()))
                 return Stream.empty();
+
+            // GitHub Issue 827: Cannot aliquot samples where parent sample has a comma in the name AND the aliquot naming pattern references ancestor lineage
+            if (ALIQUOTED_FROM_INPUT.equalsIgnoreCase(parentColName) || ALIQUOTED_FROM_INPUT_LABEL.equalsIgnoreCase(parentColName))
+            {
+                boolean isQuoted = (valueStr.contains(",") || valueStr.contains("\n") || valueStr.contains("\r")) && (valueStr.startsWith("\"") && valueStr.endsWith("\""))
+                if (isQuoted)
+                {
+                    valueStr = valueStr.substring(1, valueStr.length() - 1);
+                }
+                return Stream.of(valueStr);
+            }
 
             // Issue 44841: The names of the parents may include commas, so we parse the set of parent names
             // using TabLoader instead of just splitting on the comma.

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -51,6 +51,7 @@ import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.StringExpressionFactory.AbstractStringExpression.NullValueBehavior;
 import org.labkey.api.util.StringExpressionFactory.FieldKeyStringExpression;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.SubstitutionFormat;
 
 import java.io.IOException;
@@ -745,9 +746,7 @@ public class NameGenerator
             {
                 boolean isQuoted = (valueStr.contains(",") || valueStr.contains("\n") || valueStr.contains("\r")) && (valueStr.startsWith("\"") && valueStr.endsWith("\""))
                 if (isQuoted)
-                {
-                    valueStr = valueStr.substring(1, valueStr.length() - 1);
-                }
+                    valueStr = StringUtilsLabKey.unquoteString(valueStr).trim();
                 return Stream.of(valueStr);
             }
 

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -744,7 +744,7 @@ public class NameGenerator
             // GitHub Issue 827: Cannot aliquot samples where parent sample has a comma in the name AND the aliquot naming pattern references ancestor lineage
             if (ALIQUOTED_FROM_INPUT.equalsIgnoreCase(parentColName) || ALIQUOTED_FROM_INPUT_LABEL.equalsIgnoreCase(parentColName))
             {
-                boolean isQuoted = (valueStr.contains(",") || valueStr.contains("\n") || valueStr.contains("\r")) && (valueStr.startsWith("\"") && valueStr.endsWith("\""))
+                boolean isQuoted = (valueStr.contains(",") || valueStr.contains("\n") || valueStr.contains("\r")) && (valueStr.startsWith("\"") && valueStr.endsWith("\""));
                 if (isQuoted)
                     valueStr = StringUtilsLabKey.unquoteString(valueStr).trim();
                 return Stream.of(valueStr);


### PR DESCRIPTION
#### Rationale
Aliquot parent can be used to lookup ancestors with lineage search syntax (~DataInputs/~MaterialInputs). If a aliquot parent name is with,comma, it would come in as "with,comma", but then processed to with,comma  so the correct value is used to generate name that references the aliquot parent (Issue [45563](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45563)). Because the quotes are already stripped, aliquotParent value should not go through ExperimentService.getParentValues again, which assumes TSV encoded string. This PR short circuit aliquot parent processing in parentNames util. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7399
- https://github.com/LabKey/limsModules/pull/1978

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->