### PR TITLE
Remove the user-defined flag field option

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/model/GWTDomain.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/model/GWTDomain.java
@@ -40,7 +40,6 @@ public class GWTDomain<FieldType extends GWTPropertyDescriptor> implements IsSer
     @Getter @Setter private String container;
     @Getter @Setter private boolean allowFileLinkProperties;
     @Getter @Setter private boolean allowAttachmentProperties;
-    @Getter @Setter private boolean allowFlagProperties;
     @Getter @Setter private boolean allowTextChoiceProperties;
     @Getter @Setter private boolean allowMultiChoiceProperties;
     @Getter @Setter private boolean allowSampleSubjectProperties;
@@ -89,7 +88,6 @@ public class GWTDomain<FieldType extends GWTPropertyDescriptor> implements IsSer
         this.container = src.container;
         this.allowFileLinkProperties = src.allowFileLinkProperties;
         this.allowAttachmentProperties = src.allowAttachmentProperties;
-        this.allowFlagProperties = src.allowFlagProperties;
         this.allowTextChoiceProperties = src.allowTextChoiceProperties;
         this.allowMultiChoiceProperties = src.allowMultiChoiceProperties;
         this.allowSampleSubjectProperties = src.allowSampleSubjectProperties;

--- a/api/gwtsrc/org/labkey/api/gwt/client/ui/PropertyType.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/ui/PropertyType.java
@@ -40,7 +40,6 @@ public enum PropertyType
     xsdTime("http://www.w3.org/2001/XMLSchema#time", true, "Time", null, "time"),
     expFileLink("http://cpas.fhcrc.org/exp/xml#fileLink", false, "File"),
     expAttachment("http://www.labkey.org/exp/xml#attachment", false, "Attachment"),
-    expFlag("http://www.labkey.org/exp/xml#flag", false, "Flag (String)"),
     xsdFloat("http://www.w3.org/2001/XMLSchema#float", true, "Number (Float)", "Float", "float"),
     xsdDecimal("http://www.w3.org/2001/XMLSchema#decimal", true, "Number (Decimal)", "Decimal", "float"),
     xsdLong("http://www.w3.org/2001/XMLSchema#long", true, "Long Integer", "Long", "int"),

--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -1689,12 +1689,6 @@ public abstract class AbstractAssayProvider implements AssayProvider
     }
 
     @Override
