### PR TITLE
Fix SQL Server migration issues

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -175,9 +175,13 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
         {
             fsr.addFactories(new NotificationSettingsWriterFactory(), new NotificationSettingsImporterFactory());
         }
+    }
 
+    @Override
+    public void registerMigrationHandlers(@NotNull DatabaseMigrationService service)
+    {
         // AnnouncementModule owns the schema, so it registers the schema handler... even though it's mostly about wiki
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(CommSchema.getInstance().getSchema())
+        service.registerSchemaHandler(new DefaultMigrationSchemaHandler(CommSchema.getInstance().getSchema())
         {
             @Override
             public void beforeSchema()
@@ -212,7 +216,7 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
             }
         });
 
-        DatabaseMigrationService.get().registerTableHandler(new MigrationTableHandler()
+        service.registerTableHandler(new MigrationTableHandler()
         {
             @Override
             public TableInfo getTableInfo()
@@ -227,7 +231,6 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
             }
         });
     }
-
 
     @Override
     public void startBackgroundThreads()

--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -30,23 +30,22 @@ import org.labkey.announcements.query.AnnouncementSchema;
 import org.labkey.api.admin.FolderSerializationRegistry;
 import org.labkey.api.announcements.CommSchema;
 import org.labkey.api.announcements.api.AnnouncementService;
-import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.attachments.AttachmentParentType;
+import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.provider.MessageAuditProvider;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.WrappedColumn;
 import org.labkey.api.message.digest.DailyMessageDigest;
 import org.labkey.api.message.settings.MessageConfigService;
 import org.labkey.api.migration.DatabaseMigrationConfiguration;
 import org.labkey.api.migration.DatabaseMigrationService;
 import org.labkey.api.migration.DefaultMigrationSchemaHandler;
+import org.labkey.api.migration.GuidMapperColumn;
 import org.labkey.api.migration.MigrationTableHandler;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
@@ -56,7 +55,6 @@ import org.labkey.api.security.UserManager;
 import org.labkey.api.security.roles.EditorRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
-import org.labkey.api.util.GUID;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.emailTemplate.EmailTemplateService;
 import org.labkey.api.view.AlwaysAvailableWebPartFactory;
@@ -226,30 +224,6 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
             public ColumnInfo handleColumn(ColumnInfo col)
             {
                 return "DiscussionSrcIdentifier".equals(col.getName()) ? new GuidMapperColumn(col) : col;
-            }
-
-            // In this column, map any value that exactly matches a GUID to lowercase
-            private static final class GuidMapperColumn extends WrappedColumn
-            {
-                public GuidMapperColumn(ColumnInfo col)
-                {
-                    super(col, col.getName());
-                }
-
-                @Override
-                public SQLFragment getValueSql(String tableAlias)
-                {
-                    SQLFragment columnAlias = super.getValueSql(tableAlias);
-                    //noinspection StringConcatenationInsideStringBufferAppend - SQLFragment flips out about unmatched quotes, so we're forced to use string concatenation
-                    return new SQLFragment("CASE WHEN ")
-                        .append(columnAlias)
-                        .append(" LIKE '" + GUID.SQL_LIKE_GUID_PATTERN + "'")
-                        .append(" THEN LOWER(")
-                        .append(columnAlias)
-                        .append(") ELSE ")
-                        .append(columnAlias)
-                        .append(" END");
-                }
             }
         });
     }

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -971,11 +971,12 @@ public class ContainerManager
     }
 
     public static final String SHARED_CONTAINER_PATH = "/Shared";
+    private static final Path SHARED_CONTAINER_PATH_OBJECT = Path.parse(SHARED_CONTAINER_PATH);
 
     @NotNull
     public static Container getSharedContainer()
     {
-        return ensureContainer(Path.parse(SHARED_CONTAINER_PATH), User.getAdminServiceUser());
+        return ensureContainer(SHARED_CONTAINER_PATH_OBJECT, User.getAdminServiceUser());
     }
 
     public static List<Container> getChildren(Container parent)

--- a/api/src/org/labkey/api/data/DbSchemaType.java
+++ b/api/src/org/labkey/api/data/DbSchemaType.java
@@ -73,7 +73,7 @@ public enum DbSchemaType
         @Override
         DbSchema createDbSchema(DbScope scope, String metaDataName, Module module) throws SQLException
         {
-            Map<String, SchemaTableInfoFactory> metaDataTableNames = DbSchema.loadTableMetaData(DbScope.getLabKeyScope(), metaDataName);
+            Map<String, SchemaTableInfoFactory> metaDataTableNames = DbSchema.loadTableMetaData(scope, metaDataName);
 
             return new MigrationDbSchema(metaDataName, this, scope, metaDataTableNames, module);
         }

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1542,7 +1542,7 @@ public class DbScope
         public void testSchemaNames()
         {
             ModuleLoader.getInstance().getModules()
-                    .forEach(m -> assertEquals(getSchemaNames(m, true), getSchemaNames(m, false)));
+                .forEach(m -> assertEquals(getSchemaNames(m, true), getSchemaNames(m, false)));
         }
     }
 

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -122,7 +122,7 @@ public class OntologyManager
                     proj = c;
                 _log.debug("Loading a property descriptor for key " + key + " using project " + proj);
                 String sql = " SELECT * FROM " + getTinfoPropertyDescriptor() + " WHERE PropertyURI = ? AND Project IN (?,?)";
