### PR TITLE
LabKeyLIMS.shouldRegisterProduct to also include if set to "include" via startup property

### DIFF
--- a/api/src/org/labkey/api/module/FolderTypeManager.java
+++ b/api/src/org/labkey/api/module/FolderTypeManager.java
@@ -323,7 +323,7 @@ public class FolderTypeManager
             @Override
             public String getDescription()
             {
-                return "Comma-separated list of folder types to disable on this server";
+                return "Semicolon-separated list of folder types to disable on this server";
             }
         }
     }

--- a/api/src/org/labkey/api/products/Product.java
+++ b/api/src/org/labkey/api/products/Product.java
@@ -1,7 +1,11 @@
 package org.labkey.api.products;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.settings.StartupPropertyEntry;
 
+import java.util.Arrays;
 import java.util.List;
 
 public abstract class Product implements Comparable<Product>
@@ -17,6 +21,16 @@ public abstract class Product implements Comparable<Product>
     public abstract boolean isEnabled();
 
     public abstract @NotNull List<String> getFeatureFlags();
+
+    // return true if the ProductRegistry.include startup prop is set to include the product by name
+    public static boolean shouldIncludeViaStartupProperty(String productName)
+    {
+        ModuleLoader loader = ModuleLoader.getInstance();
+        StartupPropertyEntry entry = loader.getStartupPropertyEntries("ProductRegistry").stream()
+                .filter(e -> "include".equals(e.getName()))
+                .findFirst().orElse(null);
+        return entry != null && Arrays.stream(StringUtils.split(entry.getValue(), ",")).anyMatch(val -> productName.equals(val.trim()));
+    }
 
     @Override
     public int compareTo(@NotNull Product o)

--- a/api/src/org/labkey/api/products/Product.java
+++ b/api/src/org/labkey/api/products/Product.java
@@ -1,11 +1,7 @@
 package org.labkey.api.products;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.settings.StartupPropertyEntry;
 
-import java.util.Arrays;
 import java.util.List;
 
 public abstract class Product implements Comparable<Product>
@@ -21,16 +17,6 @@ public abstract class Product implements Comparable<Product>
     public abstract boolean isEnabled();
 
     public abstract @NotNull List<String> getFeatureFlags();
-
-    // return true if the ProductRegistry.include startup prop is set to include the product by name
-    public static boolean shouldIncludeViaStartupProperty(String productName)
-    {
-        ModuleLoader loader = ModuleLoader.getInstance();
-        StartupPropertyEntry entry = loader.getStartupPropertyEntries("ProductRegistry").stream()
-                .filter(e -> "include".equals(e.getName()))
-                .findFirst().orElse(null);
-        return entry != null && Arrays.stream(StringUtils.split(entry.getValue(), ",")).anyMatch(val -> productName.equals(val.trim()));
-    }
 
     @Override
     public int compareTo(@NotNull Product o)

--- a/api/src/org/labkey/api/settings/ProductConfiguration.java
+++ b/api/src/org/labkey/api/settings/ProductConfiguration.java
@@ -1,5 +1,6 @@
 package org.labkey.api.settings;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -9,12 +10,14 @@ import org.labkey.api.products.Product;
 import org.labkey.api.products.ProductRegistry;
 import org.labkey.api.util.logging.LogHelper;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 public class ProductConfiguration extends AbstractWriteableSettingsGroup implements StartupProperty
 {
     public static final String SCOPE_PRODUCT_CONFIGURATION = "ProductConfiguration";
     public static final String PROPERTY_NAME = "productKey";
+    public static final String INCLUDE_NAME = "include";
     private static final Logger _logger = LogHelper.getLogger(ProductConfiguration.class, "Product Configuration properties");
 
     @Override
@@ -91,8 +94,21 @@ public class ProductConfiguration extends AbstractWriteableSettingsGroup impleme
             @Override
             public void handle(Collection<StartupPropertyEntry> entries)
             {
-                entries.forEach(entry -> ProductConfiguration.setProductKey(entry.getValue()));
+                entries.forEach(entry -> {
+                    if (PROPERTY_NAME.equalsIgnoreCase(entry.getName()))
+                        ProductConfiguration.setProductKey(entry.getValue());
+                });
             }
         });
+    }
+
+    // return true if the ProductConfiguration.include startup prop is set to include the product by name
+    public static boolean shouldIncludeViaStartupProperty(String productName)
+    {
+        ModuleLoader loader = ModuleLoader.getInstance();
+        StartupPropertyEntry entry = loader.getStartupPropertyEntries(SCOPE_PRODUCT_CONFIGURATION).stream()
+                .filter(e -> INCLUDE_NAME.equals(e.getName()))
+                .findFirst().orElse(null);
+        return entry != null && Arrays.stream(StringUtils.split(entry.getValue(), ",")).anyMatch(val -> productName.equals(val.trim()));
     }
 }


### PR DESCRIPTION
#### Rationale
For the case where a lims_enterprise dist is deployed without the biologics module, we still want to have the server register the LabKey LIMS product at startup. This PR does that by allowing LabKeyLIMS.shouldRegisterProduct to also return true if set to "include" via startup property.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1995
- https://github.com/LabKey/platform/pull/7441

#### Changes
- ProductConfiguration.shouldIncludeViaStartupProperty static method to get startup props and check if a given product name is set to "include"
- FolderTypeManager disabledTypes startup prop is semicolon-separated list instead of comma-separated