### PR TITLE
Use tableName instead of tableInfo for dataclass upgrade scripts

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -622,9 +622,9 @@ public class ExperimentUpgradeCode implements UpgradeCode
         SqlExecutor executor = new SqlExecutor(scope);
         boolean isPostgreSQL = scope.getSqlDialect().isPostgreSQL();
         if (isPostgreSQL)
-            executor.execute(new SQLFragment("ALTER TABLE expdataclass.").append(provisionedTable).append(" ALTER COLUMN rowId SET NOT NULL"));
+            executor.execute(new SQLFragment("ALTER TABLE expdataclass.").append(domain.getStorageTableName()).append(" ALTER COLUMN rowId SET NOT NULL"));
         else
-            executor.execute(new SQLFragment("ALTER TABLE expdataclass.").append(provisionedTable).append(" ALTER COLUMN rowId INT NOT NULL"));
+            executor.execute(new SQLFragment("ALTER TABLE expdataclass.").append(domain.getStorageTableName()).append(" ALTER COLUMN rowId INT NOT NULL"));
 
         // Add indexes back via StorageProvisioner
         storageProvisioner.ensureTableIndices(domain);
@@ -632,7 +632,7 @@ public class ExperimentUpgradeCode implements UpgradeCode
 
         // Add FK constraint (no StorageProvisioner API for FKs on existing tables)
         String fkName = "fk_rowid_" + domain.getStorageTableName() + "_data";
-        executor.execute(new SQLFragment("ALTER TABLE expdataclass.").append(provisionedTable)
+        executor.execute(new SQLFragment("ALTER TABLE expdataclass.").append(domain.getStorageTableName())
                 .append(" ADD CONSTRAINT ").append(fkName)
                 .append(" FOREIGN KEY (rowId) REFERENCES exp.Data(RowId)"));
         LOG.info("DataClass '{}' ({}) added FK constraint on 'rowId'", dc.getName(), dc.getRowId());


### PR DESCRIPTION
#### Rationale
sql.append(tableInfo) would append both schema and tableName, resulting in 2 schema parts in some of the upgrade script. This PR reverts those usages to use tableName. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7439

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->