-                List<PropertyDescriptor> pdArray = new SqlSelector(getExpSchema(), sql, propertyURI, proj, _sharedContainer.getId()).getArrayList(PropertyDescriptor.class);
+                List<PropertyDescriptor> pdArray = new SqlSelector(getExpSchema(), sql, propertyURI, proj, ContainerManager.getSharedContainer().getId()).getArrayList(PropertyDescriptor.class);
                 if (!pdArray.isEmpty())
                 {
                     PropertyDescriptor pd = pdArray.get(0);
@@ -132,7 +132,7 @@ public class OntologyManager
                     if (pdArray.size() > 1)
                     {
                         _log.debug("Multiple PropertyDescriptors found for " + propertyURI);
-                        if (pd.getProject().equals(_sharedContainer))
+                        if (pd.getProject().equals(ContainerManager.getSharedContainer()))
                             pd = pdArray.get(1);
                     }
                     _log.debug("Loaded property descriptor " + pd);
@@ -177,7 +177,7 @@ public class OntologyManager
         DomainDescriptor dd = null;
         if (!ddArray.isEmpty())
         {
-            dd = ddArray.get(0);
+            dd = ddArray.getFirst();
 
             // if someone has explicitly inserted a descriptor with the same URI as an existing one ,
             // and one of the two is in the shared project, use the project-level descriptor.
@@ -185,7 +185,7 @@ public class OntologyManager
             {
                 _log.debug("Multiple DomainDescriptors found for " + uriOrName);
                 if (dd.getProject().equals(ContainerManager.getSharedContainer()))
-                    dd = ddArray.get(0);
+                    dd = ddArray.getFirst();
             }
         }
         return dd;
@@ -210,8 +210,8 @@ public class OntologyManager
             sql.addAll(
                 typeURI,
                 // protect against null project, just double-up shared project
-                c.isRoot() ? c.getId() : (c.getProject() == null ? _sharedContainer.getProject().getId() : c.getProject().getId()),
-                _sharedContainer.getProject().getId()
+                c.isRoot() ? c.getId() : (c.getProject() == null ? ContainerManager.getSharedContainer().getProject().getId() : c.getProject().getId()),
+                ContainerManager.getSharedContainer().getProject().getId()
             );
 
             return new SqlSelector(getExpSchema(), sql).mapStream()
@@ -230,8 +230,6 @@ public class OntologyManager
 
         return unmodifiableMap(dds);
     });
-
-    private static final Container _sharedContainer = ContainerManager.getSharedContainer();
 
     public static final String MV_INDICATOR_SUFFIX = "mvindicator";
 
@@ -1579,7 +1577,7 @@ public class OntologyManager
 
             if (_log.isDebugEnabled())
             {
-                try (ResultSet rs = new SqlSelector(getExpSchema(), sql, c, _sharedContainer, newProject).getResultSet())
+                try (ResultSet rs = new SqlSelector(getExpSchema(), sql, c, ContainerManager.getSharedContainer(), newProject).getResultSet())
                 {
                     ResultSetUtil.logData(rs, _log);
                 }
@@ -1590,7 +1588,7 @@ public class OntologyManager
             final StringBuilder sqlIn = new StringBuilder();
             final StringBuilder sep = new StringBuilder();
 
-            new SqlSelector(getExpSchema(), sql, c, _sharedContainer, newProject).forEach(rs -> {
+            new SqlSelector(getExpSchema(), sql, c, ContainerManager.getSharedContainer(), newProject).forEach(rs -> {
                 String objURI = rs.getString(1);
                 String propURI = rs.getString(2);
                 Integer propId = rs.getInt(3);
@@ -1701,7 +1699,7 @@ public class OntologyManager
         if (null == pdIn.getContainer())
         {
             assert false : "Container should be set on PropertyDescriptor";
-            pdIn.setContainer(_sharedContainer);
+            pdIn.setContainer(ContainerManager.getSharedContainer());
         }
 
         PropertyDescriptor pd = getPropertyDescriptor(pdIn.getPropertyURI(), pdIn.getContainer());
@@ -1806,7 +1804,7 @@ public class OntologyManager
         List<String> colDiffs = new ArrayList<>();
 
         // if the returned pd is in a different project, it better be the shared project
-        if (!pd.getProject().equals(pdIn.getProject()) && !pd.getProject().equals(_sharedContainer))
+        if (!pd.getProject().equals(pdIn.getProject()) && !pd.getProject().equals(ContainerManager.getSharedContainer()))
             colDiffs.add("Project");
 
         // check the pd values that can't change
@@ -1980,7 +1978,7 @@ public class OntologyManager
         // Consider: We should check that the pd and dd have been persisted (aka have a non-zero id)
 
         if (!pd.getContainer().equals(dd.getContainer())
-                && !pd.getProject().equals(_sharedContainer))
+                && !pd.getProject().equals(ContainerManager.getSharedContainer()))
             throw new IllegalStateException("ensurePropertyDomain:  property " + pd.getPropertyURI() + " not in same container as domain " + dd.getDomainURI());
 
         SQLFragment sqlInsert = new SQLFragment("INSERT INTO " + getTinfoPropertyDomain() + " ( PropertyId, DomainId, Required, SortOrder ) " +
@@ -2282,7 +2280,7 @@ public class OntologyManager
         if (null != pd)
             return pd;
 
-        key = getCacheKey(propertyURI, _sharedContainer);
+        key = getCacheKey(propertyURI, ContainerManager.getSharedContainer());
         return PROP_DESCRIPTOR_CACHE.get(key);
     }
 
@@ -2485,7 +2483,7 @@ public class OntologyManager
             return dd;
 
         // Try in the /Shared container too
-        key = getCacheKey(domainURI, _sharedContainer);
+        key = getCacheKey(domainURI, ContainerManager.getSharedContainer());
         return DOMAIN_DESCRIPTORS_BY_URI_CACHE.get(key);
     }
 
@@ -2497,7 +2495,7 @@ public class OntologyManager
 
         DomainDescriptor dd = fetchDomainDescriptorFromDB(domainURI, c);
         if (dd == null)
-            dd = fetchDomainDescriptorFromDB(domainURI, _sharedContainer);
+            dd = fetchDomainDescriptorFromDB(domainURI, ContainerManager.getSharedContainer());
         return dd;
     }
 
@@ -2531,9 +2529,9 @@ public class OntologyManager
                 }
             }
 