-    public boolean supportsFlagColumnType(ExpProtocol.AssayDomainTypes type)
-    {
-        return false;
-    }
-
-    @Override
     public Module getDeclaringModule()
     {
         return _declaringModule;

--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -22,9 +22,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.actions.AssayRunUploadForm;
 import org.labkey.api.assay.pipeline.AssayRunAsyncContext;
+import org.labkey.api.assay.plate.FilterCriteria;
 import org.labkey.api.assay.transform.AnalysisScript;
 import org.labkey.api.assay.transform.DataExchangeHandler;
-import org.labkey.api.assay.plate.FilterCriteria;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.exp.ExperimentException;
@@ -330,8 +330,6 @@ public interface AssayProvider extends Handler<ExpProtocol>
     @Nullable String getProtocolPattern();
 
     void registerLsidHandler();
-
-    boolean supportsFlagColumnType(ExpProtocol.AssayDomainTypes type);
 
     /**@ return the module in which this assay provider is declared */
     Module getDeclaringModule();

--- a/api/src/org/labkey/api/assay/AssayUrls.java
+++ b/api/src/org/labkey/api/assay/AssayUrls.java
@@ -88,7 +88,6 @@ public interface AssayUrls extends UrlProvider
     ActionURL getUpdateQCStateURL(Container container, ExpProtocol protocol);
 
     ActionURL getBeginURL(Container container);
-    ActionURL getSetResultFlagURL(Container container);
     ActionURL getChooseAssayTypeURL(Container container);
     ActionURL getImportAssayDesignURL(Container container);
     ActionURL getShowSelectedDataURL(Container container, ExpProtocol protocol);

--- a/api/src/org/labkey/api/exp/PropertyDescriptor.java
+++ b/api/src/org/labkey/api/exp/PropertyDescriptor.java
@@ -545,12 +545,7 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
         if (!StringUtils.isEmpty(getLabel()))
             map.put("Label", getLabel());
         if (null != getPropertyType())
-        {
-            if (org.labkey.api.gwt.client.ui.PropertyType.expFlag.getURI().equals(getConceptURI()))
-                map.put("Type", "Flag");
-            else
-                map.put("Type", getPropertyType().getXarName());
-        }
+            map.put("Type", getPropertyType().getXarName());
         if (getPropertyType().getJdbcType().isText())
             map.put("Scale", getScale());
         if (!StringUtils.isEmpty(getDescription()))

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -321,7 +321,6 @@ abstract public class DomainKind<T> implements Handler<String>
 
     public boolean allowFileLinkProperties() { return false; }
     public boolean allowAttachmentProperties() { return false; }
-    public boolean allowFlagProperties() { return true; }
     public boolean allowTextChoiceProperties() { return true; }
     public boolean allowMultiChoiceProperties() { return false; }
     public boolean allowSampleSubjectProperties() { return true; }

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -458,7 +458,6 @@ public class DomainUtil
         {
             gwtDomain.setAllowAttachmentProperties(kind.allowAttachmentProperties());
             gwtDomain.setAllowFileLinkProperties(kind.allowFileLinkProperties());
-            gwtDomain.setAllowFlagProperties(kind.allowFlagProperties());
             gwtDomain.setAllowTextChoiceProperties(kind.allowTextChoiceProperties());
             gwtDomain.setAllowMultiChoiceProperties(allowMultiChoice(kind));
             gwtDomain.setAllowSampleSubjectProperties(kind.allowSampleSubjectProperties());
@@ -478,7 +477,6 @@ public class DomainUtil
         gwtDomain.setDomainKindName(kind.getKindName());
         gwtDomain.setAllowAttachmentProperties(kind.allowAttachmentProperties());
         gwtDomain.setAllowFileLinkProperties(kind.allowFileLinkProperties());
-        gwtDomain.setAllowFlagProperties(kind.allowFlagProperties());
         gwtDomain.setAllowTextChoiceProperties(kind.allowTextChoiceProperties());
         gwtDomain.setAllowMultiChoiceProperties(allowMultiChoice(kind));
         gwtDomain.setAllowSampleSubjectProperties(kind.allowSampleSubjectProperties());

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.16.1"
+        "@labkey/components": "7.20.1-fb-remove-flag-field.0"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -2745,9 +2745,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.0.tgz",
-      "integrity": "sha512-QwSm82KBc9Hhd5GUDe99J35xvXIWBtbvFbXxJh81x6le62EZFQdptDoxJyKGpDQiv+cITlNEfvYXjY3CO0y1Kw==",
+      "version": "1.46.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.1.tgz",
+      "integrity": "sha512-zZEGy/MS8FbfFYjzu6KNx7smbxFaB1tfTRzbPEih31GoI0THNSz58f0spqfn9F5NQeL2PG9AC0YdSFR8eMFkCg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2788,13 +2788,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.16.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.16.1.tgz",
-      "integrity": "sha512-YsJl+61V4D6OMkmXH6VvUp+mxlEGK1gsBcmyuIKLkqU/YG+UCSAFCkSuc71YNFTJc7L0Bk9nUaheBl0YcQhxyw==",
+      "version": "7.20.1-fb-remove-flag-field.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1-fb-remove-flag-field.0.tgz",
+      "integrity": "sha512-8mqnPCK1RCLmoS3vcnkMX7hBRUE8e+1V195tUGor+JQ6Y2M1b82GBcrMCy6UBqRM/0TCjVXDN3nTS8dCcEq9AQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.0",
+        "@labkey/api": "1.46.1",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.1-fb-remove-flag-field.0"
+        "@labkey/components": "7.20.5"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -2745,9 +2745,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.1.tgz",
-      "integrity": "sha512-zZEGy/MS8FbfFYjzu6KNx7smbxFaB1tfTRzbPEih31GoI0THNSz58f0spqfn9F5NQeL2PG9AC0YdSFR8eMFkCg==",
+      "version": "1.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.47.0.tgz",
+      "integrity": "sha512-yxw+KAZ7kH5xYcYWlH7GdC1hycHpfFf9y+91Z3x2KlSshl75u8QBzOp/0hWZ7OHYOzAmTwJMYm3GBK3K93kFtg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2788,13 +2788,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.1-fb-remove-flag-field.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1-fb-remove-flag-field.0.tgz",
-      "integrity": "sha512-8mqnPCK1RCLmoS3vcnkMX7hBRUE8e+1V195tUGor+JQ6Y2M1b82GBcrMCy6UBqRM/0TCjVXDN3nTS8dCcEq9AQ==",
+      "version": "7.20.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.5.tgz",
+      "integrity": "sha512-PVFhcSxmFlxARKA43sNQVF87LpmwMRtZlULRVf+s3taAAyhK7CmLV4QYicty5X11cdj17I6MeHA77BKUj5fZpA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.1",
+        "@labkey/api": "1.47.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "7.20.1-fb-remove-flag-field.0"
+    "@labkey/components": "7.20.5"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "7.16.1"
+    "@labkey/components": "7.20.1-fb-remove-flag-field.0"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -16,7 +16,6 @@
 
 package org.labkey.assay;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -42,7 +41,6 @@ import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.assay.AssayProtocolSchema;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayQCService;
-import org.labkey.api.assay.AssayResultTable;
 import org.labkey.api.assay.AssayRunsView;
 import org.labkey.api.assay.AssaySchema;
 import org.labkey.api.assay.AssayService;
@@ -75,12 +73,10 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DataRegionSelection;
-import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.JsonWriter;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.defaults.DefaultValueService;
@@ -1213,12 +1209,6 @@ public class AssayController extends SpringActionController
         }
 
         @Override
-        public ActionURL getSetResultFlagURL(Container container)
-        {
-            return new ActionURL(SetResultFlagAction.class, container);
-        }
-
-        @Override
         public ActionURL getChooseAssayTypeURL(Container container)
         {
             return new ActionURL(ChooseAssayTypeAction.class, container);
@@ -1369,65 +1359,6 @@ public class AssayController extends SpringActionController
                 catch (NumberFormatException x) {}
             }
             return ret;
-        }
-    }
-
-
-    /**
-     * This is different from ExperimentController$SetFlagAction since Result Rows are not ExpObjects,
-     * and we store flag directly in the materialized table
-     */
-    @RequiresPermission(UpdatePermission.class)
-    public static class SetResultFlagAction extends MutatingApiAction<SetResultFlagForm>
-    {
-        @Override
-        protected @NotNull SetResultFlagForm getCommand(HttpServletRequest request)
-        {
-            return new SetResultFlagForm();
-        }
-
-        @Override
-        public ApiResponse execute(SetResultFlagForm form, BindException errors)
-        {
-            form.setContainer(getContainer());
-            ExpProtocol protocol = form.getProtocol();
-            String tableName = AssayProtocolSchema.DATA_TABLE_NAME;
-            AssaySchema schema = form.getProvider().createProtocolSchema(getUser(), getContainer(), protocol, null);
-            TableInfo table = schema.getTable(tableName);
-            if (!(table instanceof AssayResultTable assayResultTable))
-                throw new NotFoundException();
-            if (null == form.getColumnName())
-                throw new NotFoundException();
-            TableInfo ti = assayResultTable.getSchemaTableInfo();
-            String comment = StringUtils.trimToNull(form.getComment());
-
-            ColumnInfo flagCol = assayResultTable.getColumn(form.getColumnName());
-            if (null == form.getColumnName())
-                throw new NotFoundException();
-            if (!org.labkey.api.gwt.client.ui.PropertyType.expFlag.getURI().equals(flagCol.getConceptURI()))
-                throw new NotFoundException();
-
-            DbScope scope = ti.getSchema().getScope();
-            int rowsAffected  = 0 ;
-            try (DbScope.Transaction transaction = scope.ensureTransaction())
-            {
-                for (Integer id : form.getRowList())
-                {
-                    // assuming that column in storage table has same name
-                    Map<String, Object> flagComment = new HashMap<>();
-                    flagComment.put(flagCol.getColumnName(), comment);
-                    Table.update(getUser(), ti, flagComment, id);
-                    rowsAffected++;
-                }
-                transaction.commit();
-            }
-
-            // the flag is editable even if the assay is not
-            JSONObject res = new JSONObject();
-            res.put("success", true);
-            res.put("comment", form.getComment());
-            res.put("rowsAffected", rowsAffected);
-            return new ApiSimpleResponse(res);
         }
     }
 

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -233,9 +233,6 @@ public class AssayDomainServiceImpl implements AssayDomainService, ContainerUser
             gwtDomain.setFields(fields);
             gwtDomain.setMandatoryFieldNames(mandatoryPropertyDescriptors);
 
