### PR TITLE
Update array filter script name to match js and java client

### DIFF
--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -829,7 +829,7 @@ public abstract class CompareType
      */
 
 
-    public static final CompareType ARRAY_IS_EMPTY = new CompareType("Is Empty", "arrayisempty", "ARRAYISEMPTY", false, null, OperatorType.ARRAYISEMPTY)
+    public static final CompareType ARRAY_IS_EMPTY = new CompareType("Is Empty", "arrayisempty", "ARRAY_ISEMPTY", false, null, OperatorType.ARRAYISEMPTY)
     {
         @Override
         public ArrayIsEmptyClause createFilterClause(@NotNull FieldKey fieldKey, Object value)
@@ -844,7 +844,7 @@ public abstract class CompareType
         }
     };
 
-    public static final CompareType ARRAY_IS_NOT_EMPTY = new CompareType("Is Not Empty", "arrayisnotempty", "ARRAYISNOTEMPTY", false, null, OperatorType.ARRAYISNOTEMPTY)
+    public static final CompareType ARRAY_IS_NOT_EMPTY = new CompareType("Is Not Empty", "arrayisnotempty", "ARRAY_ISNOTEMPTY", false, null, OperatorType.ARRAYISNOTEMPTY)
     {
         @Override
         public ArrayIsEmptyClause createFilterClause(@NotNull FieldKey fieldKey, Object value)
@@ -859,7 +859,7 @@ public abstract class CompareType
         }
     };
 
-    public static final CompareType ARRAY_CONTAINS_ALL = new CompareType("Contains All", "arraycontainsall", "ARRAYCONTAINSALL", true, null, OperatorType.ARRAYCONTAINSALL)
+    public static final CompareType ARRAY_CONTAINS_ALL = new CompareType("Contains All", "arraycontainsall", "ARRAY_CONTAINS_ALL", true, null, OperatorType.ARRAYCONTAINSALL)
     {
         @Override
         public ArrayContainsAllClause createFilterClause(@NotNull FieldKey fieldKey, Object value)
@@ -880,7 +880,7 @@ public abstract class CompareType
         }
     };
 
-    public static final CompareType ARRAY_CONTAINS_ANY = new CompareType("Contains Any", "arraycontainsany", "ARRAYCONTAINSANY", true, null, OperatorType.ARRAYCONTAINSANY)
+    public static final CompareType ARRAY_CONTAINS_ANY = new CompareType("Contains Any", "arraycontainsany", "ARRAY_CONTAINS_ANY", true, null, OperatorType.ARRAYCONTAINSANY)
     {
         @Override
         public ArrayContainsAnyClause createFilterClause(@NotNull FieldKey fieldKey, Object value)
@@ -901,7 +901,7 @@ public abstract class CompareType
         }
     };
 
-    public static final CompareType ARRAY_CONTAINS_NONE = new CompareType("Contains None", "arraycontainsnone", "ARRAYCONTAINSNONE", true, null, OperatorType.ARRAYCONTAINSNONE)
+    public static final CompareType ARRAY_CONTAINS_NONE = new CompareType("Contains None", "arraycontainsnone", "ARRAY_CONTAINS_NONE", true, null, OperatorType.ARRAYCONTAINSNONE)
     {
         @Override
         public ArrayContainsNoneClause createFilterClause(@NotNull FieldKey fieldKey, Object value)
@@ -922,7 +922,7 @@ public abstract class CompareType
         }
     };
 
-    public static final CompareType ARRAY_MATCHES = new CompareType("Contains Exactly", "arraymatches", "ARRAYMATCHES", true, null, OperatorType.ARRAYMATCHES)
+    public static final CompareType ARRAY_MATCHES = new CompareType("Contains Exactly", "arraymatches", "ARRAY_CONTAINS_EXACT", true, null, OperatorType.ARRAYMATCHES)
     {
         @Override
         public ArrayMatchesClause createFilterClause(@NotNull FieldKey fieldKey, Object value)
@@ -943,7 +943,7 @@ public abstract class CompareType
         }
     };
 
-    public static final CompareType ARRAY_NOT_MATCHES = new CompareType("Does Not Contain Exactly", "arraynotmatches", "ARRAYNOTMATCHES", true, null, OperatorType.ARRAYNOTMATCHES)
+    public static final CompareType ARRAY_NOT_MATCHES = new CompareType("Does Not Contain Exactly", "arraynotmatches", "ARRAY_CONTAINS_NOT_EXACT", true, null, OperatorType.ARRAYNOTMATCHES)
     {
         @Override
         public ArrayNotMatchesClause createFilterClause(@NotNull FieldKey fieldKey, Object value)


### PR DESCRIPTION
#### Rationale
The published java and js client filter types uses x_y syntax for the array filter types. This PR updates the filter definition to match the script name.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- https://github.com/LabKey/labkey-api-js/pull/204
- https://github.com/LabKey/labkey-api-java/pull/88

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->