### PR TITLE
Prevent ConcurrentModificationException in TempTableThread shutdown

### DIFF
--- a/api/src/org/labkey/api/data/TempTableTracker.java
+++ b/api/src/org/labkey/api/data/TempTableTracker.java
@@ -26,6 +26,7 @@ import org.labkey.api.util.logging.LogHelper;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.lang.ref.Cleaner;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -286,7 +287,8 @@ public class TempTableTracker
         {
             synchronized(createdTableNames)
             {
-                for (TempTableTracker ttt : createdTableNames.values())
+                // Copy createdTableNames.values() to prevent ConcurrentModificationException
+                for (TempTableTracker ttt : new ArrayList<>(createdTableNames.values()))
                 {
                     ttt.state.run();
                 }


### PR DESCRIPTION
#### Rationale
`TempTableThread.shutdownStarted()` enumerates `createdTableNames.values()` and calls `CleanupState.run()`, which may end up removing elements from createdTableNames.values(). All operations are synchronized, but values() is not a concurrent collection.
Iterating over a copy will prevent this exception.
```
INFO  ContextListener          2026-02-26T13:42:09,901 gApplicationShutdownHook : Calling Temp table cleanup shutdownStarted()
ERROR ContextListener          2026-02-26T13:42:09,933 gApplicationShutdownHook : Exception during shutdownStarted(): 
java.util.ConcurrentModificationException
    at java.base/java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1522)
    at java.base/java.util.TreeMap$ValueIterator.next(TreeMap.java:1567)
    at org.labkey.api.data.TempTableTracker$TempTableThread.shutdownStarted(TempTableTracker.java:289)
    at org.labkey.api.util.ContextListener.callShutdownListeners(ContextListener.java:148)
    at org.labkey.api.util.ContextListener.contextDestroyed(ContextListener.java:99)
    at org.apache.catalina.core.StandardContext.listenerStop(StandardContext.java:4048)
```

#### Related Pull Requests
- N/A

#### Changes
- Prevent ConcurrentModificationException in TempTableThread shutdown