### PR TITLE
Add FK to owner field in GridViewAuditEvent

### DIFF
--- a/query/src/org/labkey/query/audit/GridViewAuditProvider.java
+++ b/query/src/org/labkey/query/audit/GridViewAuditProvider.java
@@ -14,6 +14,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.UserIdForeignKey;
 import org.labkey.api.query.UserSchema;
 
 import java.util.ArrayList;
@@ -104,6 +105,7 @@ public class GridViewAuditProvider extends AbstractAuditTypeProvider implements 
                 }
                 else if (COLUMN_NAME_CUSTOM_VIEW_OWNER.equalsIgnoreCase(col.getName()))
                 {
+                    UserIdForeignKey.initColumn(col);
                     col.setLabel("View Owner");
                 }
             }


### PR DESCRIPTION
#### Rationale
This PR adds a FK to user table on the GridViewAuditEvent.viewOwner field, so we display user name instead of id in the grid.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7421
- https://github.com/LabKey/labkey-ui-components/pull/1941
- https://github.com/LabKey/limsModules/pull/2002

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->


<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->