-            if (_sharedContainer.hasPermission(user, ReadPermission.class))
+            if (ContainerManager.getSharedContainer().hasPermission(user, ReadPermission.class))
             {
-                for (Map.Entry<String, DomainDescriptor> entry : getCachedDomainDescriptors(_sharedContainer, user).entrySet())
+                for (Map.Entry<String, DomainDescriptor> entry : getCachedDomainDescriptors(ContainerManager.getSharedContainer(), user).entrySet())
                 {
                     dds.putIfAbsent(entry.getKey(), entry.getValue());
                 }
@@ -2636,7 +2634,7 @@ public class OntologyManager
             DomainDescriptor dexist = ensureDomainDescriptor(dd);
 
             if (!dexist.getContainer().equals(pd.getContainer())
-                    && !pd.getProject().equals(_sharedContainer))
+                    && !pd.getProject().equals(ContainerManager.getSharedContainer()))
             {
                 // domain is defined in a different container.
                 //ToDO  define property in the domains container?  what security?

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -184,6 +184,7 @@ public class OntologyManager
             if (ddArray.size() > 1)
             {
                 _log.debug("Multiple DomainDescriptors found for " + uriOrName);
+                // TODO: This check and assignment look wrong. We always return the first element.
                 if (dd.getProject().equals(ContainerManager.getSharedContainer()))
                     dd = ddArray.getFirst();
             }

--- a/api/src/org/labkey/api/migration/DefaultMigrationSchemaHandler.java
+++ b/api/src/org/labkey/api/migration/DefaultMigrationSchemaHandler.java
@@ -232,6 +232,7 @@ public class DefaultMigrationSchemaHandler implements MigrationSchemaHandler
         return "   " + StringUtilsLabKey.pluralize(count, "row") + " not copied";
     }
 
