### PR TITLE
GitHub Issue 875: Assay Multi-File Transform Import Skips First Data Row

### DIFF
--- a/api/src/org/labkey/api/qc/TsvDataSerializer.java
+++ b/api/src/org/labkey/api/qc/TsvDataSerializer.java
@@ -91,8 +91,8 @@ public class TsvDataSerializer implements DataExchangeHandler.DataSerializer
                         sep = "\t";
                     }
                     pw.println();
-                    writeRow(row, columns, pw, tsvWriter); // GitHub Issue #875: write the first row regardless of whether we had a header or not
                 }
+                writeRow(row, columns, pw, tsvWriter); // GitHub Issue #875: write the first row regardless of whether we had a header or not
 
                 // write the remaining rows
                 while (iter.next())

--- a/api/src/org/labkey/api/qc/TsvDataSerializer.java
+++ b/api/src/org/labkey/api/qc/TsvDataSerializer.java
@@ -91,7 +91,7 @@ public class TsvDataSerializer implements DataExchangeHandler.DataSerializer
                         sep = "\t";
                     }
                     pw.println();
-                    writeRow(row, columns, pw, tsvWriter);
+                    writeRow(row, columns, pw, tsvWriter); // GitHub Issue #875: write the first row regardless of whether we had a header or not
                 }
 
                 // write the remaining rows

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -656,7 +656,7 @@ public class ExperimentModule extends SpringModule
                     assayMetrics.put("assayRunsWithMultipleInputFiles", new SqlSelector(schema, """
                         SELECT COUNT(*) FROM (
                             SELECT sourceapplicationid, COUNT(*) AS count FROM exp.data
-                            WHERE name NOT LIKE '%.log' AND name NOT LIKE '%.Rout' AND name NOT LIKE '%.pdf' AND sourceapplicationid IN (
+                            WHERE lsid NOT LIKE '%:RelatedFile.%' AND sourceapplicationid IN (
                                 SELECT rowid FROM exp.protocolapplication
                                 WHERE lsid LIKE '%:SimpleProtocol.CoreStep' AND (protocollsid LIKE '%:LuminexAssayProtocol.%' OR protocollsid LIKE '%:GeneralAssayProtocol.%')
                             )

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -652,6 +652,17 @@ public class ExperimentModule extends SpringModule
                                  JOIN exp.DomainDescriptor DD on PD.domainID = DD.domainId
                         WHERE DD.domainUri LIKE ? AND D.rangeURI = ?""", "urn:lsid:%:" + ExpProtocol.AssayDomainTypes.Result.getPrefix() + ".%", PropertyType.FILE_LINK.getTypeUri()).getObject(Long.class));
 
+                    // metric to count the number of Luminex and Standard assay runs that were imported with > 1 data file
+                    assayMetrics.put("assayRunsWithMultipleInputFiles", new SqlSelector(schema, """
+                        SELECT COUNT(*) FROM (
+                            SELECT sourceapplicationid, COUNT(*) AS count FROM exp.data
+                            WHERE name NOT LIKE '%.log' AND name NOT LIKE '%.Rout' AND name NOT LIKE '%.pdf' AND sourceapplicationid IN (
+                                SELECT rowid FROM exp.protocolapplication
+                                WHERE lsid LIKE '%:SimpleProtocol.CoreStep' AND (protocollsid LIKE '%:LuminexAssayProtocol.%' OR protocollsid LIKE '%:GeneralAssayProtocol.%')
+                            )
+                            GROUP BY sourceapplicationid
+                        ) x WHERE count > 1""").getObject(Long.class));
+
                     Map<String, Object> sampleLookupCountMetrics = new HashMap<>();
                     SQLFragment baseAssaySampleLookupSQL = new SQLFragment("SELECT COUNT(*) FROM exp.propertydescriptor WHERE (lookupschema = 'samples' OR (lookupschema = 'exp' AND lookupquery =  'Materials')) AND propertyuri LIKE ?");
 


### PR DESCRIPTION
#### Rationale
[#875](https://github.com/LabKey/internal-issues/issues/875) Luminex Multi-File Transform Import Skips First Data Row

When a Luminex assay run is imported that includes multiple files, we merge / concatenate the data from those files together into a single runData tsv file when writing the data out to the assay transform script. This PR fixes an issue where the first row of the 2nd/3rd/etc files was getting skipped.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7456
- https://github.com/LabKey/commonAssays/pull/986
- https://github.com/LabKey/testAutomation/pull/2896

#### Changes
- TsvDataSerializer.exportData() to write first row regardless of if column headers written
- Experiment module metric (assayRunsWithMultipleInputFiles) for count of the number of Luminex and Standard assay runs that were imported with > 1 data input file