-            if (isResultsDomain)
-                gwtDomain.setAllowFlagProperties(provider.supportsFlagColumnType(ExpProtocol.AssayDomainTypes.Result));
-
             gwtDomains.add(gwtDomain);
         }
 

--- a/assay/src/org/labkey/assay/TSVProtocolSchema.java
+++ b/assay/src/org/labkey/assay/TSVProtocolSchema.java
@@ -20,17 +20,13 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayProtocolSchema;
 import org.labkey.api.assay.AssayResultDomainKind;
 import org.labkey.api.assay.AssayResultTable;
-import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.assay.AssayWellExclusionService;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.JdbcType;
-import org.labkey.api.data.RemappingDisplayColumnFactory;
-import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -38,7 +34,6 @@ import org.labkey.api.exp.PropertyColumn;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.StorageProvisioner;
-import org.labkey.api.exp.flag.FlagColumnRenderer;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.query.AliasedColumn;
@@ -53,9 +48,6 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.view.ActionURL;
-import org.labkey.api.writer.HtmlWriter;
 import org.labkey.assay.plate.AssayPlateTriggerFactory;
 import org.labkey.assay.plate.PlateReplicateStatsDomainKind;
 import org.labkey.assay.plate.query.PlateSchema;
@@ -66,7 +58,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 
 public class TSVProtocolSchema extends AssayProtocolSchema