+    // afterTable() is called only if the table was filtered by a configuration filter
     @Override
     public void afterTable(TableInfo sourceTable, TableInfo targetTable, SimpleFilter notCopiedFilter)
     {

--- a/api/src/org/labkey/api/migration/GuidMapperColumn.java
+++ b/api/src/org/labkey/api/migration/GuidMapperColumn.java
@@ -1,0 +1,30 @@
+package org.labkey.api.migration;
+
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.WrappedColumn;
+import org.labkey.api.util.GUID;
+
+// In this column, map any value that exactly matches a GUID to lowercase
+public final class GuidMapperColumn extends WrappedColumn
+{
+    public GuidMapperColumn(ColumnInfo col)
+    {
+        super(col, col.getName());
+    }
+
+    @Override
+    public SQLFragment getValueSql(String tableAlias)
+    {
+        SQLFragment columnAlias = super.getValueSql(tableAlias);
+        //noinspection StringConcatenationInsideStringBufferAppend - SQLFragment flips out about unmatched quotes, so we're forced to use string concatenation
+        return new SQLFragment("CASE WHEN ")
+            .append(columnAlias)
+            .append(" LIKE '" + GUID.SQL_LIKE_GUID_PATTERN + "'")
+            .append(" THEN LOWER(")
+            .append(columnAlias)
+            .append(") ELSE ")
+            .append(columnAlias)
+            .append(" END");
+    }
+}

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -341,6 +341,9 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     {
     }
 
+    // TODO: Move getWebPartFactories() and _webPartFactories into Portal... shouldn't be the module's responsibility
+    // This should also allow moving SimpleWebPartFactoryCache and dependencies into Internal
+
     private final Object FACTORY_LOCK = new Object();
 
     @Override
@@ -350,10 +353,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         {
             if (null == _webPartFactories)
             {
-                // We promise that this method is called after upgrade is complete. Enforce that.
-                if (ModuleLoader.getInstance().isUpgradeRequired())
-                    throw new IllegalStateException("getWebPartFactories() is being called before upgrade is complete");
-
                 Collection<WebPartFactory> wpf = new ArrayList<>();
 
                 // Get all the Java webpart factories

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -21,7 +21,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -65,6 +64,7 @@ import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.ResponseHelper;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NotFoundException;
@@ -107,7 +107,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
 {
     public static final String CORE_MODULE_NAME = "Core";
 
-    private static final Logger _log = LogManager.getLogger(DefaultModule.class);
+    private static final Logger _log = LogHelper.getLogger(DefaultModule.class, "Module issues");
     private static final Set<Pair<Class<? extends DefaultModule>, String>> INSTANTIATED_MODULES = new HashSet<>();
 
     static final ModuleResourceCache<ModuleXml> MODULE_XML_CACHE = ModuleResourceCaches.create("module.xml files", new ModuleXmlCacheHandler(), ResourceRootProvider.getStandard(new Path()));
@@ -341,9 +341,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     {
     }
 
-    // TODO: Move getWebPartFactories() and _webPartFactories into Portal... shouldn't be the module's responsibility
-    // This should also allow moving SimpleWebPartFactoryCache and dependencies into Internal
-
     private final Object FACTORY_LOCK = new Object();
 
     @Override
@@ -353,6 +350,10 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         {
             if (null == _webPartFactories)
             {
+                // We promise that this method is called after upgrade is complete. Enforce that.
+                if (ModuleLoader.getInstance().isUpgradeRequired())
+                    throw new IllegalStateException("getWebPartFactories() is being called before upgrade is complete");
+
                 Collection<WebPartFactory> wpf = new ArrayList<>();
 
                 // Get all the Java webpart factories

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -30,6 +30,7 @@ import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SchemaTableInfoFactory;
 import org.labkey.api.data.UpgradeCode;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.migration.DatabaseMigrationService;
 import org.labkey.api.module.DefaultModule.UpgradeMethod;
 import org.labkey.api.query.OlapSchemaInfo;
 import org.labkey.api.resource.Resource;
@@ -439,4 +440,10 @@ public interface Module
      */
     void lock();
 
+    /**
+     * Register MigrationSchemaHandlers, MigrationTableHandlers, and MigrationFilters
+     */
+    default void registerMigrationHandlers(@NotNull DatabaseMigrationService service)
+    {
+    }
 }

--- a/api/src/org/labkey/api/view/SimpleWebPartFactoryCacheHandler.java
+++ b/api/src/org/labkey/api/view/SimpleWebPartFactoryCacheHandler.java
@@ -29,9 +29,6 @@ import java.util.stream.Stream;
 
 /**
  * Creates and caches the file-based web parts defined by modules. File changes result in dynamic reloading and re-initialization of webpart-related maps.
- * User: adam
- * Date: 12/29/13
- * Time: 12:38 PM
  */
 public class SimpleWebPartFactoryCacheHandler implements ModuleResourceCacheHandler<Collection<SimpleWebPartFactory>>
 {

--- a/api/src/org/labkey/api/view/WebPartCache.java
+++ b/api/src/org/labkey/api/view/WebPartCache.java
@@ -41,7 +41,6 @@ import org.labkey.api.view.Portal.WebPart;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -293,8 +293,12 @@ public class AssayModule extends SpringModule
         {
             svc.registerUsageMetrics(getName(), new PlateMetricsProvider());
         }
+    }
 
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(AssayDbSchema.getInstance().getSchema())
+    @Override
+    public void registerMigrationHandlers(@NotNull DatabaseMigrationService service)
+    {
+        service.registerSchemaHandler(new DefaultMigrationSchemaHandler(AssayDbSchema.getInstance().getSchema())
         {
             @Override
             public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)
@@ -311,7 +315,7 @@ public class AssayModule extends SpringModule
         });
 
         // Tables in the "assaywell" provisioned schema join to assay.Well to find their container
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(PlateMetadataDomainKind.getSchema())
+        service.registerSchemaHandler(new DefaultMigrationSchemaHandler(PlateMetadataDomainKind.getSchema())
         {
             @Override
             public FilterClause getContainerClause(TableInfo sourceTable, Set<GUID> containers)
@@ -324,7 +328,7 @@ public class AssayModule extends SpringModule
             }
         });
 
-        DatabaseMigrationService.get().registerSchemaHandler(new AssayResultMigrationSchemaHandler());
+        service.registerSchemaHandler(new AssayResultMigrationSchemaHandler());
     }
 
     @Override

--- a/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
+++ b/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
@@ -45,12 +45,12 @@ import java.util.Set;
 
 class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implements MigrationFilter
 {
-    static void register()
+    static void register(@NotNull DatabaseMigrationService service)
     {
         CoreMigrationSchemaHandler schemaHandler = new CoreMigrationSchemaHandler();
-        DatabaseMigrationService.get().registerSchemaHandler(schemaHandler);
-        DatabaseMigrationService.get().registerMigrationFilter(schemaHandler);
-        DatabaseMigrationService.get().registerTableHandler(new MigrationTableHandler()
+        service.registerSchemaHandler(schemaHandler);
+        service.registerMigrationFilter(schemaHandler);
+        service.registerTableHandler(new MigrationTableHandler()
         {
             @Override
             public TableInfo getTableInfo()
@@ -65,7 +65,7 @@ class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implement
             }
         });
 
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(PropertySchema.getInstance().getSchema()){
+        service.registerSchemaHandler(new DefaultMigrationSchemaHandler(PropertySchema.getInstance().getSchema()){
             @Override
             public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)
             {
@@ -73,7 +73,7 @@ class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implement
             }
         });
 
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(TestSchema.getInstance().getSchema()){
+        service.registerSchemaHandler(new DefaultMigrationSchemaHandler(TestSchema.getInstance().getSchema()){
             @Override
             public List<TableInfo> getTablesToCopy()
             {
@@ -83,7 +83,7 @@ class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implement
 
         if (ModuleLoader.getInstance().getModule(DbScope.getLabKeyScope(), "vehicle") != null)
         {
-            DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(DbSchema.get("vehicle", DbSchemaType.Module))
+            service.registerSchemaHandler(new DefaultMigrationSchemaHandler(DbSchema.get("vehicle", DbSchemaType.Module))
             {
                 @Override
                 public List<TableInfo> getTablesToCopy()

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -89,6 +89,7 @@ import org.labkey.api.files.FileBrowserConfigWriter;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.markdown.MarkdownService;
 import org.labkey.api.message.settings.MessageConfigService;
+import org.labkey.api.migration.DatabaseMigrationService;
 import org.labkey.api.module.FolderType;
 import org.labkey.api.module.FolderTypeManager;
 import org.labkey.api.module.Module;
@@ -1287,7 +1288,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         ContainerManager.addContainerListener(new EmailPreferenceContainerListener());
         UserManager.addUserListener(new EmailPreferenceUserListener());
 
-        CoreMigrationSchemaHandler.register();
         Encryption.checkMigration();
 
         McpServiceImpl.get().startMpcServer();
@@ -1308,6 +1308,12 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                 LOG.warn("At least one database view was not as expected in the {} schema. Attempting to recreate views automatically", schema.getName());
                 ModuleLoader.getInstance().recreateViews();
             });
+    }
+
+    @Override
+    public void registerMigrationHandlers(@NotNull DatabaseMigrationService service)
+    {
+        CoreMigrationSchemaHandler.register(service);
     }
 
     @Override

--- a/core/src/org/labkey/core/admin/sql/ScriptReorderer.java
+++ b/core/src/org/labkey/core/admin/sql/ScriptReorderer.java
@@ -203,11 +203,28 @@ public class ScriptReorderer
                     }
 
                     String tableName2 = null;
+                    String constraintKey = null;
 
                     if (m.pattern().pattern().contains("(?<table2>"))
                     {
                         tableName2 = m.group("table2");
                         assert tableName2 != null;
+                    }
+
+                    if (m.pattern().pattern().contains("(?<constraint>"))
+                    {
+                        // Stash a normalized version of the constraint name so we can save it to the map associated
+                        // with its table (below). Also, if a second table is not specified and we can determine the
+                        // constraint's table from the map, then set it as tableName2. This ensures the statement is
+                        // output after its CREATE statement. For example, a SQL Server statement like ALTER TABLE
+                        // MyTable CHECK CONSTRAINT MyConstraint may need to be output after the second table from the
+                        // original CREATE statement.
+                        String constraintName = m.group("constraint");
+                        assert constraintName != null;
+                        constraintKey = normalizeName(constraintName);
+
+                        if (tableName2 == null)
+                            tableName2 = _constraintTables.get(constraintKey); // Could be null
                     }
 
                     if (pattern.getOperation() == Operation.RenameTable)
@@ -226,15 +243,9 @@ public class ScriptReorderer
 
                     String tableKey = addStatement(tableName, tableName2, comments + m.group());
 
-                    if (m.pattern().pattern().contains("(?<constraint>"))
+                    if (constraintKey != null && !_constraintTables.containsKey(constraintKey))
                     {
-                        String constraintName = m.group("constraint");
-                        assert constraintName != null;
-                        String constraintKey = normalizeName(constraintName);
-                        if (!_constraintTables.containsKey(constraintKey))
-                        {
-                            _constraintTables.put(constraintKey, tableKey);
-                        }
+                        _constraintTables.put(constraintKey, tableKey);
                     }
 
                     _contents = _contents.substring(m.end());

--- a/core/src/org/labkey/core/admin/sql/ScriptReorderer.java
+++ b/core/src/org/labkey/core/admin/sql/ScriptReorderer.java
@@ -18,6 +18,7 @@ package org.labkey.core.admin.sql;
 
 import org.apache.commons.lang3.Strings;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringUtilsLabKey;
@@ -36,6 +37,7 @@ public class ScriptReorderer
 
     private final List<Map<String, Collection<Statement>>> _statementLists = new LinkedList<>();
     private final List<String> _endingStatements = new LinkedList<>();
+    private final Map<String, String> _constraintTables = CaseInsensitiveHashMap.of(); // Track tables associated with constraints
 
     private Map<String, Collection<Statement>> _currentStatements;
 
@@ -61,7 +63,7 @@ public class ScriptReorderer
             TABLE_NAME_REGEX = "(?<table>" + SCHEMA_NAME_REGEX + "((#?\\w+)|(\\[#?\\w+\\])))";  // # allows for temp table names, optional [] around table name
             TABLE_NAME_NO_UNDERSCORE_REGEX = null;
             STATEMENT_ENDING_REGEX = "((; GO\\s*$)|(;\\s*$)|( GO\\s*$))\\s*";       // Semicolon, GO, or both
-            CONSTRAINT_NAME_REGEX = "((\\w+)|(\\[\\w+\\]))"; // optional [] around name
+            CONSTRAINT_NAME_REGEX = "(?<constraint>((\\w+)|(\\[\\w+\\])))"; // optional [] around name
         }
         else
         {
@@ -69,7 +71,7 @@ public class ScriptReorderer
             TABLE_NAME_REGEX = "(?<table>" + SCHEMA_NAME_REGEX + "(\\w+))";
             TABLE_NAME_NO_UNDERSCORE_REGEX = "(?<table>" + SCHEMA_NAME_REGEX + "([[a-zA-Z0-9]]+))";
             STATEMENT_ENDING_REGEX = ";(\\s*?)((--)[^\\n]*)?$(\\s*)";
-            CONSTRAINT_NAME_REGEX = "(\\w+)";
+            CONSTRAINT_NAME_REGEX = "(?<constraint>(\\w+))";
         }
 
         TABLE_NAME2_REGEX = TABLE_NAME_REGEX.replace("table", "table2");
@@ -116,6 +118,7 @@ public class ScriptReorderer
             patterns.add(new SqlPattern("DROP INDEX (IF EXISTS )?\\w+ ON " + TABLE_NAME_REGEX + STATEMENT_ENDING_REGEX, Type.Table, Operation.Other));
 
             patterns.add(new SqlPattern("(CREATE|ALTER) PROCEDURE .+?" + STATEMENT_ENDING_REGEX, Type.NonTable, Operation.Other));
+            patterns.add(new SqlPattern("ALTER TABLE " + TABLE_NAME_REGEX + " CHECK CONSTRAINT " + CONSTRAINT_NAME_REGEX + STATEMENT_ENDING_REGEX, Type.Table, Operation.Other));
         }
         else
         {
@@ -204,6 +207,7 @@ public class ScriptReorderer
                     if (m.pattern().pattern().contains("(?<table2>"))
                     {
                         tableName2 = m.group("table2");
+                        assert tableName2 != null;
                     }
 
                     if (pattern.getOperation() == Operation.RenameTable)
@@ -220,7 +224,19 @@ public class ScriptReorderer
                         newStatementList();
                     }
 
-                    addStatement(tableName, tableName2, comments + m.group());
+                    String tableKey = addStatement(tableName, tableName2, comments + m.group());
+
+                    if (m.pattern().pattern().contains("(?<constraint>"))
+                    {
+                        String constraintName = m.group("constraint");
+                        assert constraintName != null;
+                        String constraintKey = normalizeName(constraintName);
+                        if (!_constraintTables.containsKey(constraintKey))
+                        {
+                            _constraintTables.put(constraintKey, tableKey);
+                        }
+                    }
+
                     _contents = _contents.substring(m.end());
                     recognized = true;
                     break;
@@ -318,18 +334,32 @@ public class ScriptReorderer
         return Pattern.compile(regEx.replaceAll(" ", "\\\\s+"), Pattern.CASE_INSENSITIVE + Pattern.DOTALL + Pattern.MULTILINE);
     }
 
-    private void addStatement(String tableName, @Nullable String tableName2, String statement)
+    // Return table key that's associated with this statement
+    private String addStatement(String tableName, @Nullable String tableName2, String statement)
     {
+        // Remove brackets for map key
+        String key = normalizeName(tableName);
+        String key2 = normalizeName(tableName2);
+
         // If there's a second table in the statement that's referenced later in the script then associate the statement
         // with the second table. For example, an FK definition will end up after BOTH tables have been created.
-        if (null != tableName2 && index(tableName2) > index(tableName))
+        if (null != key2 && index(key2) > index(key))
+        {
             tableName = tableName2;
-
-        String key = tableName.replace("[", "").replace("]", "").toLowerCase();
+            key = key2;
+        }
 
         Collection<Statement> tableStatements = _currentStatements.computeIfAbsent(key, k -> new LinkedList<>());
 
         tableStatements.add(new Statement(tableName, statement));
+
+        return key;
+    }
+
+    // Remove brackets and lower case
+    private @Nullable String normalizeName(@Nullable String name)
+    {
+        return name != null ? name.replace("[", "").replace("]", "").toLowerCase() : null;
     }
 
     private int index(String tableName)
@@ -369,14 +399,14 @@ public class ScriptReorderer
         }
         else
         {
-            sb.append(statement.getSql());
+            sb.append(statement.sql());
         }
     }
 
     private void appendStatement(StringBuilder sb, Statement statement)
     {
-        String sql = PageFlowUtil.filter(statement.getSql(), true);
-        String tableName = statement.getTableName();
+        String sql = PageFlowUtil.filter(statement.sql(), true);
+        String tableName = statement.tableName();
 
         // If we have a table name then try to highlight the first occurrence in statement
         if (null != tableName)
@@ -441,25 +471,5 @@ public class ScriptReorderer
     }
 
     // Saving the original table name helps with highlighting, especially in the case of a table rename
-    private static class Statement
-    {
-        private final @Nullable String _tableName;
-        private final String _sql;
-
-        private Statement(@Nullable String tableName, String sql)
-        {
-            _tableName = tableName;
-            _sql = sql;
-        }
-
-        public @Nullable String getTableName()
-        {
-            return _tableName;
-        }
-
-        public String getSql()
-        {
-            return _sql;
-        }
-    }
+    private record Statement(@Nullable String tableName, String sql) {}
 }

--- a/experiment/src/org/labkey/experiment/DataClassMigrationSchemaHandler.java
+++ b/experiment/src/org/labkey/experiment/DataClassMigrationSchemaHandler.java
@@ -174,7 +174,7 @@ class DataClassMigrationSchemaHandler extends DefaultMigrationSchemaHandler impl
     @Override
     public void afterSchema(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, DbSchema targetSchema)
     {
-        // Experiment shouldn't mess with Biologics tables, but it gets the job done
+        // Experiment shouldn't really mess with Biologics tables, but it gets the job done
 
         DbScope sourceScope = configuration.getSourceScope();
         DbScope targetScope = configuration.getTargetScope();

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -906,10 +906,14 @@ public class ExperimentModule extends SpringModule
                 return results;
             });
         }
