### PR TITLE
Add loading spinner to chat interface

### DIFF
--- a/devtools/src/org/labkey/devtools/view/chat.jsp
+++ b/devtools/src/org/labkey/devtools/view/chat.jsp
@@ -27,6 +27,14 @@
       background-color: lightgray;
     }
 
+    .loading-spinner {
+      margin: 8px 0;
+    }
+
+    .loading-spinner--hidden {
+      display: none;
+    }
+
 </style>
 <labkey:script>
 function startChatting(chatEndpoint)
@@ -79,18 +87,23 @@ function startChatting(chatEndpoint)
             {
                 appendTextResponse('Request failed: ' + req.status + ' ' + (req.statusText || ''));
             }
+
+            const loadingSpinner = document.querySelector('.loading-spinner');
+            loadingSpinner.classList.add('loading-spinner--hidden');
         }
     }
 
     function sendMessage(prompt)
     {
-            var url = new URL(chatEndpoint);
-            url.searchParams.set('prompt', prompt);
-            var req = new XMLHttpRequest();
-            req.open('GET', url.toString(), true);
-            req.onreadystatechange = handleChatResponse;
-            req.send();
-        }
+        var url = new URL(chatEndpoint);
+        url.searchParams.set('prompt', prompt);
+        var req = new XMLHttpRequest();
+        req.open('GET', url.toString(), true);
+        req.onreadystatechange = handleChatResponse;
+        req.send();
+        const loadingSpinner = document.querySelector('.loading-spinner');
+        loadingSpinner.classList.remove('loading-spinner--hidden');
+    }
 
     let firstChat = true;
     elPrompt.addEventListener('keydown', function (ev)
@@ -120,4 +133,9 @@ LABKEY.Utils.onReady(function()
 </labkey:script>
 
 <div id="chatHistory"></div>
+
+<div class="loading-spinner loading-spinner--hidden">
+    <span aria-hidden="true" class="fa fa-spinner fa-pulse"></span>
+</div>
+
 <textarea id="chatPrompt" style="height:100px; width:100%;" placeholder="Shift-Enter to submit"></textarea>


### PR DESCRIPTION
#### Rationale
Just added a basic loading spinner to the chat interface

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Show/hide loading spinner when waiting for response from LLM

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->