### PR TITLE
Rework startup/upgrade/bootstrap process to prune modules before core upgrade

### DIFF
--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -171,25 +171,20 @@ public class OntologyManager
             proj = c;
 
         String sql = " SELECT * FROM " + getTinfoDomainDescriptor() + " WHERE " + (isName ? "Name" : "DomainURI") + " = ? AND Project IN (?,?) ";
-        List<DomainDescriptor> ddArray = new SqlSelector(getExpSchema(), sql, uriOrName,
+        List<DomainDescriptor> ddList = new SqlSelector(getExpSchema(), sql, uriOrName,
                 proj,
                 ContainerManager.getSharedContainer().getId()).getArrayList(DomainDescriptor.class);
-        DomainDescriptor dd = null;
-        if (!ddArray.isEmpty())
-        {
-            dd = ddArray.getFirst();
 
-            // if someone has explicitly inserted a descriptor with the same URI as an existing one ,
-            // and one of the two is in the shared project, use the project-level descriptor.
-            if (ddArray.size() > 1)
-            {
-                _log.debug("Multiple DomainDescriptors found for " + uriOrName);
-                // TODO: This check and assignment look wrong. We always return the first element.
-                if (dd.getProject().equals(ContainerManager.getSharedContainer()))
-                    dd = ddArray.getFirst();
-            }
+        if (ddList.size() > 1)
+        {
+            // if there are multiple descriptors with the same URI, prefer the first one that's not in the shared project
+            _log.debug("Multiple DomainDescriptors found for {}", uriOrName);
+            for (DomainDescriptor dd : ddList)
+                if (!ContainerManager.getSharedContainer().equals(dd.getProject()))
+                    return dd;
         }
-        return dd;
+
+        return ddList.isEmpty() ? null : ddList.getFirst();
     }
 
     private static final BlockingCache<Integer, DomainDescriptor> DOMAIN_DESC_BY_ID_CACHE = DatabaseCache.get(getExpSchema().getScope(),2000, CacheManager.UNLIMITED,"Domain descriptors by ID", new DomainDescriptorLoader());

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -353,6 +353,11 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         {
             if (null == _webPartFactories)
             {
+                // We promise that this method is not called until upgrade is complete. Enforce that to (for example)
+                // prevent memory leaks associated with modules removed due to missing dependencies.
+                if (ModuleLoader.getInstance().isUpgradeRequired())
+                    throw new IllegalStateException("getWebPartFactories() is being called before upgrade is complete");
+
                 Collection<WebPartFactory> wpf = new ArrayList<>();
 
                 // Get all the Java webpart factories

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -341,9 +341,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     {
     }
 
-    // TODO: Move getWebPartFactories() and _webPartFactories into Portal... shouldn't be the module's responsibility
-    // This should also allow moving SimpleWebPartFactoryCache and dependencies into Internal
-
     private final Object FACTORY_LOCK = new Object();
 
     @Override
@@ -353,11 +350,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         {
             if (null == _webPartFactories)
             {
-                // We promise that this method is not called until upgrade is complete. Enforce that to (for example)
-                // prevent memory leaks associated with modules removed due to missing dependencies.
-                if (ModuleLoader.getInstance().isUpgradeRequired())
-                    throw new IllegalStateException("getWebPartFactories() is being called before upgrade is complete");
-
                 Collection<WebPartFactory> wpf = new ArrayList<>();
 
                 // Get all the Java webpart factories

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -146,7 +146,7 @@ public interface Module
     /** License name: e.g. "Apache 2.0", "LabKey Software License" */
     @Nullable String getLicense();
 
-    /** License URL: e.g. "http://www.apache.org/licenses/LICENSE-2.0" */
+    /** License URL: e.g. "https://www.apache.org/licenses/LICENSE-2.0" */
     @Nullable String getLicenseUrl();
 
     /**
@@ -182,7 +182,7 @@ public interface Module
 
     /**
      * The application is shutting down "gracefully". Module
-     * should do any cleanup (file handles etc) that is required.
+     * should do any cleanup (file handles, etc.) that is required.
      * Note: There is no guarantee that this will run if the server
      * process is without a nice shutdown.
      */
@@ -190,8 +190,7 @@ public interface Module
 
     /**
      * Return Collection of WebPartFactory objects for this module.
-     * NOTE: This may be called before startup, but will never be called
-     * before upgrade is complete.
+     * NOTE: This may be called early, before init() and startup(), but after core upgrade.
      *
      * @return Collection of WebPartFactory (empty collection if none)
      */

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -22,7 +22,6 @@ import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.apache.xmlbeans.XmlBeans;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.Constants;
@@ -428,7 +427,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
             {
                 throw new IllegalStateException("Not a valid module: " + archive.getName());
             }
-            moduleCreated = moduleList.get(0);
+            moduleCreated = moduleList.getFirst();
             if (null != archive)
                 moduleCreated.setZippedPath(archive);
 
@@ -480,7 +479,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
                 // avoid error in startup, DefaultModule does not expect to see module with same name initialized again
                 ((DefaultModule) moduleCreated).unregister();
                 _moduleFailures.remove(moduleCreated.getName());
-                pruneModules(moduleList);
+                ensureModulesSupportLabKeyDatabase(moduleList);
                 initializeModules(moduleList);
 
                 Throwable t = _moduleFailures.get(moduleCreated.getName());
@@ -576,7 +575,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
 
         // set the project source root before calling .initialize() on modules
         var modules = getModules();
-        Module coreModule = modules.isEmpty() ? null : modules.get(0);
+        Module coreModule = modules.isEmpty() ? null : modules.getFirst();
         if (coreModule == null || !DefaultModule.CORE_MODULE_NAME.equals(coreModule.getName()))
             throw new IllegalStateException("Core module was not first or could not find the Core module. Ensure that Tomcat user can create directories under the <LABKEY_HOME>/modules directory.");
         setProjectRoot(coreModule);
@@ -622,7 +621,9 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         // Prune modules before upgrading core module, see Issue 42150
         synchronized (_modulesLock)
         {
-            pruneModules(_modules);
+            // _modules is in dependency order
+            ensureModulesSupportLabKeyDatabase(_modules);
+            verifyDependencies(_modules);
         }
 
         if (getTableInfoModules().getTableType() == DatabaseTableType.NOT_IN_DB)
@@ -678,7 +679,6 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         synchronized (_modulesLock)
         {
             checkForRenamedModules();
-            // use _modules here because this List<> needs to be modifiable
             initializeModules(_modules);
         }
 
@@ -920,22 +920,39 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
     }
 
     /**
-     * Enumerates all the modules, removing the ones that don't support the core database
+     * Enumerates all the modules, removing the ones that don't support the primary database
      */
-    private void pruneModules(List<Module> modules)
+    private void ensureModulesSupportLabKeyDatabase(List<Module> modules)
     {
-        Module core = getCoreModule();
-
-        SupportedDatabase coreType = SupportedDatabase.get(CoreSchema.getInstance().getSqlDialect());
-        // Need to enumerate a copy of the list to avoid ConcurrentModificationException
+        SqlDialect dialect = DbScope.getLabKeyScope().getSqlDialect();
+        SupportedDatabase primaryType = SupportedDatabase.get(dialect);
+        // Enumerate a copy of the list to avoid ConcurrentModificationException
         for (Module module : new ArrayList<>(modules))
         {
-            if (module == core)
-                continue;
-            if (!module.getSupportedDatabasesSet().contains(coreType))
+            if (!module.getSupportedDatabasesSet().contains(primaryType))
             {
-                var e = new DatabaseNotSupportedException("This module does not support " + CoreSchema.getInstance().getSqlDialect().getProductName());
+                var e = new DatabaseNotSupportedException("This module does not support " + dialect.getProductName());
                 // In production mode, treat these exceptions as a module initialization error
+                // In dev mode, make them warnings so devs can easily switch databases
+                removeModule(modules, module, !AppProps.getInstance().isDevMode(), e);
+            }
+        }
+    }
+
+    /**
+     * Remove modules if any of their module dependencies are missing
+     */
+    private void verifyDependencies(List<Module> modules)
+    {
+        for (Module module : modules)
+        {
+            try
+            {
+                verifyDependencies(module);
+            }
+            catch (ModuleDependencyException e)
+            {
+                // In production mode, treat module dependency exceptions as errors
                 // In dev mode, make them warnings so devs can easily switch databases
                 removeModule(modules, module, !AppProps.getInstance().isDevMode(), e);
             }
@@ -950,14 +967,10 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         Module core = getCoreModule();
 
         /*
-         * NOTE: Module.initialize() really should not ask for resources from _other_ modules,
-         * as they may have not initialized themselves yet. However, we did not enforce that
-         * so this cross-module behavior may have crept in.
-         *
-         * To help mitigate this a little, we remove modules that do not support this DB type
-         * before calling initialize().
-         *
-         * NOTE: see FolderTypeManager.get().registerFolderType() for an example of enforcing this
+         * NOTE: Module.initialize() really should not ask for resources from _other_ modules, as they may have not
+         * initialized themselves yet. However, we did not enforce that so this cross-module behavior may have crept
+         * in. To help mitigate this a little, we previously removed modules based on supported DB type and missing
+         * dependencies. See FolderTypeManager.registerFolderType() for an example of enforcing this
          */
 
         //initialize each module in turn
@@ -968,21 +981,9 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
 
             try
             {
-                try
-                {
-                    // Make sure all its dependencies initialized successfully
-                    verifyDependencies(module);
-                    module.initialize();
-                }
-                catch (DatabaseNotSupportedException | ModuleDependencyException e)
-                {
-                    // In production mode, treat these exceptions as a module initialization error
-                    if (!AppProps.getInstance().isDevMode())
-                        throw e;
-
-                    // In dev mode, make them warnings so devs can easily switch databases
-                    removeModule(modules, module, false, e);
-                }
+                // Make sure all its dependencies initialized successfully
+                verifyDependencies(module);
+                module.initialize();
             }
             catch (Throwable t)
             {

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -996,7 +996,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         initControllerToModule();
     }
 
-    // Check a module's dependencies and throw on the first one that's not present (i.e., it was removed because its initialize() failed)
+    // Check a module's dependencies and throw on the first one that's not present (i.e., dependency is not present or was removed because its initialize() failed)
     private void verifyDependencies(Module module)
     {
         synchronized (_modulesLock)

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -479,8 +479,8 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
                 // avoid error in startup, DefaultModule does not expect to see module with same name initialized again
                 ((DefaultModule) moduleCreated).unregister();
                 _moduleFailures.remove(moduleCreated.getName());
-                ensureModulesSupportLabKeyDatabase(moduleList);
-                initializeModules(moduleList);
+                pruneModulesForDatabaseSupport(moduleList);
+                initializeAndPruneModules(moduleList);
 
                 Throwable t = _moduleFailures.get(moduleCreated.getName());
                 if (null != t)
@@ -622,8 +622,8 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         synchronized (_modulesLock)
         {
             // _modules is in dependency order
-            ensureModulesSupportLabKeyDatabase(_modules);
-            verifyDependencies(_modules);
+            pruneModulesForDatabaseSupport(_modules);
+            pruneModulesForDependencies(_modules);
         }
 
         if (getTableInfoModules().getTableType() == DatabaseTableType.NOT_IN_DB)
@@ -679,7 +679,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         synchronized (_modulesLock)
         {
             checkForRenamedModules();
-            initializeModules(_modules);
+            initializeAndPruneModules(_modules);
         }
 
         if (!_duplicateModuleErrors.isEmpty())
@@ -922,7 +922,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
     /**
      * Enumerates all the modules, removing the ones that don't support the primary database
      */
-    private void ensureModulesSupportLabKeyDatabase(List<Module> modules)
+    private void pruneModulesForDatabaseSupport(List<Module> modules)
     {
         SqlDialect dialect = DbScope.getLabKeyScope().getSqlDialect();
         SupportedDatabase primaryType = SupportedDatabase.get(dialect);
@@ -942,13 +942,13 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
     /**
      * Remove modules if any of their module dependencies are missing
      */
-    private void verifyDependencies(List<Module> modules)
+    private void pruneModulesForDependencies(List<Module> modules)
     {
         for (Module module : modules)
         {
             try
             {
-                verifyDependencies(module);
+                pruneModuleForDependencies(module);
             }
             catch (ModuleDependencyException e)
             {
@@ -962,7 +962,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
     /**
      * Enumerates all remaining modules, initializing them and removing any that fail to initialize
      */
-    private void initializeModules(List<Module> modules)
+    private void initializeAndPruneModules(List<Module> modules)
     {
         Module core = getCoreModule();
 
@@ -982,7 +982,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
             try
             {
                 // Make sure all its dependencies initialized successfully
-                verifyDependencies(module);
+                pruneModuleForDependencies(module);
                 module.initialize();
             }
             catch (Throwable t)
@@ -996,8 +996,8 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         initControllerToModule();
     }
 
-    // Check a module's dependencies and throw on the first one that's not present (i.e., dependency is not present or was removed because its initialize() failed)
-    private void verifyDependencies(Module module)
+    // Check a single module's dependencies and throw on the first one that's not present (i.e., dependency is not present or its init() threw)
+    private void pruneModuleForDependencies(Module module)
     {
         synchronized (_modulesLock)
         {

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -934,7 +934,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
                 var e = new DatabaseNotSupportedException("This module does not support " + dialect.getProductName());
                 // In production mode, treat these exceptions as a module initialization error
                 // In dev mode, make them warnings so devs can easily switch databases
-                removeModule(modules, module, !AppProps.getInstance().isDevMode(), e);
+                removeModule(modules, module, !AppProps.getInstance().isDevMode(), e, "load");
             }
         }
     }
@@ -948,13 +948,13 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         {
             try
             {
-                pruneModuleForDependencies(module);
+                pruneModuleForDependencies(module, "load");
             }
             catch (ModuleDependencyException e)
             {
                 // In production mode, treat module dependency exceptions as errors
                 // In dev mode, make them warnings so devs can easily switch databases
-                removeModule(modules, module, !AppProps.getInstance().isDevMode(), e);
+                removeModule(modules, module, !AppProps.getInstance().isDevMode(), e, "load");
             }
         }
     }
@@ -982,12 +982,21 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
             try
             {
                 // Make sure all its dependencies initialized successfully
-                pruneModuleForDependencies(module);
+                pruneModuleForDependencies(module, "initialize");
+            }
+            catch (ModuleDependencyException mde)
+            {
+                removeModule(modules, module, !AppProps.getInstance().isDevMode(), mde, "load");
+                continue;
+            }
+
+            try
+            {
                 module.initialize();
             }
             catch (Throwable t)
             {
-                removeModule(modules, module, true, t);
+                removeModule(modules, module, true, t, "initialize");
             }
         }
 
@@ -997,37 +1006,37 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
     }
 
     // Check a single module's dependencies and throw on the first one that's not present (i.e., dependency is not present or its init() threw)
-    private void pruneModuleForDependencies(Module module)
+    private void pruneModuleForDependencies(Module module, String action)
     {
         synchronized (_modulesLock)
         {
             for (String dependency : module.getModuleDependenciesAsSet())
                 if (!_moduleMap.containsKey(dependency))
-                    throw new ModuleDependencyException(dependency);
+                    throw new ModuleDependencyException(dependency, action);
         }
     }
 
     private static class ModuleDependencyException extends ConfigurationException
     {
-        public ModuleDependencyException(String dependencyName)
+        public ModuleDependencyException(String dependencyName, String action)
         {
-            super("This module depends on the \"" + dependencyName + "\" module, which failed to initialize");
+            super("This module depends on the \"" + dependencyName + "\" module, which failed to " + action);
         }
     }
 
-    private void removeModule(List<Module> modules, Module current, boolean treatAsError, Throwable t)
+    private void removeModule(List<Module> modules, Module current, boolean treatAsError, Throwable t, String action)
     {
         String name = current.getName();
 
         if (treatAsError)
         {
-            _log.error("Unable to initialize module {}", name, t);
+            _log.error("Unable to {} module {}", action, name, t);
             //noinspection ThrowableResultOfMethodCallIgnored
             _moduleFailures.put(name, t);
         }
         else
         {
-            _log.warn("Unable to initialize module {} due to: {}", name, t.getMessage());
+            _log.warn("Unable to {} module {} due to: {}", action, name, t.getMessage());
         }
 
         synchronized (_modulesLock)


### PR DESCRIPTION
#### Rationale
Adding SNPRC modules to the TeamCity PostgreSQL distributions resulted in memory leaks since their SND dependency is not yet present.

Currently, modules with missing dependencies are removed *after* the core module is upgraded. The removed modules show up as leaked, since several code paths end up holding onto them. For example, core `bootstrap()` creates key containers (/, /home, /shared), which causes us to enumerate the active modules, which loads file-based webparts, which creates file watcher listeners that hold onto their owning modules. While webparts are the culprit here, it's likely that other resources could cause similar leaks.

My solution is to rework the startup/upgrade/bootstrap process to prune modules with missing dependencies *before* core upgrade occurs. So now we prune for database compatibility and then immediately prune for module dependencies. As a result, core upgrade and `init()` implementations that enumerate active modules work on the pruned list. A side benefit is that we log messages about all pruned modules (regardless of reason) together. Module initialization still happens after core upgrade, and any module that fails initialization still gets pruned along with its dependents. A module leak will likely happen in this case, but I think it's rare for init() to throw, plus it's always treated as a module startup error.

I considered initializing all modules before core upgrade, which is appealing in theory. However, that would have meant any operation that touches the database (role registration, property retrieval & update, etc.) would need to move from init() into `startup()` since core schemas could be empty or in a bad state when init() is invoked. This would have changed our rules and forced updates to 25+ modules that we manage (plus potentially others that we don't).

#### Related Pull Requests
- https://github.com/LabKey/wnprc-modules/pull/917