+    }
 
+    @Override
+    public void registerMigrationHandlers(@NotNull DatabaseMigrationService service)
+    {
         ExperimentMigrationSchemaHandler handler = new ExperimentMigrationSchemaHandler();
-        DatabaseMigrationService.get().registerSchemaHandler(handler);
-        DatabaseMigrationService.get().registerTableHandler(new MigrationTableHandler()
+        service.registerSchemaHandler(handler);
+        service.registerTableHandler(new MigrationTableHandler()
         {
             @Override
             public TableInfo getTableInfo()
@@ -926,7 +930,7 @@ public class ExperimentModule extends SpringModule
                     filter.addClause(includedClause);
             }
         });
-        DatabaseMigrationService.get().registerTableHandler(new MigrationTableHandler()
+        service.registerTableHandler(new MigrationTableHandler()
         {
             @Override
             public TableInfo getTableInfo()
@@ -943,7 +947,7 @@ public class ExperimentModule extends SpringModule
                     filter.addClause(includedClause);
             }
         });
-        DatabaseMigrationService.get().registerTableHandler(new MigrationTableHandler()
+        service.registerTableHandler(new MigrationTableHandler()
         {
             @Override
             public TableInfo getTableInfo()
@@ -960,9 +964,9 @@ public class ExperimentModule extends SpringModule
                     filter.addClause(includedClause);
             }
         });
-        DatabaseMigrationService.get().registerSchemaHandler(new SampleTypeMigrationSchemaHandler());
+        service.registerSchemaHandler(new SampleTypeMigrationSchemaHandler());
         DataClassMigrationSchemaHandler dcHandler = new DataClassMigrationSchemaHandler();
-        DatabaseMigrationService.get().registerSchemaHandler(dcHandler);
+        service.registerSchemaHandler(dcHandler);
         ExperimentDeleteService.setInstance(dcHandler);
     }
 

