### PR TITLE
GitHub Issue 442: don't default to SORT_ASC during clearSort

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -2999,10 +2999,6 @@ if (!LABKEY.DataRegions) {
             });
         }
 
-        if (!direction) {
-            direction = SORT_ASC;
-        }
-
         if (LABKEY.Utils.isString(direction)) {
             newSorts = [direction + columnName].concat(newSorts);
         }


### PR DESCRIPTION
#### Rationale
Related to the changes made in [this](https://github.com/LabKey/internal-issues/issues/442) PR for https://github.com/LabKey/internal-issues/issues/442

In DataRegion.js _alterSortString (which is called when sort direction changes or is cleared), prior to the previous PR changes it would check for a SORT_ASC direction and use an empty string instead. The change was made so that instead it would check for no direction value and set it to SORT_ASC. This means that when clearSort() calls this function it would set the sort to SORT_ASC instead of clearing it. This resulted in a failure in the ListTest.testCustomViews.

#### Related Pull Requests
- https://github.com/LabKey/internal-issues/issues/442

#### Changes
- DataRegion.js don't default to SORT_ASC during clearSort

#### Tasks 📍
- [x] Manual Testing @DariaBod 
- ~Needs Automation~
- ~Verify Fix~
