### PR TITLE
Always use container relative URLs

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.2-fb-container-first-clients.0"
+        "@labkey/components": "7.20.2"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -2745,9 +2745,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.2-fb-container-first-clients.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.2-fb-container-first-clients.1.tgz",
-      "integrity": "sha512-kpuFQSghH94bLh89TaICOzQbZpr8Ompq9ox9JGZXU5DSzI9ub1RC2gpsnt9gHKvKemp0XVmEyOENP2ct1wvX0w==",
+      "version": "1.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.47.0.tgz",
+      "integrity": "sha512-yxw+KAZ7kH5xYcYWlH7GdC1hycHpfFf9y+91Z3x2KlSshl75u8QBzOp/0hWZ7OHYOzAmTwJMYm3GBK3K93kFtg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2788,13 +2788,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.2-fb-container-first-clients.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2-fb-container-first-clients.0.tgz",
-      "integrity": "sha512-+47YMWgLrwzPQDWz7opgERwFMHcvelN0tO8VCkpmRnPtSYwdn0w/PUIIARfH2aoqcYbeYNbS2lwRDOBNTZzOhw==",
+      "version": "7.20.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2.tgz",
+      "integrity": "sha512-3vWuXxmtDfA7/UmShSftR0c7mENLtnPIEauqWmqX0g1AnzBGQJVyKUzEo1i7Qx2pdy0juYjsync+i6fjHQDXGg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.2-fb-container-first-clients.1",
+        "@labkey/api": "1.47.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.1"
+        "@labkey/components": "7.20.2-fb-container-first-clients.0"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -2745,9 +2745,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.1.tgz",
-      "integrity": "sha512-zZEGy/MS8FbfFYjzu6KNx7smbxFaB1tfTRzbPEih31GoI0THNSz58f0spqfn9F5NQeL2PG9AC0YdSFR8eMFkCg==",
+      "version": "1.46.2-fb-container-first-clients.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.2-fb-container-first-clients.1.tgz",
+      "integrity": "sha512-kpuFQSghH94bLh89TaICOzQbZpr8Ompq9ox9JGZXU5DSzI9ub1RC2gpsnt9gHKvKemp0XVmEyOENP2ct1wvX0w==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2788,13 +2788,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1.tgz",
-      "integrity": "sha512-ShGllYov7JZJRSyDJOMlc0/U/4jTPVyYCLoCryiUQgKUlUTlUUjRIBA4SU/nZNFwvGRtGJG26mcHm1d+ZWaUkg==",
+      "version": "7.20.2-fb-container-first-clients.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2-fb-container-first-clients.0.tgz",
+      "integrity": "sha512-+47YMWgLrwzPQDWz7opgERwFMHcvelN0tO8VCkpmRnPtSYwdn0w/PUIIARfH2aoqcYbeYNbS2lwRDOBNTZzOhw==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.1",
+        "@labkey/api": "1.46.2-fb-container-first-clients.1",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "7.20.2-fb-container-first-clients.0"
+    "@labkey/components": "7.20.2"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "7.20.1"
+    "@labkey/components": "7.20.2-fb-container-first-clients.0"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.2-fb-container-first-clients.0",
+        "@labkey/components": "7.20.2",
         "@labkey/themes": "1.6.0"
       },
       "devDependencies": {
@@ -3814,9 +3814,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.2-fb-container-first-clients.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.2-fb-container-first-clients.1.tgz",
-      "integrity": "sha512-kpuFQSghH94bLh89TaICOzQbZpr8Ompq9ox9JGZXU5DSzI9ub1RC2gpsnt9gHKvKemp0XVmEyOENP2ct1wvX0w==",
+      "version": "1.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.47.0.tgz",
+      "integrity": "sha512-yxw+KAZ7kH5xYcYWlH7GdC1hycHpfFf9y+91Z3x2KlSshl75u8QBzOp/0hWZ7OHYOzAmTwJMYm3GBK3K93kFtg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3857,13 +3857,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.2-fb-container-first-clients.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2-fb-container-first-clients.0.tgz",
-      "integrity": "sha512-+47YMWgLrwzPQDWz7opgERwFMHcvelN0tO8VCkpmRnPtSYwdn0w/PUIIARfH2aoqcYbeYNbS2lwRDOBNTZzOhw==",
+      "version": "7.20.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2.tgz",
+      "integrity": "sha512-3vWuXxmtDfA7/UmShSftR0c7mENLtnPIEauqWmqX0g1AnzBGQJVyKUzEo1i7Qx2pdy0juYjsync+i6fjHQDXGg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.2-fb-container-first-clients.1",
+        "@labkey/api": "1.47.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.1",
+        "@labkey/components": "7.20.2-fb-container-first-clients.0",
         "@labkey/themes": "1.6.0"
       },
       "devDependencies": {
@@ -3814,9 +3814,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.1.tgz",
-      "integrity": "sha512-zZEGy/MS8FbfFYjzu6KNx7smbxFaB1tfTRzbPEih31GoI0THNSz58f0spqfn9F5NQeL2PG9AC0YdSFR8eMFkCg==",
+      "version": "1.46.2-fb-container-first-clients.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.2-fb-container-first-clients.1.tgz",
+      "integrity": "sha512-kpuFQSghH94bLh89TaICOzQbZpr8Ompq9ox9JGZXU5DSzI9ub1RC2gpsnt9gHKvKemp0XVmEyOENP2ct1wvX0w==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3857,13 +3857,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1.tgz",
-      "integrity": "sha512-ShGllYov7JZJRSyDJOMlc0/U/4jTPVyYCLoCryiUQgKUlUTlUUjRIBA4SU/nZNFwvGRtGJG26mcHm1d+ZWaUkg==",
+      "version": "7.20.2-fb-container-first-clients.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2-fb-container-first-clients.0.tgz",
+      "integrity": "sha512-+47YMWgLrwzPQDWz7opgERwFMHcvelN0tO8VCkpmRnPtSYwdn0w/PUIIARfH2aoqcYbeYNbS2lwRDOBNTZzOhw==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.1",
+        "@labkey/api": "1.46.2-fb-container-first-clients.1",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "7.20.1",
+    "@labkey/components": "7.20.2-fb-container-first-clients.0",
     "@labkey/themes": "1.6.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "7.20.2-fb-container-first-clients.0",
+    "@labkey/components": "7.20.2",
     "@labkey/themes": "1.6.0"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.1"
+        "@labkey/components": "7.20.2-fb-container-first-clients.0"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -3591,9 +3591,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.1.tgz",
-      "integrity": "sha512-zZEGy/MS8FbfFYjzu6KNx7smbxFaB1tfTRzbPEih31GoI0THNSz58f0spqfn9F5NQeL2PG9AC0YdSFR8eMFkCg==",
+      "version": "1.46.2-fb-container-first-clients.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.2-fb-container-first-clients.1.tgz",
+      "integrity": "sha512-kpuFQSghH94bLh89TaICOzQbZpr8Ompq9ox9JGZXU5DSzI9ub1RC2gpsnt9gHKvKemp0XVmEyOENP2ct1wvX0w==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3634,13 +3634,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1.tgz",
-      "integrity": "sha512-ShGllYov7JZJRSyDJOMlc0/U/4jTPVyYCLoCryiUQgKUlUTlUUjRIBA4SU/nZNFwvGRtGJG26mcHm1d+ZWaUkg==",
+      "version": "7.20.2-fb-container-first-clients.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2-fb-container-first-clients.0.tgz",
+      "integrity": "sha512-+47YMWgLrwzPQDWz7opgERwFMHcvelN0tO8VCkpmRnPtSYwdn0w/PUIIARfH2aoqcYbeYNbS2lwRDOBNTZzOhw==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.1",
+        "@labkey/api": "1.46.2-fb-container-first-clients.1",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.2-fb-container-first-clients.0"
+        "@labkey/components": "7.20.2"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -3591,9 +3591,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.2-fb-container-first-clients.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.2-fb-container-first-clients.1.tgz",
-      "integrity": "sha512-kpuFQSghH94bLh89TaICOzQbZpr8Ompq9ox9JGZXU5DSzI9ub1RC2gpsnt9gHKvKemp0XVmEyOENP2ct1wvX0w==",
+      "version": "1.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.47.0.tgz",
+      "integrity": "sha512-yxw+KAZ7kH5xYcYWlH7GdC1hycHpfFf9y+91Z3x2KlSshl75u8QBzOp/0hWZ7OHYOzAmTwJMYm3GBK3K93kFtg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3634,13 +3634,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.2-fb-container-first-clients.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2-fb-container-first-clients.0.tgz",
-      "integrity": "sha512-+47YMWgLrwzPQDWz7opgERwFMHcvelN0tO8VCkpmRnPtSYwdn0w/PUIIARfH2aoqcYbeYNbS2lwRDOBNTZzOhw==",
+      "version": "7.20.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2.tgz",
+      "integrity": "sha512-3vWuXxmtDfA7/UmShSftR0c7mENLtnPIEauqWmqX0g1AnzBGQJVyKUzEo1i7Qx2pdy0juYjsync+i6fjHQDXGg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.2-fb-container-first-clients.1",
+        "@labkey/api": "1.47.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.20.1"
+    "@labkey/components": "7.20.2-fb-container-first-clients.0"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.20.2-fb-container-first-clients.0"
+    "@labkey/components": "7.20.2"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.1"
+        "@labkey/components": "7.20.2-fb-container-first-clients.0"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -2979,9 +2979,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.1.tgz",
-      "integrity": "sha512-zZEGy/MS8FbfFYjzu6KNx7smbxFaB1tfTRzbPEih31GoI0THNSz58f0spqfn9F5NQeL2PG9AC0YdSFR8eMFkCg==",
+      "version": "1.46.2-fb-container-first-clients.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.2-fb-container-first-clients.1.tgz",
+      "integrity": "sha512-kpuFQSghH94bLh89TaICOzQbZpr8Ompq9ox9JGZXU5DSzI9ub1RC2gpsnt9gHKvKemp0XVmEyOENP2ct1wvX0w==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3022,13 +3022,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.1.tgz",
-      "integrity": "sha512-ShGllYov7JZJRSyDJOMlc0/U/4jTPVyYCLoCryiUQgKUlUTlUUjRIBA4SU/nZNFwvGRtGJG26mcHm1d+ZWaUkg==",
+      "version": "7.20.2-fb-container-first-clients.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2-fb-container-first-clients.0.tgz",
+      "integrity": "sha512-+47YMWgLrwzPQDWz7opgERwFMHcvelN0tO8VCkpmRnPtSYwdn0w/PUIIARfH2aoqcYbeYNbS2lwRDOBNTZzOhw==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.1",
+        "@labkey/api": "1.46.2-fb-container-first-clients.1",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.20.2-fb-container-first-clients.0"
+        "@labkey/components": "7.20.2"
       },
       "devDependencies": {
         "@labkey/build": "8.8.0",
@@ -2979,9 +2979,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.46.2-fb-container-first-clients.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.46.2-fb-container-first-clients.1.tgz",
-      "integrity": "sha512-kpuFQSghH94bLh89TaICOzQbZpr8Ompq9ox9JGZXU5DSzI9ub1RC2gpsnt9gHKvKemp0XVmEyOENP2ct1wvX0w==",
+      "version": "1.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.47.0.tgz",
+      "integrity": "sha512-yxw+KAZ7kH5xYcYWlH7GdC1hycHpfFf9y+91Z3x2KlSshl75u8QBzOp/0hWZ7OHYOzAmTwJMYm3GBK3K93kFtg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3022,13 +3022,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.20.2-fb-container-first-clients.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2-fb-container-first-clients.0.tgz",
-      "integrity": "sha512-+47YMWgLrwzPQDWz7opgERwFMHcvelN0tO8VCkpmRnPtSYwdn0w/PUIIARfH2aoqcYbeYNbS2lwRDOBNTZzOhw==",
+      "version": "7.20.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.20.2.tgz",
+      "integrity": "sha512-3vWuXxmtDfA7/UmShSftR0c7mENLtnPIEauqWmqX0g1AnzBGQJVyKUzEo1i7Qx2pdy0juYjsync+i6fjHQDXGg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.46.2-fb-container-first-clients.1",
+        "@labkey/api": "1.47.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "7.20.1"
+    "@labkey/components": "7.20.2-fb-container-first-clients.0"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "7.20.2-fb-container-first-clients.0"
+    "@labkey/components": "7.20.2"
   },
   "devDependencies": {
     "@labkey/build": "8.8.0",


### PR DESCRIPTION
#### Rationale
Container Relative URLs are no longer an experimental feature, and are always enabled. This PR updates the api-js dependency and removes all references to the containerRelativeURL experimental feature flag.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/207
* https://github.com/LabKey/labkey-ui-components/pull/1942
* https://github.com/LabKey/labkey-ui-premium/pull/898
* https://github.com/LabKey/platform/pull/7451
* https://github.com/LabKey/limsModules/pull/2005

#### Changes
- Bump @labkey/components
- Remove references to containerRelativeURL