--- a/issues/src/org/labkey/issue/IssueMigrationSchemaHandler.java
+++ b/issues/src/org/labkey/issue/IssueMigrationSchemaHandler.java
@@ -32,6 +32,8 @@ public class IssueMigrationSchemaHandler extends DefaultMigrationSchemaHandler
 
     private final Set<Integer> COPIED_ISSUE_IDS = new HashSet<>();
 
+    private boolean _filtered = false;
+
     public IssueMigrationSchemaHandler()
     {
         super(DbSchema.get(IssuesSchema.ISSUE_DEF_SCHEMA_NAME, DbSchemaType.Provisioned));
@@ -40,6 +42,9 @@ public class IssueMigrationSchemaHandler extends DefaultMigrationSchemaHandler
     @Override
     public void afterTable(TableInfo sourceTable, TableInfo targetTable, SimpleFilter notCopiedFilter)
     {
+        // Remember that issues tables are being filtered so afterSchema() can clean up associated tables (or not)
+        _filtered = true;
+
         // Collect the issue IDs that were copied into the target table. We're assuming this set is much smaller than
         // the set of issues IDs that *weren't* copied.
         int startSize = COPIED_ISSUE_IDS.size();
@@ -59,23 +64,26 @@ public class IssueMigrationSchemaHandler extends DefaultMigrationSchemaHandler
     @Override
     public void afterSchema(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, DbSchema targetSchema)
     {
-        LOG.info("{} were copied. Now deleting related issues, comments, and issues rows associated with all issues that were not copied.", StringUtilsLabKey.pluralize(COPIED_ISSUE_IDS.size(), "issue"));
+        if (_filtered)
+        {
+            LOG.info("{} were copied. Now deleting related issues, comments, and issues rows associated with all issues that were not copied.", StringUtilsLabKey.pluralize(COPIED_ISSUE_IDS.size(), "issue"));
 
-        // Delete all issues, comments, and related issues that were NOT copied
-        SimpleFilter deleteRelatedFilter = new SimpleFilter(
-            new InClause(FieldKey.fromParts("RelatedIssueId"), COPIED_ISSUE_IDS, false, true) // Negated
-        );
-        int deletedRowCount = Table.delete(IssuesSchema.getInstance().getTableInfoRelatedIssues(), deleteRelatedFilter);
-        LOG.info("   Deleted {} from RelatedIssues (RelatedIssueId)", StringUtilsLabKey.pluralize(deletedRowCount, "row"));
-        SimpleFilter deleteFilter = new SimpleFilter(
-            new InClause(FieldKey.fromParts("IssueId"), COPIED_ISSUE_IDS, false, true) // Negated
-        );
-        deletedRowCount = Table.delete(IssuesSchema.getInstance().getTableInfoRelatedIssues(), deleteFilter);
-        LOG.info("   Deleted {} from RelatedIssues (IssueId)", StringUtilsLabKey.pluralize(deletedRowCount, "row"));
-        deletedRowCount = Table.delete(IssuesSchema.getInstance().getTableInfoComments(), deleteFilter);
-        LOG.info("   Deleted {} from Comments", StringUtilsLabKey.pluralize(deletedRowCount, "row"));
-        deletedRowCount = Table.delete(IssuesSchema.getInstance().getTableInfoIssues(), deleteFilter);
-        LOG.info("   Deleted {} from Issues", StringUtilsLabKey.pluralize(deletedRowCount, "row"));
+            // Delete all issues, comments, and related issues that were NOT copied
+            SimpleFilter deleteRelatedFilter = new SimpleFilter(
+                new InClause(FieldKey.fromParts("RelatedIssueId"), COPIED_ISSUE_IDS, false, true) // Negated
+            );
+            int deletedRowCount = Table.delete(IssuesSchema.getInstance().getTableInfoRelatedIssues(), deleteRelatedFilter);
+            LOG.info("   Deleted {} from RelatedIssues (RelatedIssueId)", StringUtilsLabKey.pluralize(deletedRowCount, "row"));
+            SimpleFilter deleteFilter = new SimpleFilter(
+                new InClause(FieldKey.fromParts("IssueId"), COPIED_ISSUE_IDS, false, true) // Negated
+            );
+            deletedRowCount = Table.delete(IssuesSchema.getInstance().getTableInfoRelatedIssues(), deleteFilter);
+            LOG.info("   Deleted {} from RelatedIssues (IssueId)", StringUtilsLabKey.pluralize(deletedRowCount, "row"));
+            deletedRowCount = Table.delete(IssuesSchema.getInstance().getTableInfoComments(), deleteFilter);
+            LOG.info("   Deleted {} from Comments", StringUtilsLabKey.pluralize(deletedRowCount, "row"));
+            deletedRowCount = Table.delete(IssuesSchema.getInstance().getTableInfoIssues(), deleteFilter);
+            LOG.info("   Deleted {} from Issues", StringUtilsLabKey.pluralize(deletedRowCount, "row"));
+        }
     }
 
     @Override

--- a/issues/src/org/labkey/issue/IssueMigrationSchemaHandler.java
+++ b/issues/src/org/labkey/issue/IssueMigrationSchemaHandler.java
@@ -32,7 +32,7 @@ public class IssueMigrationSchemaHandler extends DefaultMigrationSchemaHandler
 
     private final Set<Integer> COPIED_ISSUE_IDS = new HashSet<>();
 
-    private boolean _filtered = false;
+    private boolean _filtered;
 
     public IssueMigrationSchemaHandler()
     {
@@ -40,9 +40,16 @@ public class IssueMigrationSchemaHandler extends DefaultMigrationSchemaHandler
     }
 
     @Override
+    public void beforeSchema()
+    {
+        _filtered = false;
+    }
+
+    @Override
     public void afterTable(TableInfo sourceTable, TableInfo targetTable, SimpleFilter notCopiedFilter)
     {
-        // Remember that issues tables are being filtered so afterSchema() can clean up associated tables (or not)
+        // afterTable() is called only when rows are filtered (i.e., a DomainDataFilter is configured). Remember this so
+        // afterSchema() can clean up associated tables (or not).
         _filtered = true;
 
         // Collect the issue IDs that were copied into the target table. We're assuming this set is much smaller than

--- a/issues/src/org/labkey/issue/IssuesModule.java
+++ b/issues/src/org/labkey/issue/IssuesModule.java
@@ -162,8 +162,12 @@ public class IssuesModule extends DefaultModule implements SearchService.Documen
                 return metric;
             });
         }
