### PR TITLE
Use deferred upgrade for dataclass

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -519,6 +519,7 @@ public class ExperimentUpgradeCode implements UpgradeCode
      * Drop the classid column and add a rowId column to existing provisioned DataClass tables.
      */
     @SuppressWarnings("unused")
+    @DeferredUpgrade
     public static void addRowIdToProvisionedDataClassTables(ModuleContext context)
     {
         if (context.isNewInstall())


### PR DESCRIPTION
#### Rationale
DataClass upgrade script calls storageProvisioner.ensureTableIndices, which queries exp.ObjectPropertiesView, which is a view that's created in exp-create.sql. The Deferred annotation was taken off but should be brought back.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7439

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->