@@ -142,14 +133,6 @@ public class TSVProtocolSchema extends AssayProtocolSchema
         _AssayResultTable(AssayProtocolSchema schema, ContainerFilter cf, boolean includeLinkedToStudyColumns)
         {
             super(schema, cf, includeLinkedToStudyColumns);
-            String flagConceptURI = org.labkey.api.gwt.client.ui.PropertyType.expFlag.getURI();
-            for (ColumnInfo col : getColumns())
-            {
-                if (col.getJdbcType() == JdbcType.VARCHAR && flagConceptURI.equals(col.getConceptURI()))
-                {
-                    ((BaseColumnInfo)col).setDisplayColumnFactory(new _FlagDisplayColumnFactory(schema.getProtocol(), this.getName()));
-                }
-            }
 
             if (getProvider().isPlateMetadataEnabled(getProtocol()))
             {
@@ -306,92 +289,6 @@ public class TSVProtocolSchema extends AssayProtocolSchema
         public @Nullable QueryUpdateService getUpdateService()
         {
             return new DefaultQueryUpdateService(this, getRealTable());
-        }
-    }
-
-    static class _FlagDisplayColumnFactory implements RemappingDisplayColumnFactory
-    {
-        FieldKey rowId = new FieldKey(null, "RowId");
-        final ExpProtocol protocol;
-        final String dataregion;
-
-        _FlagDisplayColumnFactory(ExpProtocol protocol, String dataregionName)
-        {
-            this.protocol = protocol;
-            this.dataregion = dataregionName;
-        }
-
-        @Override
-        public _FlagDisplayColumnFactory remapFieldKeys(@Nullable FieldKey parent, @Nullable Map<FieldKey, FieldKey> remap)
-        {
-            _FlagDisplayColumnFactory remapped = this.clone();
-            var fk = FieldKey.remap(rowId, parent, remap);
-            if (null != fk)
-                remapped.rowId = fk;
-            return remapped;
-        }
-
-        @Override
-        public DisplayColumn createRenderer(ColumnInfo colInfo)
-        {
-            return new _FlagColumnRenderer(colInfo, rowId, protocol);
-        }
-
-        @Override
-        protected _FlagDisplayColumnFactory clone()
-        {
-            try
-            {
-                return (_FlagDisplayColumnFactory)super.clone();
-            }
-            catch (CloneNotSupportedException e)
-            {
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
-    /**
-     * NOTE: The base class FlagColumnRenderer usually wraps an lsid and uses the
-     * display column to find the comment.
-     * This class turns that around.  It wraps a flag/comment column and uses
-     * run/lsid and rowid to generate a fake lsid
-     */
-    private static class _FlagColumnRenderer extends FlagColumnRenderer
-    {
-        private final FieldKey rowId;
-        private final ExpProtocol protocol;
-
-        private _FlagColumnRenderer(ColumnInfo col, FieldKey rowId, ExpProtocol protocol)
-        {
-            super(col);
-            this.rowId = rowId;
-            this.protocol = protocol;
-            ActionURL url = PageFlowUtil.urlProvider(AssayUrls.class).getSetResultFlagURL(protocol.getContainer());
-            url.addParameter("rowId", protocol.getRowId());
-            url.addParameter("columnName", col.getName());
-            this.endpoint = url.getLocalURIString();
-            // I think the column name here does not really matter, see AssayController.getRowList()).
-            this.jsConvertPKToLSID = "function(pk){return " +
-                    PageFlowUtil.jsString("protocol" + protocol.getRowId() + "." + getBoundColumn().getName() + ":") + " + pk}";
-        }
-
-        @Override
-        protected void renderFlag(RenderContext ctx, HtmlWriter out)
-        {
-            renderFlagScript(ctx, out);
-            Integer id = ctx.get(rowId, Integer.class);
-            Object comment = getValue(ctx);
-            // I think the column name here does not really matter, see AssayController.getRowList()).
-            String lsid = null==id ? null : "protocol" + protocol.getRowId() + "." + getBoundColumn().getName() +  ":" + id;
-            _renderFlag(ctx, out, lsid, null == comment ? null : String.valueOf(comment));
-        }
-
-        @Override
-        public void addQueryFieldKeys(Set<FieldKey> keys)
-        {
-            super.addQueryFieldKeys(keys);
-            keys.add(rowId);
         }
     }
 }

--- a/assay/src/org/labkey/assay/TsvAssayProvider.java
+++ b/assay/src/org/labkey/assay/TsvAssayProvider.java
@@ -385,12 +385,6 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
     }
 
     @Override
-    public boolean supportsFlagColumnType(ExpProtocol.AssayDomainTypes type)
-    {
-        return ExpProtocol.AssayDomainTypes.Result.equals(type);
-    }
-
-    @Override
     public boolean supportsPlateMetadata(ExpProtocol protocol)
     {
         if (protocol != null)

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.1-fb-remove-flag-field.0",
+        "@labkey/components": "7.20.5",
         "@labkey/themes": "1.6.0"
       },
       "devDependencies": {
@@ -3814,9 +3814,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.1.tgz",
-      "integrity": "sha512-zZEGy/MS8FbfFYjzu6KNx7smbxFaB1tfTRzbPEih31GoI0THNSz58f0spqfn9F5NQeL2PG9AC0YdSFR8eMFkCg==",
+      "version": "1.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.47.0.tgz",
+      "integrity": "sha512-yxw+KAZ7kH5xYcYWlH7GdC1hycHpfFf9y+91Z3x2KlSshl75u8QBzOp/0hWZ7OHYOzAmTwJMYm3GBK3K93kFtg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3857,13 +3857,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.1-fb-remove-flag-field.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1-fb-remove-flag-field.0.tgz",
-      "integrity": "sha512-8mqnPCK1RCLmoS3vcnkMX7hBRUE8e+1V195tUGor+JQ6Y2M1b82GBcrMCy6UBqRM/0TCjVXDN3nTS8dCcEq9AQ==",
+      "version": "7.20.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.5.tgz",
+      "integrity": "sha512-PVFhcSxmFlxARKA43sNQVF87LpmwMRtZlULRVf+s3taAAyhK7CmLV4QYicty5X11cdj17I6MeHA77BKUj5fZpA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.1",
+        "@labkey/api": "1.47.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.0",
+        "@labkey/components": "7.20.1-fb-remove-flag-field.0",
         "@labkey/themes": "1.6.0"
       },
       "devDependencies": {
@@ -3857,9 +3857,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.0.tgz",
-      "integrity": "sha512-LCinLOEDkyc5PxZUkrY/rbI7ohZfquGHyndeSYswplIu9REkwJUEuFa/VTL7wTNy0x2fazZmGAGFIuAeP/B1ZA==",
+      "version": "7.20.1-fb-remove-flag-field.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1-fb-remove-flag-field.0.tgz",
+      "integrity": "sha512-8mqnPCK1RCLmoS3vcnkMX7hBRUE8e+1V195tUGor+JQ6Y2M1b82GBcrMCy6UBqRM/0TCjVXDN3nTS8dCcEq9AQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "7.20.0",
+    "@labkey/components": "7.20.1-fb-remove-flag-field.0",
     "@labkey/themes": "1.6.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "7.20.1-fb-remove-flag-field.0",
+    "@labkey/components": "7.20.5",
     "@labkey/themes": "1.6.0"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.1-fb-remove-flag-field.0"
+        "@labkey/components": "7.20.5"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -3591,9 +3591,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.1.tgz",
-      "integrity": "sha512-zZEGy/MS8FbfFYjzu6KNx7smbxFaB1tfTRzbPEih31GoI0THNSz58f0spqfn9F5NQeL2PG9AC0YdSFR8eMFkCg==",
+      "version": "1.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.47.0.tgz",
+      "integrity": "sha512-yxw+KAZ7kH5xYcYWlH7GdC1hycHpfFf9y+91Z3x2KlSshl75u8QBzOp/0hWZ7OHYOzAmTwJMYm3GBK3K93kFtg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3634,13 +3634,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.1-fb-remove-flag-field.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1-fb-remove-flag-field.0.tgz",
-      "integrity": "sha512-8mqnPCK1RCLmoS3vcnkMX7hBRUE8e+1V195tUGor+JQ6Y2M1b82GBcrMCy6UBqRM/0TCjVXDN3nTS8dCcEq9AQ==",
+      "version": "7.20.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.5.tgz",
+      "integrity": "sha512-PVFhcSxmFlxARKA43sNQVF87LpmwMRtZlULRVf+s3taAAyhK7CmLV4QYicty5X11cdj17I6MeHA77BKUj5fZpA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.1",
+        "@labkey/api": "1.47.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.0"
+        "@labkey/components": "7.20.1-fb-remove-flag-field.0"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -3634,9 +3634,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.0.tgz",
-      "integrity": "sha512-LCinLOEDkyc5PxZUkrY/rbI7ohZfquGHyndeSYswplIu9REkwJUEuFa/VTL7wTNy0x2fazZmGAGFIuAeP/B1ZA==",
+      "version": "7.20.1-fb-remove-flag-field.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1-fb-remove-flag-field.0.tgz",
+      "integrity": "sha512-8mqnPCK1RCLmoS3vcnkMX7hBRUE8e+1V195tUGor+JQ6Y2M1b82GBcrMCy6UBqRM/0TCjVXDN3nTS8dCcEq9AQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.20.0"
+    "@labkey/components": "7.20.1-fb-remove-flag-field.0"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.20.1-fb-remove-flag-field.0"
+    "@labkey/components": "7.20.5"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-26.002-26.003.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-26.002-26.003.sql
@@ -1,0 +1,1 @@
+UPDATE exp.propertyDescriptor SET concepturi = NULL WHERE concepturi = 'http://www.labkey.org/exp/xml#flag';

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-26.002-26.003.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-26.002-26.003.sql
@@ -1,0 +1,1 @@
+UPDATE exp.propertyDescriptor SET concepturi = NULL WHERE concepturi = 'http://www.labkey.org/exp/xml#flag';

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -205,7 +205,7 @@ public class ExperimentModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 26.002;
+        return 26.003;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -22,12 +22,10 @@ import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.Sets;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.NullColumnInfo;
-import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.OntologyManager;
@@ -287,8 +285,6 @@ abstract public class ExpTableImpl<C extends Enum>
         ret.setInputType("text");
         ret.setMeasure(false);
         ret.setDimension(false);
-        ret.setConceptURI(org.labkey.api.gwt.client.ui.PropertyType.expFlag.getURI());
-        ret.setPropertyURI(org.labkey.api.gwt.client.ui.PropertyType.expFlag.getURI());
         ret.setImportAliasesSet(Sets.newCaseInsensitiveHashSet("comment"));
         return ret;
     }

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -1189,12 +1189,7 @@ public class DomainPropertyImpl implements DomainProperty
         if (!StringUtils.isEmpty(getLabel()))
             map.put("Label", getLabel());
         if (null != getPropertyType())
-        {
-            if (org.labkey.api.gwt.client.ui.PropertyType.expFlag.getURI().equals(getConceptURI()))
-                map.put("Type", "Flag");
-            else
-                map.put("Type", getPropertyType().getXarName());
-        }
+            map.put("Type", getPropertyType().getXarName());
         if (getPropertyType().getJdbcType().isText())
             map.put("Scale", getScale());
         if (!StringUtils.isEmpty(getDescription()))

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.16.1"
+        "@labkey/components": "7.20.1-fb-remove-flag-field.0"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -2979,9 +2979,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.0.tgz",
-      "integrity": "sha512-QwSm82KBc9Hhd5GUDe99J35xvXIWBtbvFbXxJh81x6le62EZFQdptDoxJyKGpDQiv+cITlNEfvYXjY3CO0y1Kw==",
+      "version": "1.46.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.1.tgz",
+      "integrity": "sha512-zZEGy/MS8FbfFYjzu6KNx7smbxFaB1tfTRzbPEih31GoI0THNSz58f0spqfn9F5NQeL2PG9AC0YdSFR8eMFkCg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3022,13 +3022,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.16.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.16.1.tgz",
-      "integrity": "sha512-YsJl+61V4D6OMkmXH6VvUp+mxlEGK1gsBcmyuIKLkqU/YG+UCSAFCkSuc71YNFTJc7L0Bk9nUaheBl0YcQhxyw==",
+      "version": "7.20.1-fb-remove-flag-field.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1-fb-remove-flag-field.0.tgz",
+      "integrity": "sha512-8mqnPCK1RCLmoS3vcnkMX7hBRUE8e+1V195tUGor+JQ6Y2M1b82GBcrMCy6UBqRM/0TCjVXDN3nTS8dCcEq9AQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.0",
+        "@labkey/api": "1.46.1",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.1-fb-remove-flag-field.0"
+        "@labkey/components": "7.20.5"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -2979,9 +2979,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.1.tgz",
-      "integrity": "sha512-zZEGy/MS8FbfFYjzu6KNx7smbxFaB1tfTRzbPEih31GoI0THNSz58f0spqfn9F5NQeL2PG9AC0YdSFR8eMFkCg==",
+      "version": "1.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.47.0.tgz",
+      "integrity": "sha512-yxw+KAZ7kH5xYcYWlH7GdC1hycHpfFf9y+91Z3x2KlSshl75u8QBzOp/0hWZ7OHYOzAmTwJMYm3GBK3K93kFtg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3022,13 +3022,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.1-fb-remove-flag-field.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1-fb-remove-flag-field.0.tgz",
-      "integrity": "sha512-8mqnPCK1RCLmoS3vcnkMX7hBRUE8e+1V195tUGor+JQ6Y2M1b82GBcrMCy6UBqRM/0TCjVXDN3nTS8dCcEq9AQ==",
+      "version": "7.20.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.5.tgz",
+      "integrity": "sha512-PVFhcSxmFlxARKA43sNQVF87LpmwMRtZlULRVf+s3taAAyhK7CmLV4QYicty5X11cdj17I6MeHA77BKUj5fZpA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.1",
+        "@labkey/api": "1.47.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "7.20.1-fb-remove-flag-field.0"
+    "@labkey/components": "7.20.5"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "7.16.1"
+    "@labkey/components": "7.20.1-fb-remove-flag-field.0"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",

--- a/study/test/src/org/labkey/test/tests/study/AssayTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AssayTest.java
@@ -325,11 +325,8 @@ public class AssayTest extends AbstractAssayTest
         clickButton("Submit");
         assertTextPresent("Could not convert value: " + "notAnumber");
         setFormElement(Locator.name("quf_testAssayDataProp5"), "514801");
-        setFormElement(Locator.name("quf_Flags"), "This Flag Has Been Edited");
         clickButton("Submit");
         assertTextPresent("EditedSpecimenID", "601.5", "514801");
-        assertElementPresent(Locator.xpath("//i[contains(@class, 'lk-flag-enabled')][@title='This Flag Has Been Edited']"), 1);
-        assertElementPresent(Locator.xpath("//i[contains(@class, 'lk-flag-disabled')][@title='Flag for review']"), 9);
 
         // Try a delete
         dataTable.checkCheckbox(table.getRowIndex("Specimen ID", "EditedSpecimenID"));
@@ -341,7 +338,7 @@ public class AssayTest extends AbstractAssayTest
 
         // Verify that the edit was audited
         AuditLogHelper auditLogHelper = new AuditLogHelper(this, () -> WebTestHelper.getRemoteApiConnection(false));
-        auditLogHelper.checkAuditEventDiffCount(getProjectName(), AuditLogHelper.AuditEvent.QUERY_UPDATE_AUDIT_EVENT, List.of(0/*delete*/, 4/*edit*/));
+        auditLogHelper.checkAuditEventDiffCount(getProjectName(), AuditLogHelper.AuditEvent.QUERY_UPDATE_AUDIT_EVENT, List.of(0/*delete*/, 3/*edit*/));
 
         goToSchemaBrowser();
         viewQueryData("auditLog", "ExperimentAuditEvent");


### PR DESCRIPTION
#### Rationale
This will remove the user defined flag type field from domain designers. The built in flag field for assay runs, samples, data classes will remain.

- Remove the flag `conceptURI` from the code and clear it from any saved property descriptors. This will convert them to `String` field types.
- Remove references to the type from serialized domains, assay providers, domain kinds, tests etc.
- Delete the display column and endpoint for flag fields that were created for GPAT result domains.

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/2893
https://github.com/LabKey/limsModules/pull/2000
https://github.com/LabKey/platform/pull/7447
https://github.com/LabKey/labkey-ui-premium/pull/897
https://github.com/LabKey/labkey-ui-components/pull/1940