+    }
 
-        DatabaseMigrationService.get().registerSchemaHandler(new IssueMigrationSchemaHandler());
+    @Override
+    public void registerMigrationHandlers(@NotNull DatabaseMigrationService service)
+    {
+        service.registerSchemaHandler(new IssueMigrationSchemaHandler());
     }
 
     @NotNull

--- a/list/src/org/labkey/list/ListModule.java
+++ b/list/src/org/labkey/list/ListModule.java
@@ -163,8 +163,12 @@ public class ListModule extends SpringModule
                 return metric;
             });
         }
+    }
 
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(ListSchema.getInstance().getSchema()){
+    @Override
+    public void registerMigrationHandlers(@NotNull DatabaseMigrationService service)
+    {
+        service.registerSchemaHandler(new DefaultMigrationSchemaHandler(ListSchema.getInstance().getSchema()){
             @Override
             public @NotNull Collection<AttachmentParentType> getAttachmentTypes()
             {

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -23,14 +23,19 @@ import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.DefaultAuditProvider;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.Aggregate;
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DataRegionSelection;
 import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.views.DataViewService;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.message.digest.DailyMessageDigest;
 import org.labkey.api.message.digest.ReportAndDatasetChangeDigestProvider;
+import org.labkey.api.migration.DatabaseMigrationService;
+import org.labkey.api.migration.GuidMapperColumn;
+import org.labkey.api.migration.MigrationTableHandler;
 import org.labkey.api.module.AdminLinkManager;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.Module;
@@ -339,6 +344,22 @@ public class QueryModule extends DefaultModule
         Role trustedAnalystRole = RoleManager.getRole("org.labkey.api.security.roles.TrustedAnalystRole");
         if (null != trustedAnalystRole)
             trustedAnalystRole.addPermission(EditQueriesPermission.class);
+
+        DatabaseMigrationService.get().registerTableHandler(new MigrationTableHandler()
+        {
+            @Override
+            public TableInfo getTableInfo()
+            {
+                return QueryManager.get().getTableInfoExternalSchema();
+            }
+
+            @Override
+            public ColumnInfo handleColumn(ColumnInfo col)
+            {
+                // In the LinkedSchema case, the container GUID is stored in the "DataSource" column
+                return "DataSource".equals(col.getName()) ? new GuidMapperColumn(col) : col;
+            }
+        });
     }
 
     @Override

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -344,8 +344,12 @@ public class QueryModule extends DefaultModule
         Role trustedAnalystRole = RoleManager.getRole("org.labkey.api.security.roles.TrustedAnalystRole");
         if (null != trustedAnalystRole)
             trustedAnalystRole.addPermission(EditQueriesPermission.class);
+    }
 
-        DatabaseMigrationService.get().registerTableHandler(new MigrationTableHandler()
+    @Override
+    public void registerMigrationHandlers(@NotNull DatabaseMigrationService service)
+    {
+        service.registerTableHandler(new MigrationTableHandler()
         {
             @Override
             public TableInfo getTableInfo()

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -195,8 +195,12 @@ public class SearchModule extends DefaultModule
             long count = new TableSelector(auditTable).getRowCount();
             return Collections.singletonMap("fullTextSearches", count);
         });
+    }
 
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(SearchSchema.getInstance().getSchema())
+    @Override
+    public void registerMigrationHandlers(@NotNull DatabaseMigrationService service)
+    {
+        service.registerSchemaHandler(new DefaultMigrationSchemaHandler(SearchSchema.getInstance().getSchema())
         {
             @Override
             public List<TableInfo> getTablesToCopy()

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -529,8 +529,12 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
 
         AdminConsole.addLink(AdminConsole.SettingsLinkType.Premium, "Master Patient Index", new ActionURL(StudyController.MasterPatientProviderAction.class, ContainerManager.getRoot()), AdminPermission.class);
         DataStateImportExportHelper.registerProvider(new StudyQCImportExportHelper());
+    }
 
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(StudySchema.getInstance().getSchema())
+    @Override
+    public void registerMigrationHandlers(@NotNull DatabaseMigrationService service)
+    {
+        service.registerSchemaHandler(new DefaultMigrationSchemaHandler(StudySchema.getInstance().getSchema())
         {
             @Override
             public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)
@@ -552,7 +556,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
             }
         });
 
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(StudySchema.getInstance().getDatasetSchema())
+        service.registerSchemaHandler(new DefaultMigrationSchemaHandler(StudySchema.getInstance().getDatasetSchema())
         {
             @Override
             public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)
@@ -562,7 +566,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
             }
         });
 
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(DbSchema.get(SpecimenTablesProvider.SCHEMA_NAME, DbSchemaType.Provisioned))
+        service.registerSchemaHandler(new DefaultMigrationSchemaHandler(DbSchema.get(SpecimenTablesProvider.SCHEMA_NAME, DbSchemaType.Provisioned))
         {
             @Override
             public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/kanban/issues/1577

Several inconsistencies in the migration code were uncovered when migrating TNPRC's SQL Server database to PostgreSQL:

1. Linked schemas no longer resolve
1. No `issues.Issues` rows are present
1. Dataset, issue, etc. table names appear to be empty in the source DB
1. New dataset tables are missing some columns.

#### Changes
1. Hoist `GuidMapperColumn` into API. Use it to lowercase linked schema GUIDs that are stored in the `ExternalSchema.DataSource` column.
1. Don't delete issues, comments, and related issues if no filter is in place
1. Correct scope used in `DbSchemaType.Migration`
1. Stop stashing the shared container in OntologyManager. A stale value left from pre-migration time caused domains with any shared property to lose all custom properties.
1. Register migration handlers only if a migration is taking place
1. Script reorderer now tracks the primary table associated with each constraint and uses that to order constraint statements (e.g., `ALTER TABLE foo CHECK CONSTRAINT bar`)