### PR TITLE
Fix wiki delete npe and hide datasource test button

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -714,7 +714,8 @@ public class QueryController extends SpringActionController
         public ModelAndView getView(Object o, BindException errors)
         {
             // Site Admin or Troubleshooter? Troubleshooters can see all the information but can't test data sources.
-            boolean hasAdminOpsPerms = getContainer().hasPermission(getUser(), AdminOperationsPermission.class);
+            // Dev mode only, since "Test" is meant for LabKey's own development and testing purposes.
+            boolean showTestButton = getContainer().hasPermission(getUser(), AdminOperationsPermission.class) && AppProps.getInstance().isDevMode();
             List<ExternalSchemaDef> allDefs = QueryManager.get().getExternalSchemaDefs(null);
 
             MultiValuedMap<String, ExternalSchemaDef> byDataSourceName = new ArrayListValuedHashMap<>();
@@ -729,7 +730,7 @@ public class QueryController extends SpringActionController
                 BR(),
                 TABLE(cl("labkey-data-region"),
                     TR(cl("labkey-show-borders"),
-                        hasAdminOpsPerms ? TD(cl("labkey-column-header"), "Test") : null,
+                        showTestButton ? TD(cl("labkey-column-header"), "Test") : null,
                         TD(cl("labkey-column-header"), "Data Source"),
                         TD(cl("labkey-column-header"), "Current Status"),
                         TD(cl("labkey-column-header"), "URL"),
@@ -759,7 +760,7 @@ public class QueryController extends SpringActionController
                             return Stream.of(
                                 TR(
                                     cl(rowStyle),
-                                    hasAdminOpsPerms ? TD(connected ? new ButtonBuilder("Test").href(new ActionURL(TestDataSourceConfirmAction.class, getContainer()).addParameter("dataSource", scope.getDataSourceName())) : "") : null,
+                                    showTestButton ? TD(connected ? new ButtonBuilder("Test").href(new ActionURL(TestDataSourceConfirmAction.class, getContainer()).addParameter("dataSource", scope.getDataSourceName())) : "") : null,
                                     TD(HtmlString.NBSP, scope.getDisplayName()),
                                     TD(status),
                                     TD(scope.getDatabaseUrl()),

--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -427,7 +427,7 @@ public class WikiController extends SpringActionController
         @Override
         public ActionURL getFailURL(WikiNameForm wikiNameForm, BindException errors)
         {
-            return new ManageAction(getViewContext(), _wiki).getUrl();
+            return _wiki != null ? new ManageAction(getViewContext(), _wiki).getUrl() : null;
         }
     }
 


### PR DESCRIPTION
#### Rationale
Addressing two unrelated issues:
- Hide the data source "Test" button when in production mode. https://github.com/LabKey/internal-issues/issues/835
- Fix an NPE when "bad" parameters are passed to the wiki delete action.
  - Found by the TeamCity crawler: https://teamcity.labkey.org/buildConfiguration/LabKey_2511Release_Community_DailySqlServer/3839876?buildTab=overview
  - This URL reproduces the exception (and behaves better with the fix): wiki-delete.view?version=">%27>%27"<script>alert(%278(%27)<%2Fscript>
  - The NPE occurs because generic form binding fails (the form expects `version` to be an int data type) and the action code that always populates the `_wiki` instance var is never invoked
  - Returning `null` from `getFailureURL()` means the confirm action displays a generic view showing the error message