### PR TITLE
Make ConvertHelper.convert() return the same success result as ConvertUtils.convert().

### DIFF
--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -804,6 +804,9 @@ public class ConvertHelper implements PropertyEditorRegistrar
         }
         catch (ClassCastException ex)
         {
+            // for testing let's blow up dramatically here
+            if (cl.isPrimitive())
+                throw new IllegalArgumentException("primitive type is not allowed: " + cl.getName());
             throw new ConversionException("Could not convert value to " + cl.getSimpleName());
         }
     }

--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -1093,6 +1093,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
                 // ConvertHelper used to short-circuit null which would break this test
                 var a = ConvertUtils.convert((String)null, MultiChoice.Array.class);
                 var b = ConvertHelper.convert(null, MultiChoice.Array.class);
+                assertNotNull(a);
                 assertEquals(a,b);
             }
         }

--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -791,15 +791,23 @@ public class ConvertHelper implements PropertyEditorRegistrar
         }
     }
 
-    /** Simple genericized wrapper around ConvertUtils.convert(). Also handles calling toString() on value, if non-null */
+
+    /** Genericized wrapper around ConvertUtils.convert(). */
     public static <T> T convert(Object value, Class<T> cl)
     {
-        if (value == null)
-        {
+        var ret = ConvertUtils.convert(value, cl);
+        if (ret == null)
             return null;
+        try
+        {
+            return cl.cast(ret);
         }
-        return (T)ConvertUtils.convert(value.toString(), cl);
+        catch (ClassCastException ex)
+        {
+            throw new ConversionException("Could not convert value to " + cl.getSimpleName());
+        }
     }
+
 
     public static SimpleConvert getSimpleConvert(Class<?> targetType)
     {
@@ -1060,6 +1068,33 @@ public class ConvertHelper implements PropertyEditorRegistrar
 
     public static class TestCase extends Assert
     {
+        @Test
+        public void testConvertHelperEqualsConvertUtils()
+        {
+            {
+                // ConvertHelper used to call toString() which would break this test
+                var a = ConvertHelper.convert("a,b,c", String[].class);
+                assert a instanceof String[] arr && arr.length == 3;
+                var b = ConvertHelper.convert(a, String[].class);
+                assertArrayEquals(a, b);
+            }
+
+            {
+                var a = ConvertUtils.convert("a,b,c", String[].class);
+                assert a instanceof String[] arr && arr.length == 3;
+                var b = ConvertUtils.convert(a, String[].class);
+                assertArrayEquals((String [])a, (String [])b);
+            }
+
+            {
+                // ConvertHelper used to short-circuit null which would break this test
+                var a = ConvertUtils.convert((String)null, MultiChoice.Array.class);
+                var b = ConvertHelper.convert(null, MultiChoice.Array.class);
+                assertEquals(a,b);
+            }
+        }
+
+
         @Test
         public void testConvertTimestamp()
         {


### PR DESCRIPTION
#### Rationale
I've run into to many cases where I had to switch code from ConvertHelper to ConvertUtils because of differences in behavior.   It's time to make them be the same.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->