### PR TITLE
Improved validation for XML parsing and paths

### DIFF
--- a/api/src/org/labkey/api/reader/ExcelLoader.java
+++ b/api/src/org/labkey/api/reader/ExcelLoader.java
@@ -46,6 +46,7 @@ import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.StringUtilsLabKey;
+import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.vfs.FileLike;
 import org.labkey.vfs.FileSystemLike;
 import org.xml.sax.Attributes;
@@ -540,7 +541,7 @@ public class ExcelLoader extends DataLoader
                         if (sheetMatches(sheetIndex, iter.getSheetName()))
                         {
                             InputSource sheetSource = new InputSource(stream);
-                            SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+                            SAXParserFactory saxFactory = XmlBeansUtil.SAX_PARSER_FACTORY;
                             try
                             {
                                 SAXParser saxParser = saxFactory.newSAXParser();

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -289,7 +289,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         }
 
         Set<String> filesToSkip = new TreeSet<>();
-        File fileLocation = parent instanceof AttachmentDirectory ? ((AttachmentDirectory) parent).getFileSystemDirectory() : null;
+        File fileLocation = parent instanceof AttachmentDirectory dir ? dir.getFileSystemDirectory() : null;
 
         for (AttachmentFile file : files)
         {

--- a/filecontent/src/org/labkey/filecontent/FileSystemAttachmentParent.java
+++ b/filecontent/src/org/labkey/filecontent/FileSystemAttachmentParent.java
@@ -191,7 +191,7 @@ public class FileSystemAttachmentParent implements AttachmentDirectory
     {
         Path fileLocation = getFileSystemDirectoryPath();
         InputStream is = file.openInputStream();
-        Path saveFile = fileLocation.resolve(file.getFilename());
+        Path saveFile = FileUtil.appendName(fileLocation, file.getFilename());
         try
         {
             Files.copy(is, saveFile);

--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
@@ -694,6 +694,12 @@ public class PipelineStatusManager
                     PipelineStatusFileImpl sf = PipelineStatusManager.getStatusFile(rowId);
                     if (sf != null)
                     {
+                        Container container = sf.lookupContainer();
+                        if (container == null || !container.hasPermission(user, UpdatePermission.class))
+                        {
+                            throw new UnauthorizedException();
+                        }
+
                         LOG.info("Job " + sf.getFilePath() + " was marked as complete by " + user);
                         sf.setStatus(PipelineJob.TaskStatus.complete.toString());
                         sf.setInfo(null);


### PR DESCRIPTION
#### Rationale
We should configure XML parsers consistently and use our preferred patterns in other places.

#### Related Pull Requests
- https://github.com/LabKey/server/pull/1284

#### Changes
- Use our standard parser setup
- Append file names consistently
- Check permissions consistently in pipeline job completion

#### Tasks 📍
- Manual Testing - N/A
- Needs Automation - N/A
