### PR TITLE
Only send HTML to browser-type clients

### DIFF
--- a/api/src/org/labkey/api/action/ExtFormResponseWriter.java
+++ b/api/src/org/labkey/api/action/ExtFormResponseWriter.java
@@ -19,6 +19,7 @@ import org.json.JSONObject;
 import org.labkey.api.query.PropertyValidationError;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.util.HttpUtil;
 import org.labkey.api.util.MimeMap;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
@@ -70,7 +71,8 @@ public class ExtFormResponseWriter extends ApiJsonWriter
     public ExtFormResponseWriter(HttpServletRequest request, HttpServletResponse response) throws IOException
     {
         boolean sendHtml = !"XMLHttpRequest".equals(request.getHeader("X-Requested-With")) &&
-                request instanceof MultipartHttpServletRequest;
+                request instanceof MultipartHttpServletRequest &&
+                HttpUtil.isBrowser(request);
         super(response, sendHtml ? MimeMap.MimeType.HTML.getContentType() : CONTENT_TYPE_JSON);
         setErrorResponseStatus(HttpServletResponse.SC_OK);
     }

--- a/api/src/org/labkey/api/util/XmlBeansUtil.java
+++ b/api/src/org/labkey/api/util/XmlBeansUtil.java
@@ -139,7 +139,13 @@ public class XmlBeansUtil
             SAX_PARSER_FACTORY.setNamespaceAware(true);
             SAX_PARSER_FACTORY.setFeature("http://xml.org/sax/features/validation", false);
             SAX_PARSER_FACTORY.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+            // Disable features that could lead to XXE or other vulnerabilities
+            // Keep in sync with ModuleArchive.nameFromModuleXML()
             SAX_PARSER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            SAX_PARSER_FACTORY.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            SAX_PARSER_FACTORY.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            SAX_PARSER_FACTORY.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 
             DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
             DOCUMENT_BUILDER_FACTORY.setNamespaceAware(true);


### PR DESCRIPTION
#### Rationale
The fix to properly encode JSON when rendered as HTML fixed actually setting the content type. This broke R, Python, and likely other non-browser scenarios.

https://github.com/LabKey/platform/pull/7385

#### Changes
- Only choose to send `text/html` to browser-type clients

#### Tasks 📍
- Needs Automation
  - [x] https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_ModuleSuites_JavaScript_RlabkeyLinux/3851007
  - [x] https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_ModuleSuites_ApiSuites_PythonIntegration/3851004
