### PR TITLE
Stop generating controller-first URLs

### DIFF
--- a/api/src/org/labkey/api/jsp/taglib/FormTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/FormTag.java
@@ -69,8 +69,7 @@ public class FormTag extends BodyTagSupport
     @Deprecated // TODO: Eliminate all usages and remove
     public void setAction(String s)
     {
-        if (AppProps.getInstance().getUseContainerRelativeURL() &&
-                StringUtils.containsNone(s, "/-") && (StringUtils.endsWith(s, ".view") || StringUtils.endsWith(s, ".post")))
+        if (StringUtils.containsNone(s, "/-") && (StringUtils.endsWith(s, ".view") || StringUtils.endsWith(s, ".post")))
         {
             ViewContext ctx = HttpView.getRootContext();
             if (null != ctx)

--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -49,7 +49,6 @@ public interface AppProps
     String EXPERIMENTAL_RESOLVE_PROPERTY_URI_COLUMNS = "resolve-property-uri-columns";
     String ADMIN_PROVIDED_ALLOWED_EXTERNAL_RESOURCES = "allowedExternalResources";
     String QUANTITY_COLUMN_SUFFIX_TESTING = "quantityColumnSuffixTesting";
-    String GENERATE_CONTROLLER_FIRST_URLS = "generateControllerFirstUrls";
     String REJECT_CONTROLLER_FIRST_URLS = "rejectControllerFirstUrls";
     String MULTI_VALUE_TEXT_CHOICE = "multiChoiceDataType";
 
@@ -207,13 +206,6 @@ public interface AppProps
      * @return Email address of the primary site or application administrator
      */
     @Nullable String getAdministratorContactEmail(boolean includeAppAdmins);
-
-    /**
-     * Whether to use the newer, and preferred, container-relative style of URLs of the form
-     * /contextPath/container/controller-action.view, or the older controller-relative style like
-     * /contextPath/controller/container/action.view
-     */
-    boolean getUseContainerRelativeURL();
 
     boolean isAllowApiKeys();
 

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -549,12 +549,6 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
     }
 
     @Override
-    public boolean getUseContainerRelativeURL()
-    {
-        return !OptionalFeatureService.get().isFeatureEnabled(AppProps.GENERATE_CONTROLLER_FIRST_URLS);
-    }
-
-    @Override
     public boolean isAllowApiKeys()
     {
         return lookupBooleanValue(allowApiKeys, false);

--- a/api/src/org/labkey/api/settings/SiteSettingsProperties.java
+++ b/api/src/org/labkey/api/settings/SiteSettingsProperties.java
@@ -35,14 +35,6 @@ public enum SiteSettingsProperties implements StartupProperty, SafeToRenderEnum
             }
         }
     },
-    useContainerRelativeURL("Use \"path first\" urls (/home/project-begin.view)")
-    {
-        @Override
-        public void setValue(WriteableAppProps writeable, String value)
-        {
-            writeable.setUseContainerRelativeURL(Boolean.parseBoolean(value));
-        }
-    },
     usageReportingLevel("Check for updates and report usage statistics to the LabKey team. Valid values: " + Arrays.toString(UsageReportingLevel.values()))
     {
         @Override

--- a/api/src/org/labkey/api/settings/WriteableAppProps.java
+++ b/api/src/org/labkey/api/settings/WriteableAppProps.java
@@ -213,11 +213,6 @@ public class WriteableAppProps extends AppPropsImpl
         app.save(null);
     }
 
-    public void setUseContainerRelativeURL(boolean b)
-    {
-        OptionalFeatureService.get().setFeatureEnabled(GENERATE_CONTROLLER_FIRST_URLS, !b, null);
-    }
-
     public void setAllowApiKeys(boolean b)
     {
         storeBooleanValue(allowApiKeys, b);

--- a/api/src/org/labkey/api/util/HttpUtil.java
+++ b/api/src/org/labkey/api/util/HttpUtil.java
@@ -336,7 +336,7 @@ public class HttpUtil
             try
             {
                 ActionURL url = new ActionURL(referer);
-                return url.toContainerRelativeURL();
+                return url.toRelativeURL();
             }
             catch (Exception e)
             {

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2174,7 +2174,7 @@ public class PageFlowUtil
         // Expose some experimental flags to the client
         // Note: If you update this set of flags please update enum on client in @labkey/api
         JSONObject experimental = new JSONObject();
-        experimental.put("containerRelativeURL", appProps.getUseContainerRelativeURL());
+        experimental.put("containerRelativeURL", true);
         experimental.put(AppProps.EXPERIMENTAL_NO_GUESTS, AppProps.getInstance().isOptionalFeatureEnabled(AppProps.EXPERIMENTAL_NO_GUESTS));
         json.put("experimental", experimental);
 

--- a/api/src/org/labkey/api/view/ActionURL.java
+++ b/api/src/org/labkey/api/view/ActionURL.java
@@ -70,11 +70,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 /// @see ViewServlet
 public class ActionURL extends URLHelper implements Cloneable
 {
-    private static boolean useContainerRelativeURL()
-    {
-        return AppProps.getInstance().getUseContainerRelativeURL();
-    }
-
     public enum Param implements SafeToRenderEnum
     {
         returnUrl,
@@ -224,41 +219,20 @@ public class ActionURL extends URLHelper implements Cloneable
     }
 
     /** @return just the controller-action.view?parameters#fragment part of the URL, omitting the server name, context path, and container path */
-    public String toContainerRelativeURL()
+    public String toRelativeURL()
     {
-        StringBuilder result = new StringBuilder(toPathStringNew(Path.emptyPath, _controller, _action, Path.emptyPath));
+        StringBuilder result = new StringBuilder(toPathString(Path.emptyPath, _controller, _action, Path.emptyPath));
         appendParamsAndFragment(result, false);
         return result.toString();
     }
 
+    /** Generates in the format of /contextPath/containerPath/controller-action.view */
     private String toPathString(Path contextPath, String controller, String action, Path extraPath)
     {
-        if (useContainerRelativeURL())
-            return toPathStringNew(contextPath, controller, action, extraPath);
-        else
-            return toPathStringOld(contextPath, controller, action, extraPath);
-    }
-
-    /** Generates in the format of /contextPath/controller/containerPath/action.view */
-    private static String toPathStringOld(Path contextPath, String controller, String action, Path extraPath)
-    {
-        Path path = contextPath.append(controller).append(extraPath);
-        if (null != action)
-        {
-            if (-1 == action.indexOf('.'))
-                action = action + ".view";
-            path = path.append(action, false);
-        }
-        return path.encode();
-    }
-
-    /** Generates in the format of /contextPath/containerPath/controller-action.view */
-    private static String toPathStringNew(Path contextPath, String pageFlow, String action, Path extraPath)
-    {
         Path path = contextPath.append(extraPath);
-        if (null != action && null != pageFlow)
+        if (null != action && null != controller)
         {
-            action = pageFlow + "-" + action + (-1 == action.indexOf('.') ? ".view" : "");
+            action = controller + "-" + action + (-1 == action.indexOf('.') ? ".view" : "");
             path = path.append(action, false);
         }
         return path.encode();
@@ -573,14 +547,14 @@ public class ActionURL extends URLHelper implements Cloneable
         {
             controller = action.substring(0, dash);
             action = action.substring(dash+1);
-            setIsCanonical(useContainerRelativeURL());
+            setIsCanonical(true);
         }
         else
         {
             // Reject controller-first URLs if that experimental feature is enabled AND the generate controller-first URLs option is NOT enabled. Otherwise, admin would end up in a very bad state.
-            if (OptionalFeatureService.get().isFeatureEnabled(AppProps.REJECT_CONTROLLER_FIRST_URLS) && !OptionalFeatureService.get().isFeatureEnabled(AppProps.GENERATE_CONTROLLER_FIRST_URLS))
+            if (OptionalFeatureService.get().isFeatureEnabled(AppProps.REJECT_CONTROLLER_FIRST_URLS))
                 throw new IllegalArgumentException("Controller-first URLs are not allowed! (" + savedPath +")");
-            setIsCanonical(!useContainerRelativeURL());
+            setIsCanonical(false);
         }
 
         // parse controller
@@ -706,10 +680,7 @@ public class ActionURL extends URLHelper implements Cloneable
 
             ActionURL parse = new ActionURL("/Controller/path/action.view?foo=bar");
             String toString = parse.getLocalURIString();
-            if (useContainerRelativeURL())
-                assertEquals(parse.getContextPath() + "/path/controller-action.view?foo=bar", toString);
-            else
-                assertEquals(parse.getContextPath() + "/controller/path/action.view?foo=bar", toString);
+            assertEquals(parse.getContextPath() + "/path/controller-action.view?foo=bar", toString);
         }
 
         @Test

--- a/core/resources/scripts/labkey/ActionURL.js
+++ b/core/resources/scripts/labkey/ActionURL.js
@@ -266,11 +266,7 @@ that points back to the current page:
                 action += '.view';
             var query = LABKEY.ActionURL.queryString(parameters);
 
-            var newUrl;
-            if (LABKEY.experimental && LABKEY.experimental.containerRelativeURL)
-                newUrl = LABKEY.contextPath + containerPath + controller + "-" + action;
-            else
-                newUrl = LABKEY.contextPath + "/" + controller + containerPath + action;
+            var newUrl = LABKEY.contextPath + containerPath + controller + "-" + action;
             if (query)
                 newUrl += '?' + query;
             return newUrl;

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -540,11 +540,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             "Short-circuit robots",
             "Save resources by not rendering pages marked as 'noindex' for robots. This is experimental as not all robots are search engines.",
             false);
-        OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(AppProps.GENERATE_CONTROLLER_FIRST_URLS,
-            "Restore controller-first URLs",
-            "Generate URLs in a legacy format that puts the controller name before the folder path. This option will be removed in LabKey Server 26.3.",
-            false, false, OptionalFeatureService.FeatureType.Deprecated
-        ));
         OptionalFeatureService.get().addExperimentalFeatureFlag(AppProps.REJECT_CONTROLLER_FIRST_URLS,
             "Reject controller-first URLs",
             "Require standard path-first URLs. Note: This option will be ignored if the deprecated feature for generating controller-first URLs is enabled.",
@@ -1202,7 +1197,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                 customLog4JConfig = Boolean.parseBoolean(ModuleLoader.getServletContext().getInitParameter("org.labkey.customLog4JConfig"));
             }
             results.put("customLog4JConfig", customLog4JConfig);
-            results.put("containerRelativeURL", AppProps.getInstance().getUseContainerRelativeURL());
             results.put("runtimeMode", AppProps.getInstance().isDevMode() ? "development" : "production");
             Set<String> deployedApps = new HashSet<>(CoreWarningProvider.collectAllDeployedApps());
             deployedApps.remove(labkeyContextPath);


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/679

Also, rename `ActionURL.toContainerRelativeURL()` to `toRelativeURL()` for clarity