### PR TITLE
Impersonating Troubleshooters can now impersonate users and groups

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -135,7 +135,7 @@ import org.labkey.api.security.RoleSet;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
-import org.labkey.api.security.impersonation.ImpersonationTest;
+import org.labkey.api.security.impersonation.ImpersonationTestCase;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.AppPropsTestCase;
 import org.labkey.api.settings.BaseServerProperties;
@@ -399,7 +399,7 @@ public class ApiModule extends CodeOnlyModule
             FileUtil.TestCase.class,
             GenerateUniqueDataIterator.TestCase.class,
             HelpTopic.TestCase.class,
-            ImpersonationTest.class,
+            ImpersonationTestCase.class,
             InlineInClauseGenerator.TestCase.class,
             JSONDataLoader.HeaderMatchTest.class,
             JSONDataLoader.MetadataTest.class,

--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -135,6 +135,7 @@ import org.labkey.api.security.RoleSet;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
+import org.labkey.api.security.impersonation.ImpersonationTest;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.AppPropsTestCase;
 import org.labkey.api.settings.BaseServerProperties;
@@ -398,6 +399,7 @@ public class ApiModule extends CodeOnlyModule
             FileUtil.TestCase.class,
             GenerateUniqueDataIterator.TestCase.class,
             HelpTopic.TestCase.class,
+            ImpersonationTest.class,
             InlineInClauseGenerator.TestCase.class,
             JSONDataLoader.HeaderMatchTest.class,
             JSONDataLoader.MetadataTest.class,

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -827,7 +828,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
             return false;
         }
 
-        if (StringUtils.endsWithIgnoreCase(name, ".view") || StringUtils.endsWithIgnoreCase(name, ".api") || StringUtils.endsWithIgnoreCase(name, ".post"))
+        if (Strings.CI.endsWith(name, ".view") || Strings.CI.endsWith(name, ".api") || Strings.CI.endsWith(name, ".post"))
         {
             error.append("Folder name should not end with '.view', '.api', or '.post'.");
             return false;
@@ -1249,7 +1250,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
         }
 
         // always put the required modules in the set
-        // note that this will pickup the modules from the folder type's getActiveModules()
+        // note that this will pick up the modules from the folder type's getActiveModules()
         Set<Module> modules = new HashSet<>(getRequiredModules());
 
         // add all modules found in user preferences:

--- a/api/src/org/labkey/api/module/IgnoresForbiddenProjectCheck.java
+++ b/api/src/org/labkey/api/module/IgnoresForbiddenProjectCheck.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 /**
  * Designates actions that should not enforce forbidden project checking, which is used to support impersonation
  * container restrictions and project locking. Use with caution. Allows project admins to perform actions outside
- * of the project they administer and non-admins the ability to invoke actions in locked projects.
+ * the project they administer and non-admins the ability to invoke actions in locked projects.
  *
  * @see org.labkey.api.action.PermissionCheckableAction#checkPermissions()
  * @see org.labkey.api.data.Container#isForbiddenProject(org.labkey.api.security.User)

--- a/api/src/org/labkey/api/security/NormalPermissionsContext.java
+++ b/api/src/org/labkey/api/security/NormalPermissionsContext.java
@@ -22,8 +22,7 @@ import org.labkey.api.security.impersonation.GroupImpersonationContextFactory;
 import org.labkey.api.security.impersonation.ImpersonationContextFactory;
 import org.labkey.api.security.impersonation.RoleImpersonationContextFactory;
 import org.labkey.api.security.impersonation.UserImpersonationContextFactory;
-import org.labkey.api.security.permissions.AdminPermission;
-import org.labkey.api.security.permissions.CanImpersonatePrivilegedSiteRolesPermission;
+import org.labkey.api.security.permissions.ImpersonatePermission;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
@@ -93,19 +92,13 @@ public class NormalPermissionsContext implements PermissionsContext
         {
             @Nullable Container project = c.getProject();
 
-            // Must be site or project admin (folder admins can't impersonate)
-            if (user.hasRootAdminPermission() || (null != project && project.hasPermission(user, AdminPermission.class)))
+            // Site admin, app admin, and impersonating troubleshooter can impersonate anywhere; project admin can
+            // impersonate in that project. Folder admins can't impersonate.
+            if (user.hasRootPermission(ImpersonatePermission.class) || (project != null && project.hasPermission(user, ImpersonatePermission.class)))
             {
                 NavTree impersonateMenu = new NavTree("Impersonate");
                 UserImpersonationContextFactory.addMenu(impersonateMenu);
                 GroupImpersonationContextFactory.addMenu(impersonateMenu);
-                RoleImpersonationContextFactory.addMenu(impersonateMenu);
-                menu.addChild(impersonateMenu);
-            }
-            // Or Impersonating Troubleshooter to impersonate site roles only
-            else if (null == project && user.hasRootPermission(CanImpersonatePrivilegedSiteRolesPermission.class))
-            {
-                NavTree impersonateMenu = new NavTree("Impersonate");
                 RoleImpersonationContextFactory.addMenu(impersonateMenu);
                 menu.addChild(impersonateMenu);
             }

--- a/api/src/org/labkey/api/security/PermissionsContext.java
+++ b/api/src/org/labkey/api/security/PermissionsContext.java
@@ -64,7 +64,7 @@ public interface PermissionsContext extends Serializable
                 if (!(role instanceof AbstractRootContainerRole siteRole))
                     throw new IllegalStateException("Root roles should all be AbstractRootContainerRole");
 
-                return siteRole.isAvailableEverywhere() || resource.equals(root);
+                return siteRole.isApplicableOutsideRoot() || resource.equals(root);
             });
 
         if (!resource.equals(root))

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -822,7 +822,7 @@ public class SecurityManager
         @Nullable Container project = viewContext.getContainer().getProject();
         User user = viewContext.getUser();
 
-        if (user.hasRootAdminPermission())
+        if (user.hasRootPermission(ImpersonatePermission.class))
             project = null;
 
         impersonate(viewContext, new UserImpersonationContextFactory(project, user, impersonatedUser, returnUrl));

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -74,7 +74,7 @@ import org.labkey.api.security.impersonation.UserImpersonationContextFactory;
 import org.labkey.api.security.permissions.AbstractPermission;
 import org.labkey.api.security.permissions.AddUserPermission;
 import org.labkey.api.security.permissions.AdminPermission;
-import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
+import org.labkey.api.security.permissions.ImpersonatePermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
@@ -839,7 +839,7 @@ public class SecurityManager
         @Nullable Container project = viewContext.getContainer().getProject();
         User user = viewContext.getUser();
 
-        if (user.hasRootPermission(CanImpersonateSiteRolesPermission.class))
+        if (user.hasRootPermission(ImpersonatePermission.class))
             project = null;
 
         impersonate(viewContext, new RoleImpersonationContextFactory(project, user, newImpersonationRoles, currentImpersonationRoles, returnUrl));
@@ -1412,7 +1412,7 @@ public class SecurityManager
     }
 
     // A permission class that uniquely identifies the root admins, of which we insist there must be at least one
-    public static final Class<? extends Permission> ROOT_ADMIN_PERMISSION = CanImpersonateSiteRolesPermission.class;
+    public static final Class<? extends Permission> ROOT_ADMIN_PERMISSION = ImpersonatePermission.class;
 
     public static boolean isRootAdmin(User user)
     {

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -33,7 +33,7 @@ import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.AnalystPermission;
 import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.security.permissions.BrowserDeveloperPermission;
-import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
+import org.labkey.api.security.permissions.ImpersonatePermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
@@ -594,7 +594,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
             props.put("isAdmin", nonNullContainer && container.hasPermission(user, AdminPermission.class));
             props.put("isRootAdmin", user.hasRootAdminPermission());
             props.put("isSystemAdmin", user.hasSiteAdminPermission());
-            props.put("canImpersonateSiteRoles", user.hasRootPermission(CanImpersonateSiteRolesPermission.class));
+            props.put("canImpersonateSiteRoles", user.hasRootPermission(ImpersonatePermission.class));
             props.put("isGuest", user.isGuest());
             props.put("isDeveloper", user.isBrowserDev());
             props.put("isAnalyst", user.hasRootPermission(AnalystPermission.class));

--- a/api/src/org/labkey/api/security/UserCache.java
+++ b/api/src/org/labkey/api/security/UserCache.java
@@ -114,7 +114,7 @@ class UserCache
 
     static @NotNull Map<ValidEmail, User> getUserEmailMap()
     {
-        return Collections.unmodifiableMap(getUserCollections().getEmailMap());
+        return getUserCollections().getEmailMap();
     }
 
     static int getActiveUserCount()

--- a/api/src/org/labkey/api/security/UserCache.java
+++ b/api/src/org/labkey/api/security/UserCache.java
@@ -83,8 +83,8 @@ class UserCache
         return null != user ? user.cloneUser() : null;
     }
 
-    // Returns a deep copy of the active users list, allowing callers to interrogate user permissions without affecting
-    // cached users. Collection is ordered by email... maybe it should be ordered by display name?
+    // Returns a mutable deep copy of the active users list, allowing callers to interrogate user permissions without
+    // affecting cached users. Collection is ordered by email... maybe it should be ordered by display name?
     static @NotNull Collection<User> getActiveUsers()
     {
         List<User> activeUsers = getUserCollections().getActiveUsers();
@@ -95,7 +95,7 @@ class UserCache
             .collect(Collectors.toCollection(LinkedList::new));
     }
 
-    // Returns a deep copy of the users list including deactivated accounts, allowing callers to interrogate user permissions
+    // Returns a mutable deep copy of the users list including deactivated accounts, allowing callers to interrogate user permissions
     // without affecting cached users. Collection is ordered randomly... maybe it should be ordered by display name?
     static @NotNull Collection<User> getActiveAndInactiveUsers()
     {
@@ -104,7 +104,7 @@ class UserCache
         return users
             .stream()
             .map(User::cloneUser)
-            .collect(Collectors.toList());
+            .collect(Collectors.toCollection(LinkedList::new));
     }
 
     static @NotNull List<Integer> getUserIds()

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -59,7 +59,7 @@ import org.labkey.api.query.UserIdRenderer;
 import org.labkey.api.security.SecurityManager.UserManagementException;
 import org.labkey.api.security.permissions.AbstractActionPermissionTest;
 import org.labkey.api.security.permissions.ApplicationAdminPermission;
-import org.labkey.api.security.permissions.CanImpersonatePrivilegedSiteRolesPermission;
+import org.labkey.api.security.permissions.ImpersonatePrivilegedSiteRolesPermission;
 import org.labkey.api.security.permissions.SiteAdminPermission;
 import org.labkey.api.security.roles.ApplicationAdminRole;
 import org.labkey.api.security.roles.SiteAdminRole;
@@ -162,7 +162,7 @@ public class UserManager
     public static void addUserListener(UserListener listener, boolean meFirst)
     {
         if (meFirst)
-            _listeners.add(0, listener);
+            _listeners.addFirst(listener);
         else
             _listeners.add(listener);
     }
@@ -670,12 +670,14 @@ public class UserManager
     }
 
     @NotNull
+    // Returns a mutable collection
     public static Collection<User> getActiveUsers()
     {
         return getUsers(false);
     }
 
     @NotNull
+    // Returns a mutable collection
     public static Collection<User> getUsers(boolean includeInactive)
     {
         return includeInactive ? UserCache.getActiveAndInactiveUsers() : UserCache.getActiveUsers() ;
@@ -1305,7 +1307,7 @@ public class UserManager
             assertTrue("Expected all SiteAdmins to be in the AppAdmins list",
                 appAdmins.containsAll(siteAdmins));
 
-            List<User> privilegedUsers = SecurityManager.getUsersWithPermissions(ContainerManager.getRoot(), Set.of(CanImpersonatePrivilegedSiteRolesPermission.class));
+            List<User> privilegedUsers = SecurityManager.getUsersWithPermissions(ContainerManager.getRoot(), Set.of(ImpersonatePrivilegedSiteRolesPermission.class));
             assertTrue("Expected all users with privileged role impersonation permissions to have a privileged role",
                 privilegedUsers.stream().allMatch(User::hasPrivilegedRole));
 

--- a/api/src/org/labkey/api/security/impersonation/AbstractImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/AbstractImpersonationContext.java
@@ -29,6 +29,104 @@ import org.labkey.api.view.NavTree;
 
 import java.util.stream.Stream;
 
+///
+/// The ability to impersonate users, groups, and roles is a powerful and useful security feature of LabKey.
+/// Administrators use impersonation to review and troubleshoot their permissions configurations. Developers, testers,
+/// and automated tests use impersonation widely to develop and validate LabKey features. This comment documents the
+/// rules we've developed over the years to ensure impersonation is useful and secure.
+///
+/// ### Guiding Principles
+/// Before delving into details, here are some guiding principles we've tried to follow while designing the
+/// impersonation features:
+/// - Those who can impersonate are already trusted, high-level administrators with wide-ranging permissions.
+/// - We strive for flexibility in allowing impersonations. Any restrictions should be there for a good reason.
+/// - Starting and stopping impersonation is recorded in the audit log. All key actions taken while impersonating are
+///   recorded in the audit log with a clear indication of who was impersonating at the time.
+/// - Escalation of permissions is prevented in the vast majority of most cases. We intentionally allow limited
+///   exceptions to this and accept the audit log record of impersonators' actions as mitigation for this.
+///
+/// ### Three Impersonation Options
+/// - Impersonating a user effectively turns the admin into that user. However, the impersonating admin is listed in
+///   all audit log entries associated with their actions while impersonating. Admins can't impersonate inactive users
+///   or themselves.
+/// - Impersonating a group means the admin is still themselves (they'll see their own profile, updates will be tagged
+///   with their user ID, etc.), but they are stripped of all role assignments except for the roles granted to three
+///   groups: Guests, All Site Users, and the impersonated group. This provides the ability to test the effects of
+///   a single group's role assignments in isolation. Admins can't impersonate the Guests group; they can just log out
+///   to see the site from a guest's perspective.
+/// - Impersonating roles means the admin is still themselves, but they are stripped of all role assignments except
+///   the role(s) selected during impersonation. Unlike user and group impersonation (which allow a single principal
+///   to be impersonated at a time), admins can impersonate multiple roles. They can also impersonate roles and
+///   subsequently adjust that impersonation, adding and removing roles from the impersonation session. Note that many
+///   roles don't include read permission; the impersonate roles dialog will encourage (though not require) the
+///   addition of a read-granting role if the current selection lacks read permission.
+///
+///  ### Three Root Roles Can Impersonate
+/// - Three roles that are assigned at the root that can impersonate: Site Administrator, Impersonating Troubleshooter,
+///   and Application Admin.
+/// - Site Administrators and Impersonating Troubleshooters are all-powerful and already have (or can instantly give
+///   themselves) any permission in the system. Other than the exceptions mentioned above, they can impersonate any
+///   user, group, or role in the system without restriction.
+/// - Application Admins can impersonate the same users and groups as the other two root roles. They can impersonate
+///   any role except for three especially powerful roles that are designated as "privileged": Site Administrator,
+///   Platform Developer, and Impersonating Troubleshooter. Application Admins can't impersonate privileged roles
+///   directly, and when they impersonate a user or group, any privileged roles granted to that principal are filtered
+///   out during permission checks. As such, an Application Admin can't take on permissions that are exclusive to a
+///   Site Administrator or a Platform Developer through impersonation.
+/// - These three root roles can impersonate from the root, in which case they have the option to impersonate any
+///   user, any site group, or any site role. They can also impersonate from a project or folder, in which case they
+///   can impersonate any user, any site group, any project group from that project, or any role that's applicable to
+///   the current folder. When they impersonate, they are free to navigate to any container allowed by their new
+///   impersonated permissions.
+/// - Troubleshooters and other root roles can't impersonate.
+///
+/// ### Project Administrators Can Also Impersonate
+/// - Project Administrators can impersonate, but with less freedom than the root roles. Project Administrators are
+///   granted most permissions in the system, but only in the context of their project, so their impersonation
+///   power is limited accordingly.
+/// - Unlike the other three impersonating roles, Project Administrators are completely restricted to the project
+///   where impersonation starts. While impersonating, they can't navigate to any other project or the root, no
+///   matter what their new impersonation permissions grant.
+/// - Project Administrators can impersonate any user with read permissions in the project. This isn't a security
+///   restriction, since Project Administrators can grant any user read permissions in their project and impersonate
+///   them. This limit is a convenience to focus on just the users with access to that project. Some deployments are
+///   partitioned with disjoint sets of users in each project; showing all users would be confusing and inconvenient.
+///   Also, it's not very useful to impersonate a user who lacks read permissions.
+/// - Project Administrators can impersonate any project group in that project or any site group where they are
+///   already a member (though see the first "Considerations" point below).
+/// - Project Administrators can impersonate any role that's applicable to the current folder. That means they can't
+///   impersonate site roles because they can't impersonate from the root.
+/// - Like Application Admins, Project Administrators can't impersonate privileged roles; these roles are filtered
+///   out when impersonating a user or group that has them.
+/// - Folder Administrators have wide-ranging permissions in their folder, but they can't impersonate.
+///
+/// ### Miscellaneous Details
+/// - A handful of operations are prohibited while impersonating. These include creating API keys, applying an
+///   electronic signature, and impersonating (no chaining of impersonations).
+/// - The four admins who can impersonate have automatically been granted the vast majority of permissions in the
+///   system, but there are some permissions that must be granted explicitly, even to high-level admins. Areas where
+///   admins don't automatically receive permissions include PHI reading and adjudication. For these types of
+///   permissions, an admin could escalate their permissions while impersonating, receiving permissions they lack
+///   normally (although they could easily grant these permissions to themselves). Also, Project Administrators can
+///   impersonate an Application Admin and gain at least one new permission within the project (update user profiles);
+///   project sandboxing means they can't take any action as an Application Admin in the root or other projects. In
+///   both escalation cases, the audit log tags all actions they take with the impersonating admin's user id.
+/// - The UI and the API disallow impersonating site roles and project/folder roles at the same time (though see the
+///   second "Considerations" point below).
+///
+/// ### Considerations
+/// - Eliminate the requirement that Project Administrators must be a member of a site group in order to impersonate
+///   it? Project Administrators can already impersonate any user (who could be a member of any group) and we already
+///   filter out the privileged roles, so this restriction is hard to justify.
+/// - Allow impersonation of site roles from the project and eliminate the prohibition on impersonating site roles
+///   and project/folder roles at the same time? Admins can already impersonate users and groups that are granted a
+///   mix of roles, and we already filter out the privileged roles, so this restriction seems arbitrary and hard to
+///   justify. We would eliminate the isApplicable() check on roles, which would also make it easier to impersonate
+///   roles with special requirements, such as EHR- or study-related roles. If we took this step, we could likely
+///   combine the permissions-checking methods in RoleImpersonationContextFactory (getValidImpersonationRoles() and
+///   verifyPermissions()).
+///
+
 public abstract class AbstractImpersonationContext implements PermissionsContext
 {
     private final User _adminUser;

--- a/api/src/org/labkey/api/security/impersonation/AbstractImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/AbstractImpersonationContext.java
@@ -21,7 +21,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.security.LoginUrls;
 import org.labkey.api.security.PermissionsContext;
 import org.labkey.api.security.User;
-import org.labkey.api.security.permissions.CanImpersonatePrivilegedSiteRolesPermission;
+import org.labkey.api.security.permissions.ImpersonatePrivilegedSiteRolesPermission;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
@@ -88,7 +88,7 @@ public abstract class AbstractImpersonationContext implements PermissionsContext
      */
     protected Stream<Role> getFilteredRoles(Stream<Role> roles)
     {
-        if (getAdminUser() != null && !getAdminUser().hasRootPermission(CanImpersonatePrivilegedSiteRolesPermission.class))
+        if (getAdminUser() != null && !getAdminUser().hasRootPermission(ImpersonatePrivilegedSiteRolesPermission.class))
             return roles.filter(role -> !role.isPrivileged());
 
         return roles;

--- a/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
@@ -134,8 +134,8 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
             return false;
 
         // Site admin, app admin, and impersonating troubleshooter can impersonate any group, even those assigned
-        // privileged roles. In the case where an app admin impersonates such a group, the privileged roles are
-        // filtered out (see GroupImpersonationContext.getAssignedRoles() below).
+        // privileged roles. However, in the case where an app admin impersonates such a group, the privileged roles
+        // are filtered out (see GroupImpersonationContext.getAssignedRoles() below).
         if (adminUser.hasRootPermission(ImpersonatePermission.class))
             return true;
 

--- a/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
@@ -133,11 +133,9 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
         if (group.isGuests())
             return false;
 
-        // Impersonating "Site: Administrators" or any other group assigned a privileged role requires special permission
-        if (group.hasPrivilegedRole() && !adminUser.hasRootPermission(ImpersonatePrivilegedSiteRolesPermission.class))
-            return false;
-
-        // Site admin, app admin, and impersonating troubleshooter can impersonate any other group
+        // Site admin, app admin, and impersonating troubleshooter can impersonate any group, even those assigned
+        // privileged roles. In the case where an app admin impersonates such a group, the privileged roles are
+        // filtered out (see GroupImpersonationContext.getAssignedRoles() below).
         if (adminUser.hasRootPermission(ImpersonatePermission.class))
             return true;
 
@@ -183,13 +181,13 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
 
         @JsonCreator
         protected GroupImpersonationContext(
-                @JsonProperty("_project") @Nullable Container project,
-                @JsonProperty("_adminUser") User adminUser,
-                @JsonProperty("_group") Group group,
-                @JsonProperty("_groups") PrincipalArray groups,
-                @JsonProperty("_returnUrl") ActionURL returnUrl,
-                @JsonProperty("_factory") ImpersonationContextFactory factory)
-
+            @JsonProperty("_project") @Nullable Container project,
+            @JsonProperty("_adminUser") User adminUser,
+            @JsonProperty("_group") Group group,
+            @JsonProperty("_groups") PrincipalArray groups,
+            @JsonProperty("_returnUrl") ActionURL returnUrl,
+            @JsonProperty("_factory") ImpersonationContextFactory factory
+        )
         {
             super(adminUser, project, returnUrl, factory);
             _group = group;

--- a/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
@@ -31,7 +31,8 @@ import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
-import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.ImpersonatePermission;
+import org.labkey.api.security.permissions.ImpersonatePrivilegedSiteRolesPermission;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.util.GUID;
 import org.labkey.api.view.ActionURL;
@@ -126,28 +127,28 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
         return UserManager.getUser(_adminUserId);
     }
 
-    private static boolean canImpersonateGroup(@Nullable Container project, User user, Group group)
+    private static boolean canImpersonateGroup(@Nullable Container project, User adminUser, Group group)
     {
         // Impersonating the "Site: Guests" group leads to confusion and is not useful. Better to just log out. See #20140.
         if (group.isGuests())
             return false;
 
-        // Impersonating "Site: Administrators" or any other group assigned a privileged role by a non-site admin is confusing as well.
-        if (group.hasPrivilegedRole() && !user.hasSiteAdminPermission())
+        // Impersonating "Site: Administrators" or any other group assigned a privileged role requires special permission
+        if (group.hasPrivilegedRole() && !adminUser.hasRootPermission(ImpersonatePrivilegedSiteRolesPermission.class))
             return false;
 
-        // Site/app admin can impersonate any other group
-        if (user.hasRootAdminPermission())
+        // Site admin, app admin, and impersonating troubleshooter can impersonate any other group
+        if (adminUser.hasRootPermission(ImpersonatePermission.class))
             return true;
 
         // Project admin...
-        if (null != project && project.hasPermission(user, AdminPermission.class))
+        if (null != project && project.hasPermission(adminUser, ImpersonatePermission.class))
         {
             // ...can impersonate any project group but must be a member of a site group to impersonate it
             if (group.isProjectGroup())
                 return group.getContainer().equals(project.getId());
             else
-                return user.isInGroup(group.getUserId());
+                return adminUser.isInGroup(group.getUserId());
         }
 
         return false;
@@ -160,11 +161,12 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
         menu.addChild(groupMenu);
     }
 
+    // Returns the groups this user is allowed to impersonate. Empty for users who aren't allowed to impersonate.
     public static Collection<Group> getValidImpersonationGroups(Container c, User user)
     {
         LinkedList<Group> validGroups = new LinkedList<>();
-        List<Group> groups = SecurityManager.getGroups(c.getProject(), true);
         Container project = c.getProject();
+        List<Group> groups = SecurityManager.getGroups(project, true);
 
         // Site groups are always first, followed by project groups
         for (Group group : groups)

--- a/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
@@ -126,6 +126,28 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
         return UserManager.getUser(_adminUserId);
     }
 
+    public static void addMenu(NavTree menu)
+    {
+        NavTree groupMenu = new NavTree("Group");
+        groupMenu.setScript("LABKEY.Security.Impersonation.showImpersonateGroup();");
+        menu.addChild(groupMenu);
+    }
+
+    // Returns the groups this user is allowed to impersonate. Empty for users who aren't allowed to impersonate.
+    public static Collection<Group> getValidImpersonationGroups(Container c, User user)
+    {
+        LinkedList<Group> validGroups = new LinkedList<>();
+        Container project = c.getProject();
+        List<Group> groups = SecurityManager.getGroups(project, true);
+
+        // Site groups are always first, followed by project groups
+        for (Group group : groups)
+            if (canImpersonateGroup(project, user, group))
+                validGroups.add(group);
+
+        return validGroups;
+    }
+
     private static boolean canImpersonateGroup(@Nullable Container project, User adminUser, Group group)
     {
         // Impersonating the "Site: Guests" group leads to confusion and is not useful. Better to just log out. See #20140.
@@ -149,28 +171,6 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
         }
 
         return false;
-    }
-
-    public static void addMenu(NavTree menu)
-    {
-        NavTree groupMenu = new NavTree("Group");
-        groupMenu.setScript("LABKEY.Security.Impersonation.showImpersonateGroup();");
-        menu.addChild(groupMenu);
-    }
-
-    // Returns the groups this user is allowed to impersonate. Empty for users who aren't allowed to impersonate.
-    public static Collection<Group> getValidImpersonationGroups(Container c, User user)
-    {
-        LinkedList<Group> validGroups = new LinkedList<>();
-        Container project = c.getProject();
-        List<Group> groups = SecurityManager.getGroups(project, true);
-
-        // Site groups are always first, followed by project groups
-        for (Group group : groups)
-            if (canImpersonateGroup(project, user, group))
-                validGroups.add(group);
-
-        return validGroups;
     }
 
     private static class GroupImpersonationContext extends AbstractImpersonationContext

--- a/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
@@ -32,7 +32,6 @@ import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.ImpersonatePermission;
-import org.labkey.api.security.permissions.ImpersonatePrivilegedSiteRolesPermission;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.util.GUID;
 import org.labkey.api.view.ActionURL;

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationTest.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationTest.java
@@ -1,0 +1,160 @@
+package org.labkey.api.security.impersonation;
+
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.security.Group;
+import org.labkey.api.security.MutableSecurityPolicy;
+import org.labkey.api.security.SecurityManager;
+import org.labkey.api.security.SecurityManager.UserManagementException;
+import org.labkey.api.security.SecurityPolicyManager;
+import org.labkey.api.security.User;
+import org.labkey.api.security.UserManager;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.ValidEmail;
+import org.labkey.api.security.ValidEmail.InvalidEmailException;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.PlatformDeveloperRole;
+import org.labkey.api.security.roles.ReaderRole;
+import org.labkey.api.security.roles.Role;
+import org.labkey.api.security.roles.RoleManager;
+import org.labkey.api.util.TestContext;
+import org.labkey.api.util.logging.LogHelper;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * We have many impersonation permissions rules. This attempts to test them all.
+ */
+public class ImpersonationTest extends Assert
+{
+    private static final Logger LOG = LogHelper.getLogger(ImpersonationTest.class, "Progress of ImpersonationTest");
+
+    @Test
+    public void testPermissions() throws Exception
+    {
+        Container root = ContainerManager.getRoot();
+        User testUser = TestContext.get().getUser();
+
+        Container projectToDelete = null;
+        User noPermUser = null;
+        User readPermUser = null;
+        Group readPermGroup = null;
+        Group priviledgedGroup = null;
+        try
+        {
+            // Need to test in a new project since all users get read permission in /Shared, which we don't want
+            Container project = projectToDelete = ContainerManager.createContainer(root, "_testImpersonationPermissions", testUser);
+
+            // Ensure there's at least one user without permissions in the project
+            noPermUser = SecurityManager.addUser(new ValidEmail("test_no_permissions@test.com"), null).getUser();
+
+            // Ensure there's a user assigned read permissions in the project
+            readPermUser = SecurityManager.addUser(new ValidEmail("test_read_permissions@test.com"), null).getUser();
+            MutableSecurityPolicy projectPolicy = new MutableSecurityPolicy(project.getPolicy());
+            projectPolicy.addRoleAssignment(readPermUser, ReaderRole.class);
+            SecurityPolicyManager.savePolicy(projectPolicy, testUser);
+
+            // Ensure there's another project group
+            readPermGroup = SecurityManager.createGroup(root, "Test_Read_Perm", null);
+
+            // Ensure there's at least one site group assigned to a privileged role
+            priviledgedGroup = SecurityManager.createGroup(root, "Test_Privileged", null);
+            MutableSecurityPolicy policy = new MutableSecurityPolicy(root.getPolicy());
+            Role privilegedRole = RoleManager.getRole(PlatformDeveloperRole.class);
+            policy.addRoleAssignment(priviledgedGroup, privilegedRole);
+            SecurityPolicyManager.savePolicy(policy, testUser);
+
+            // Site-related counts
+            int siteUserCount = UserManager.getUserIds().size(); // Includes inactive
+            List<Group> siteGroups = SecurityManager.getGroups(null, false);
+            int siteGroupCount = siteGroups.size() - 1; // Can't impersonate the guests group
+            int privilegedSiteGroupCount = (int)siteGroups.stream().filter(UserPrincipal::hasPrivilegedRole).count();
+            int siteRoleCount = RoleManager.getSiteRoles().size();
+
+            // Project-related counts
+            int projectUserCount = SecurityManager.getUsersWithPermissions(project, Set.of(ReadPermission.class)).size();
+            assertTrue(projectUserCount < siteUserCount); // Should be at least one less because test_no_permissions@test.com doesn't have read
+            int projectGroupCount = SecurityManager.getGroups(project, false).size();
+            int allGroupCount = siteGroupCount + projectGroupCount;
+            List<Role> projectRoles = RoleManager.getAllRoles().stream().filter(role -> role.isAssignable() && role.isApplicable(projectPolicy, project)).toList();
+            int projectRoleCount = projectRoles.size();
+
+            testImpersonator("SiteAdminRole", true, project, siteUserCount, siteGroupCount, siteRoleCount, siteUserCount, allGroupCount, projectRoleCount);
+            testImpersonator("ImpersonatingTroubleshooterRole", true, project, siteUserCount, siteGroupCount, siteRoleCount, siteUserCount, allGroupCount, projectRoleCount);
+            // Can't impersonate privileged roles, so SiteAdmin, ImpersonatingTroubleshooter, and PlatformDeveloper should not appear as valid site roles (siteRoleCount - 3)
+            // Can't impersonate a group with a privileged role (siteGroupCount - privilegedSiteGroupCount)
+            testImpersonator("ApplicationAdminRole", true, project, siteUserCount, siteGroupCount - privilegedSiteGroupCount, siteRoleCount - 3, siteUserCount, allGroupCount - privilegedSiteGroupCount, projectRoleCount);
+
+            // Can impersonate any project group plus any site group where project admin has read permission. As a
+            // brand-new user, Site:Users is the only site group where they have read and we created one project group,
+            // so they can impersonate two groups at the project level.
+            testImpersonator("ProjectAdminRole", false, project, 0, 0, 0, projectUserCount, 2, projectRoleCount);
+
+            // Can't impersonate anything anywhere
+            testImpersonator("FolderAdminRole", false, project, 0, 0, 0, 0, 0, 0);
+            testImpersonator("EditorRole", false, project, 0, 0, 0, 0, 0, 0);
+            testImpersonator("ReaderRole", false, project, 0, 0, 0, 0, 0, 0);
+        }
+        finally
+        {
+            if (priviledgedGroup != null)
+                SecurityManager.deleteGroup(priviledgedGroup, testUser);
+            if (readPermGroup != null)
+                SecurityManager.deleteGroup(readPermGroup, testUser);
+            if (readPermUser != null)
+                UserManager.deleteUser(readPermUser.getUserId());
+            if (noPermUser != null)
+                UserManager.deleteUser(noPermUser.getUserId());
+            if (projectToDelete != null)
+                ContainerManager.delete(projectToDelete, testUser);
+        }
+    }
+
+    private void testImpersonator(String roleName, boolean siteRole, Container project, int expectedSiteUsers, int expectedSiteGroups, int expectedSiteRoles, int expectedProjectUsers, int expectedProjectGroups, int expectedProjectRoles) throws InvalidEmailException, UserManagementException
+    {
+        LOG.info("Testing {}", roleName);
+        Container root = ContainerManager.getRoot();
+        User userToDelete = null;
+
+        try
+        {
+            // Create user and assign role
+            String email = roleName + "@test.com";
+            User user = userToDelete = SecurityManager.addUser(new ValidEmail(email), null).getUser();
+            Role role = RoleManager.getRole("org.labkey.api.security.roles." + roleName);
+            assertNotNull("Could not resolve " + roleName, role);
+            Container roleContainer = siteRole ? root : project;
+            MutableSecurityPolicy rootPolicy = new MutableSecurityPolicy(roleContainer.getPolicy());
+            rootPolicy.addRoleAssignment(user, role);
+            SecurityPolicyManager.savePolicyForTests(rootPolicy, TestContext.get().getUser());
+
+            // Test impersonating at the site level
+            // TODO: Active vs. all?
+            Collection<User> validUsers = UserImpersonationContextFactory.getValidImpersonationUsers(null, user);
+            assertEquals(expectedSiteUsers, validUsers.size());
+            assertTrue(user + " is able to impersonate themselves!", validUsers.stream().noneMatch(u -> u.equals(user)));
+            Collection<Group> validSiteGroups = GroupImpersonationContextFactory.getValidImpersonationGroups(root, user);
+            assertEquals(expectedSiteGroups, validSiteGroups.size());
+            Collection<Role> validSiteRoles = RoleImpersonationContextFactory.filterImpersonationRoles(root, user, RoleManager.getAllRoles());
+            assertEquals(expectedSiteRoles, validSiteRoles.size());
+
+            // Test impersonating at the project level
+            Collection<User> projectUsers = UserImpersonationContextFactory.getValidImpersonationUsers(project, user);
+            assertEquals(expectedProjectUsers, projectUsers.size());
+            Collection<Group> validProjectGroups = GroupImpersonationContextFactory.getValidImpersonationGroups(project, user);
+            assertEquals(expectedProjectGroups, validProjectGroups.size());
+            Collection<Role> validProjectRoles = RoleImpersonationContextFactory.filterImpersonationRoles(project, user, RoleManager.getAllRoles());
+            assertEquals(expectedProjectRoles, validProjectRoles.size());
+        }
+        finally
+        {
+            if (userToDelete != null)
+                UserManager.deleteUser(userToDelete.getUserId());
+        }
+    }
+}

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationTest.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationTest.java
@@ -12,7 +12,6 @@ import org.labkey.api.security.SecurityManager.UserManagementException;
 import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
-import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.ValidEmail.InvalidEmailException;
 import org.labkey.api.security.permissions.ReadPermission;
@@ -133,13 +132,12 @@ public class ImpersonationTest extends Assert
             SecurityPolicyManager.savePolicyForTests(rootPolicy, TestContext.get().getUser());
 
             // Test impersonating at the site level
-            // TODO: Active vs. all?
             Collection<User> validUsers = UserImpersonationContextFactory.getValidImpersonationUsers(null, user);
             assertEquals(expectedSiteUsers, validUsers.size());
             assertTrue(user + " is able to impersonate themselves!", validUsers.stream().noneMatch(u -> u.equals(user)));
             Collection<Group> validSiteGroups = GroupImpersonationContextFactory.getValidImpersonationGroups(root, user);
             assertEquals(expectedSiteGroups, validSiteGroups.size());
-            Collection<Role> validSiteRoles = RoleImpersonationContextFactory.filterImpersonationRoles(null, user, RoleManager.getAllRoles());
+            Collection<Role> validSiteRoles = RoleImpersonationContextFactory.getValidImpersonationRoles(ContainerManager.getRoot(), user).toList();
             assertEquals(expectedSiteRoles, validSiteRoles.size());
 
             // Test impersonating at the project level
@@ -147,7 +145,7 @@ public class ImpersonationTest extends Assert
             assertEquals(expectedProjectUsers, projectUsers.size());
             Collection<Group> validProjectGroups = GroupImpersonationContextFactory.getValidImpersonationGroups(project, user);
             assertEquals(expectedProjectGroups, validProjectGroups.size());
-            Collection<Role> validProjectRoles = RoleImpersonationContextFactory.filterImpersonationRoles(project, user, RoleManager.getAllRoles());
+            Collection<Role> validProjectRoles = RoleImpersonationContextFactory.getValidImpersonationRoles(project, user).toList();
             assertEquals(expectedProjectRoles, validProjectRoles.size());
         }
         finally

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationTest.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationTest.java
@@ -87,8 +87,8 @@ public class ImpersonationTest extends Assert
             testImpersonator("SiteAdminRole", true, project, siteUserCount, siteGroupCount, siteRoleCount, siteUserCount, allGroupCount, projectRoleCount);
             testImpersonator("ImpersonatingTroubleshooterRole", true, project, siteUserCount, siteGroupCount, siteRoleCount, siteUserCount, allGroupCount, projectRoleCount);
             // Can't impersonate privileged roles, so SiteAdmin, ImpersonatingTroubleshooter, and PlatformDeveloper should not appear as valid site roles (siteRoleCount - 3)
-            // Can't impersonate a group with a privileged role (siteGroupCount - privilegedSiteGroupCount)
-            testImpersonator("ApplicationAdminRole", true, project, siteUserCount, siteGroupCount - privilegedSiteGroupCount, siteRoleCount - 3, siteUserCount, allGroupCount - privilegedSiteGroupCount, projectRoleCount);
+            // Can impersonate all users and groups (same counts as above), but privileged roles will get filtered out by the impersonation contexts
+            testImpersonator("ApplicationAdminRole", true, project, siteUserCount, siteGroupCount, siteRoleCount - 3, siteUserCount, allGroupCount, projectRoleCount);
 
             // Can impersonate any project group plus any site group where project admin has read permission. As a
             // brand-new user, Site:Users is the only site group where they have read and we created one project group,

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationTest.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationTest.java
@@ -73,7 +73,6 @@ public class ImpersonationTest extends Assert
             int siteUserCount = UserManager.getUserIds().size(); // Includes inactive
             List<Group> siteGroups = SecurityManager.getGroups(null, false);
             int siteGroupCount = siteGroups.size() - 1; // Can't impersonate the guests group
-            int privilegedSiteGroupCount = (int)siteGroups.stream().filter(UserPrincipal::hasPrivilegedRole).count();
             int siteRoleCount = RoleManager.getSiteRoles().size();
 
             // Project-related counts
@@ -90,9 +89,9 @@ public class ImpersonationTest extends Assert
             // Can impersonate all users and groups (same counts as above), but privileged roles will get filtered out by the impersonation contexts
             testImpersonator("ApplicationAdminRole", true, project, siteUserCount, siteGroupCount, siteRoleCount - 3, siteUserCount, allGroupCount, projectRoleCount);
 
-            // Can impersonate any project group plus any site group where project admin has read permission. As a
-            // brand-new user, Site:Users is the only site group where they have read and we created one project group,
-            // so they can impersonate two groups at the project level.
+            // Can impersonate any project group plus any site group where project admin is a member. As a brand-new
+            // user, they are a member in Site:Users only and we created one project group, so they can impersonate two
+            // groups at the project level.
             testImpersonator("ProjectAdminRole", false, project, 0, 0, 0, projectUserCount, 2, projectRoleCount);
 
             // Can't impersonate anything anywhere

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationTest.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationTest.java
@@ -44,7 +44,7 @@ public class ImpersonationTest extends Assert
         User noPermUser = null;
         User readPermUser = null;
         Group readPermGroup = null;
-        Group priviledgedGroup = null;
+        Group privilegedGroup = null;
         try
         {
             // Need to test in a new project since all users get read permission in /Shared, which we don't want
@@ -63,10 +63,10 @@ public class ImpersonationTest extends Assert
             readPermGroup = SecurityManager.createGroup(root, "Test_Read_Perm", null);
 
             // Ensure there's at least one site group assigned to a privileged role
-            priviledgedGroup = SecurityManager.createGroup(root, "Test_Privileged", null);
+            privilegedGroup = SecurityManager.createGroup(root, "Test_Privileged", null);
             MutableSecurityPolicy policy = new MutableSecurityPolicy(root.getPolicy());
             Role privilegedRole = RoleManager.getRole(PlatformDeveloperRole.class);
-            policy.addRoleAssignment(priviledgedGroup, privilegedRole);
+            policy.addRoleAssignment(privilegedGroup, privilegedRole);
             SecurityPolicyManager.savePolicy(policy, testUser);
 
             // Site-related counts
@@ -101,8 +101,8 @@ public class ImpersonationTest extends Assert
         }
         finally
         {
-            if (priviledgedGroup != null)
-                SecurityManager.deleteGroup(priviledgedGroup, testUser);
+            if (privilegedGroup != null)
+                SecurityManager.deleteGroup(privilegedGroup, testUser);
             if (readPermGroup != null)
                 SecurityManager.deleteGroup(readPermGroup, testUser);
             if (readPermUser != null)
@@ -139,7 +139,7 @@ public class ImpersonationTest extends Assert
             assertTrue(user + " is able to impersonate themselves!", validUsers.stream().noneMatch(u -> u.equals(user)));
             Collection<Group> validSiteGroups = GroupImpersonationContextFactory.getValidImpersonationGroups(root, user);
             assertEquals(expectedSiteGroups, validSiteGroups.size());
-            Collection<Role> validSiteRoles = RoleImpersonationContextFactory.filterImpersonationRoles(root, user, RoleManager.getAllRoles());
+            Collection<Role> validSiteRoles = RoleImpersonationContextFactory.filterImpersonationRoles(null, user, RoleManager.getAllRoles());
             assertEquals(expectedSiteRoles, validSiteRoles.size());
 
             // Test impersonating at the project level

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationTestCase.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationTestCase.java
@@ -27,11 +27,11 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * We have many impersonation permissions rules. This attempts to test them all.
+ * We have many impersonation permissions rules. This attempts to test many of them.
  */
-public class ImpersonationTest extends Assert
+public class ImpersonationTestCase extends Assert
 {
-    private static final Logger LOG = LogHelper.getLogger(ImpersonationTest.class, "Progress of ImpersonationTest");
+    private static final Logger LOG = LogHelper.getLogger(ImpersonationTestCase.class, "Progress of ImpersonationTest");
 
     @Test
     public void testPermissions() throws Exception

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -31,20 +31,17 @@ import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
-import org.labkey.api.security.permissions.AdminPermission;
-import org.labkey.api.security.permissions.CanImpersonatePrivilegedSiteRolesPermission;
-import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
+import org.labkey.api.security.permissions.ImpersonatePermission;
+import org.labkey.api.security.permissions.ImpersonatePrivilegedSiteRolesPermission;
 import org.labkey.api.security.roles.AbstractRootContainerRole;
 import org.labkey.api.security.roles.Role;
-import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.GUID;
-import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -183,16 +180,30 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         menu.addChild(newRoleMenu);
     }
 
-    public static Stream<Role> getValidImpersonationRoles(Container c, User user)
+    // Returns a stream of roles that this user is allowed to impersonate. Empty if user can't impersonate.
+    public static Collection<Role> filterImpersonationRoles(Container c, User adminUser, Collection<Role> roles)
     {
+        boolean canImpersonate = adminUser.hasRootPermission(ImpersonatePermission.class);
+
+        if (!canImpersonate && !c.isRoot())
+        {
+            canImpersonate = c.hasPermission(adminUser, ImpersonatePermission.class);
+        }
+
+        if (!canImpersonate)
+        {
+            return Collections.emptyList();
+        }
+
+        boolean canImpersonatePrivilegedRoles = adminUser.hasRootPermission(ImpersonatePrivilegedSiteRolesPermission.class);
         SecurityPolicy policy = SecurityPolicyManager.getPolicy(c);
-        boolean canImpersonatePrivilegedRoles = user.hasRootPermission(CanImpersonatePrivilegedSiteRolesPermission.class);
 
         // Stream the valid roles
-        return RoleManager.getAllRoles().stream()
+        return roles.stream()
             .filter(Role::isAssignable)
             .filter(role -> role.isApplicable(policy, c))
-            .filter(role -> !role.isPrivileged() || canImpersonatePrivilegedRoles);
+            .filter(role -> !role.isPrivileged() || canImpersonatePrivilegedRoles)
+            .toList();
     }
 
     public static class RoleImpersonationContext extends AbstractImpersonationContext
@@ -226,8 +237,10 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         }
 
         // Throws if user is not authorized to impersonate all roles
-        private void verifyPermissions(@Nullable Container project, User user, Set<Role> roles)
+        private void verifyPermissions(@Nullable Container project, User adminUser, Set<Role> roles)
         {
+            final Collection<Role> filteredRoles;
+
             if (null == project)
             {
                 // Ensure we have either site roles or project roles, not both
@@ -238,32 +251,15 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
                 if (map.size() > 1)
                     throw new UnauthorizedImpersonationException("You are not allowed to impersonate site roles and project roles at the same time", getFactory());
 
-                // Site Administrator and Impersonating Troubleshooter can impersonate any site role
-                if (user.hasRootPermission(CanImpersonatePrivilegedSiteRolesPermission.class))
-                    return;
-
-                if (!user.hasRootPermission(CanImpersonateSiteRolesPermission.class))
-                    throw new UnauthorizedImpersonationException("You are not allowed to impersonate site roles", getFactory());
-
-                // Application Administrator can impersonate all site roles except the privileged ones
-                List<String> privileged = roles.stream()
-                    .filter(Role::isPrivileged)
-                    .map(Role::getDisplayName)
-                    .toList();
-
-                if (!privileged.isEmpty())
-                    throw new UnauthorizedImpersonationException("You are not allowed to impersonate " + StringUtilsLabKey.joinWithConjunction(privileged, "or"), getFactory());
+                filteredRoles = filterImpersonationRoles(ContainerManager.getRoot(), adminUser, roles);
             }
             else
             {
-                // Must have admin permissions in this project
-                if (!project.hasPermission(user, AdminPermission.class))
-                    throw new UnauthorizedImpersonationException("You are not allowed to impersonate a role in this project", getFactory());
-
-                // Must not be impersonating any site roles
-                if (roles.stream().anyMatch(role -> (role instanceof AbstractRootContainerRole)))
-                    throw new UnauthorizedImpersonationException("You are not allowed to impersonate site roles", getFactory());
+                filteredRoles = filterImpersonationRoles(project, adminUser, roles);
             }
+
+            if (filteredRoles.size() != roles.size())
+                throw new UnauthorizedImpersonationException("One or more impersonation roles are not authorized", getFactory());
         }
 
         @Override
@@ -285,7 +281,7 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
             // impersonate the specified roles. See Issue #50248 to understand the "instanceof Container" check.
             return resource instanceof Container c ?
                 _roles.stream()
-                    .filter(role -> !(role instanceof AbstractRootContainerRole siteRole) || siteRole.isAvailableEverywhere() || c.isRoot()) :
+                    .filter(role -> !(role instanceof AbstractRootContainerRole siteRole) || siteRole.isApplicableOutsideRoot() || c.isRoot()) :
                 Stream.empty();
         }
 

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -180,14 +180,14 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         menu.addChild(newRoleMenu);
     }
 
-    // Returns a collection of roles that this user is allowed to impersonate. Empty if user can't impersonate.
-    public static Collection<Role> filterImpersonationRoles(Container c, User adminUser, Collection<Role> candidates)
+    // Returns a collection of roles that this user is allowed to impersonate in this project (or root). Empty if user can't impersonate.
+    public static Collection<Role> filterImpersonationRoles(@Nullable Container project, User adminUser, Collection<Role> candidates)
     {
         boolean canImpersonate = adminUser.hasRootPermission(ImpersonatePermission.class);
 
-        if (!canImpersonate && !c.isRoot())
+        if (!canImpersonate && project != null)
         {
-            canImpersonate = c.hasPermission(adminUser, ImpersonatePermission.class);
+            canImpersonate = project.hasPermission(adminUser, ImpersonatePermission.class);
         }
 
         if (!canImpersonate)
@@ -195,6 +195,7 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
             return Collections.emptyList();
         }
 
+        Container c = project != null ? project : ContainerManager.getRoot();
         boolean canImpersonatePrivilegedRoles = adminUser.hasRootPermission(ImpersonatePrivilegedSiteRolesPermission.class);
         SecurityPolicy policy = SecurityPolicyManager.getPolicy(c);
 
@@ -240,24 +241,16 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         // Throws if user is not authorized to impersonate all roles
         private void verifyPermissions(@Nullable Container project, User adminUser, Set<Role> roles)
         {
-            final Collection<Role> filteredRoles;
-
-            if (null == project)
+            // Ensure we have either site roles or project roles, not both. UI prevents this, but crafty admin could
+            // attempt it by crafting a post with specific class names
+            if (roles.stream()
+                .collect(Collectors.groupingBy(role -> role instanceof AbstractRootContainerRole))
+                .size() > 1)
             {
-                // Ensure we have either site roles or project roles, not both
-                var map = roles.stream()
-                    .collect(Collectors.groupingBy(role -> role instanceof AbstractRootContainerRole));
-
-                // UI prevents this, but crafty admin could attempt it by crafting a post with specific class names
-                if (map.size() > 1)
-                    throw new UnauthorizedImpersonationException("You are not allowed to impersonate site roles and project roles at the same time", getFactory());
-
-                filteredRoles = filterImpersonationRoles(ContainerManager.getRoot(), adminUser, roles);
+                throw new UnauthorizedImpersonationException("You are not allowed to impersonate site roles and project roles at the same time", getFactory());
             }
-            else
-            {
-                filteredRoles = filterImpersonationRoles(project, adminUser, roles);
-            }
+
+            Collection<Role> filteredRoles = filterImpersonationRoles(project, adminUser, roles);
 
             if (filteredRoles.size() != roles.size())
                 throw new UnauthorizedImpersonationException("One or more impersonation roles are not authorized", getFactory());

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.servlet.http.HttpServletRequest;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
@@ -35,13 +36,15 @@ import org.labkey.api.security.permissions.ImpersonatePermission;
 import org.labkey.api.security.permissions.ImpersonatePrivilegedSiteRolesPermission;
 import org.labkey.api.security.roles.AbstractRootContainerRole;
 import org.labkey.api.security.roles.Role;
+import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -180,35 +183,72 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         menu.addChild(newRoleMenu);
     }
 
-    // Returns a collection of roles that this user is allowed to impersonate in this project (or root). Empty if user
-    // can't impersonate these roles (or maybe at all). We always check "applicability" at the project or root level,
-    // never folder, because when AuthFilter calls this on every impersonated request, it has no idea what the current
-    // folder is. All it has is the project stashed in the factory that's in session. That means admins can't
-    // impersonate roles that are applicable only in a folder (e.g., due to folder types).
-    public static Collection<Role> filterImpersonationRoles(@Nullable Container project, User adminUser, Collection<Role> candidates)
+    // Can this user impersonate in this container?
+    private static boolean canImpersonate(@Nullable Container c, User user)
     {
-        boolean canImpersonate = adminUser.hasRootPermission(ImpersonatePermission.class);
+        return user.hasRootPermission(ImpersonatePermission.class) || (c != null && !c.isRoot() && c.hasPermission(user, ImpersonatePermission.class));
+    }
 
-        if (!canImpersonate && project != null)
+    public static Stream<Role> getValidImpersonationRoles(@NotNull Container c, User user)
+    {
+        if (canImpersonate(c, user))
         {
-            canImpersonate = project.hasPermission(adminUser, ImpersonatePermission.class);
-        }
+            SecurityPolicy policy = SecurityPolicyManager.getPolicy(c);
+            boolean canImpersonatePrivilegedRoles = user.hasRootPermission(ImpersonatePrivilegedSiteRolesPermission.class);
 
-        if (!canImpersonate)
+            // Stream the valid roles
+            return RoleManager.getAllRoles().stream()
+                .filter(Role::isAssignable)
+                .filter(role -> role.isApplicable(policy, c))
+                .filter(role -> !role.isPrivileged() || canImpersonatePrivilegedRoles);
+        }
+        else
         {
-            return Collections.emptyList();
+            return Stream.empty();
         }
+    }
 
-        Container c = project != null ? project : ContainerManager.getRoot();
-        boolean canImpersonatePrivilegedRoles = adminUser.hasRootPermission(ImpersonatePrivilegedSiteRolesPermission.class);
-        SecurityPolicy policy = SecurityPolicyManager.getPolicy(c);
+    // Throws if user is not authorized to impersonate all roles
+    private static void verifyPermissions(@Nullable Container project, User adminUser, Set<Role> roles, ImpersonationContextFactory factory)
+    {
+        if (canImpersonate(project, adminUser))
+        {
+            // null project means a root admin is impersonating. Impersonation could have started in the root, project, or folder... we don't know.
+            if (null == project)
+            {
+                // Ensure we have either site roles or project roles, not both. UI prevents this, but crafty admin could
+                // attempt it by crafting a post with specific class names
+                if (roles.stream()
+                        .collect(Collectors.groupingBy(role -> role instanceof AbstractRootContainerRole))
+                        .size() > 1)
+                {
+                    throw new UnauthorizedImpersonationException("You are not allowed to impersonate site roles and project roles at the same time", factory);
+                }
 
-        // Stream the valid roles
-        return candidates.stream()
-            .filter(Role::isAssignable)
-            .filter(role -> role.isApplicable(policy, c))
-            .filter(role -> !role.isPrivileged() || canImpersonatePrivilegedRoles)
-            .toList();
+                if (!adminUser.hasRootPermission(ImpersonatePrivilegedSiteRolesPermission.class))
+                {
+                    // Application Administrator is not allowed to impersonate privileged roles
+                    List<String> privileged = roles.stream()
+                        .filter(Role::isPrivileged)
+                        .map(Role::getDisplayName)
+                        .toList();
+
+                    if (!privileged.isEmpty())
+                        throw new UnauthorizedImpersonationException("You are not allowed to impersonate " + StringUtilsLabKey.joinWithConjunction(privileged, "or"), factory);
+                }
+            }
+            else
+            {
+                // Must not be impersonating any site roles
+                if (roles.stream().anyMatch(role -> (role instanceof AbstractRootContainerRole)))
+                    throw new UnauthorizedImpersonationException("You are not allowed to impersonate site roles", factory);
+            }
+        }
+        else
+        {
+            // Admin's permissions must have been revoked since impersonation began
+            throw new UnauthorizedImpersonationException("You are not allowed to impersonate here", factory);
+        }
     }
 
     public static class RoleImpersonationContext extends AbstractImpersonationContext
@@ -229,35 +269,18 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         }
 
         private RoleImpersonationContext(
-                @Nullable Container project,
-                User adminUser,
-                RoleSet roles,
-                ActionURL returnUrl,
-                ImpersonationContextFactory factory,
-                String cacheKey)
+            @Nullable Container project,
+            User adminUser,
+            RoleSet roles,
+            ActionURL returnUrl,
+            ImpersonationContextFactory factory,
+            String cacheKey
+        )
         {
             super(adminUser, project, returnUrl, factory);
             _roles = roles;
             _cacheKey = cacheKey;
-            verifyPermissions(project, adminUser, _roles.getRoles());
-        }
-
-        // Throws if user is not authorized to impersonate all roles
-        private void verifyPermissions(@Nullable Container project, User adminUser, Set<Role> roles)
-        {
-            // Ensure we have either site roles or project roles, not both. UI prevents this, but crafty admin could
-            // attempt it by crafting a post with specific class names
-            if (roles.stream()
-                .collect(Collectors.groupingBy(role -> role instanceof AbstractRootContainerRole))
-                .size() > 1)
-            {
-                throw new UnauthorizedImpersonationException("You are not allowed to impersonate site roles and project roles at the same time", getFactory());
-            }
-
-            Collection<Role> filteredRoles = filterImpersonationRoles(project, adminUser, roles);
-
-            if (filteredRoles.size() != roles.size())
-                throw new UnauthorizedImpersonationException("One or more impersonation roles are not authorized", getFactory());
+            verifyPermissions(project, adminUser, _roles.getRoles(), factory);
         }
 
         @Override

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -180,8 +180,8 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         menu.addChild(newRoleMenu);
     }
 
-    // Returns a stream of roles that this user is allowed to impersonate. Empty if user can't impersonate.
-    public static Collection<Role> filterImpersonationRoles(Container c, User adminUser, Collection<Role> roles)
+    // Returns a collection of roles that this user is allowed to impersonate. Empty if user can't impersonate.
+    public static Collection<Role> filterImpersonationRoles(Container c, User adminUser, Collection<Role> candidates)
     {
         boolean canImpersonate = adminUser.hasRootPermission(ImpersonatePermission.class);
 
@@ -199,7 +199,7 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         SecurityPolicy policy = SecurityPolicyManager.getPolicy(c);
 
         // Stream the valid roles
-        return roles.stream()
+        return candidates.stream()
             .filter(Role::isAssignable)
             .filter(role -> role.isApplicable(policy, c))
             .filter(role -> !role.isPrivileged() || canImpersonatePrivilegedRoles)
@@ -213,11 +213,12 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
 
         @JsonCreator
         private RoleImpersonationContext(
-                @JsonProperty("_project") @Nullable Container project,
-                @JsonProperty("_adminUser") User adminUser,
-                @JsonProperty("_roles") RoleSet roles,
-                @JsonProperty("_factory") ImpersonationContextFactory factory,
-                @JsonProperty("_cacheKey") String cacheKey)
+            @JsonProperty("_project") @Nullable Container project,
+            @JsonProperty("_adminUser") User adminUser,
+            @JsonProperty("_roles") RoleSet roles,
+            @JsonProperty("_factory") ImpersonationContextFactory factory,
+            @JsonProperty("_cacheKey") String cacheKey
+        )
         {
             this(project, adminUser, roles, null, factory, cacheKey);
         }

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -180,7 +180,11 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         menu.addChild(newRoleMenu);
     }
 
-    // Returns a collection of roles that this user is allowed to impersonate in this project (or root). Empty if user can't impersonate.
+    // Returns a collection of roles that this user is allowed to impersonate in this project (or root). Empty if user
+    // can't impersonate these roles (or maybe at all). We always check "applicability" at the project or root level,
+    // never folder, because when AuthFilter calls this on every impersonated request, it has no idea what the current
+    // folder is. All it has is the project stashed in the factory that's in session. That means admins can't
+    // impersonate roles that are applicable only in a folder (e.g., due to folder types).
     public static Collection<Role> filterImpersonationRoles(@Nullable Container project, User adminUser, Collection<Role> candidates)
     {
         boolean canImpersonate = adminUser.hasRootPermission(ImpersonatePermission.class);

--- a/api/src/org/labkey/api/security/impersonation/UserImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/UserImpersonationContextFactory.java
@@ -30,7 +30,8 @@ import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
-import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.ImpersonatePermission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.SessionHelper;
@@ -40,6 +41,7 @@ import org.labkey.api.view.ViewContext;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -147,20 +149,22 @@ public class UserImpersonationContextFactory extends AbstractImpersonationContex
     // project == null means return all site users (if authorized)
     public static Collection<User> getValidImpersonationUsers(@Nullable Container project, User adminUser)
     {
+        // Must assign a mutable list in all scenarios to allow subsequent remove() call
         Collection<User> validUsers;
 
-        // Site admin can impersonate any active user...
-        if (null == project)
+        // Site admin, app admin, and impersonating troubleshooter can impersonate any user, regardless of user's permissions and where impersonation is initiated
+        if (adminUser.hasRootPermission(ImpersonatePermission.class))
         {
-            validUsers = adminUser.hasRootAdminPermission() ? UserManager.getUsers(true) : new ArrayList<>(0); // Mutable list to allow subsequent remove() call
+            validUsers = UserManager.getUsers(true);
         }
-        else if (!project.hasPermission(adminUser, AdminPermission.class))
+        else if (project != null && project.hasPermission(adminUser, ImpersonatePermission.class))
         {
-            validUsers = new ArrayList<>(0); // Mutable list to allow subsequent remove() call
+            // The read permission check is not for security; it just seems useless to offer impersonation on a user who lacks read.
+            validUsers = new ArrayList<>(SecurityManager.getUsersWithPermissions(project, true, Set.of(ReadPermission.class)));
         }
         else
         {
-            validUsers = SecurityManager.getProjectUsers(project);
+            validUsers = new ArrayList<>(0);
         }
 
         validUsers.remove(adminUser);
@@ -191,12 +195,12 @@ public class UserImpersonationContextFactory extends AbstractImpersonationContex
             if (impersonatedUser.equals(adminUser))
                 throw new UnauthorizedImpersonationException("Can't impersonate yourself", getFactory());
 
-            // Site/app admin can impersonate anywhere
-            if (adminUser.hasRootAdminPermission())
+            // Site admin, app admin, and impersonating troubleshooter can impersonate anywhere, regardless of user's permissions
+            if (adminUser.hasRootPermission(ImpersonatePermission.class))
                 return;
 
             // Project admin...
-            if (null != project && project.hasPermission(adminUser, AdminPermission.class) && SecurityManager.getProjectUsersIds(project).contains(impersonatedUser.getUserId()))
+            if (null != project && project.hasPermission(adminUser, ImpersonatePermission.class) && project.hasPermission(impersonatedUser, ReadPermission.class))
                 return;
 
             throw new UnauthorizedImpersonationException("Can't impersonate this user", getFactory());

--- a/api/src/org/labkey/api/security/impersonation/UserImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/UserImpersonationContextFactory.java
@@ -145,8 +145,11 @@ public class UserImpersonationContextFactory extends AbstractImpersonationContex
         menu.addChild(userMenu);
     }
 
-    // Somewhat redundant with verifyPermissions() below, but much more expensive in the single-user case. Keep these two methods in sync.
-    // project == null means return all site users (if authorized)
+    // Redundant with verifyPermissions() below, but much more expensive in the single-user case. Keep these two methods
+    // in sync. project == null means return all site users (if authorized). Includes inactive users so we can show them
+    // grayed out in the UI, but they can't be impersonated. Note that we allow app admins and project admins to
+    // impersonate site admins and other users with privileged roles, but those roles are filtered out by
+    // UserImpersonationContext. Project admins are also restricted to their project.
     public static Collection<User> getValidImpersonationUsers(@Nullable Container project, User adminUser)
     {
         // Must assign a mutable list in all scenarios to allow subsequent remove() call
@@ -172,13 +175,34 @@ public class UserImpersonationContextFactory extends AbstractImpersonationContex
         return validUsers;
     }
 
+    // Keep in sync with getValidImpersonationUsers() above
+    private static void verifyPermissions(@Nullable Container project, User impersonatedUser, User adminUser, ImpersonationContextFactory factory)
+    {
+        if (impersonatedUser.equals(adminUser))
+            throw new UnauthorizedImpersonationException("Can't impersonate yourself", factory);
+
+        if (!impersonatedUser.isActive())
+            throw new UnauthorizedImpersonationException("Can't impersonate an inactive user", factory);
+
+        // Site admin, app admin, and impersonating troubleshooter can impersonate anywhere, regardless of user's permissions
+        if (adminUser.hasRootPermission(ImpersonatePermission.class))
+            return;
+
+        // Project admin...
+        if (project != null && project.hasPermission(adminUser, ImpersonatePermission.class) && project.hasPermission(impersonatedUser, ReadPermission.class))
+            return;
+
+        throw new UnauthorizedImpersonationException("Can't impersonate this user", factory);
+    }
+
     private static class UserImpersonationContext extends AbstractImpersonationContext
     {
         @JsonCreator
         protected UserImpersonationContext(
-                @JsonProperty("_project") @Nullable Container project,
-                @JsonProperty("_adminUser") User adminUser,
-                @JsonProperty("_factory") ImpersonationContextFactory factory)
+            @JsonProperty("_project") @Nullable Container project,
+            @JsonProperty("_adminUser") User adminUser,
+            @JsonProperty("_factory") ImpersonationContextFactory factory
+        )
         {
             super(adminUser, project, null, factory);
         }
@@ -186,24 +210,7 @@ public class UserImpersonationContextFactory extends AbstractImpersonationContex
         private UserImpersonationContext(@Nullable Container project, User adminUser, User impersonatedUser, ActionURL returnUrl, ImpersonationContextFactory factory)
         {
             super(adminUser, project, returnUrl, factory);
-            verifyPermissions(project, impersonatedUser, adminUser);
-        }
-
-        // Keep in sync with getValidImpersonationUsers() above
-        private void verifyPermissions(@Nullable Container project, User impersonatedUser, User adminUser)
-        {
-            if (impersonatedUser.equals(adminUser))
-                throw new UnauthorizedImpersonationException("Can't impersonate yourself", getFactory());
-
-            // Site admin, app admin, and impersonating troubleshooter can impersonate anywhere, regardless of user's permissions
-            if (adminUser.hasRootPermission(ImpersonatePermission.class))
-                return;
-
-            // Project admin...
-            if (null != project && project.hasPermission(adminUser, ImpersonatePermission.class) && project.hasPermission(impersonatedUser, ReadPermission.class))
-                return;
-
-            throw new UnauthorizedImpersonationException("Can't impersonate this user", getFactory());
+            verifyPermissions(project, impersonatedUser, adminUser, factory);
         }
 
         @Override

--- a/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
@@ -67,6 +67,7 @@ public abstract class AbstractActionPermissionTest extends Assert
     private static final String AUTHOR_EMAIL = "author@actionpermission.test";
     private static final String READER_EMAIL = "reader@actionpermission.test";
     private static final String SUBMITTER_EMAIL = "submitter@actionpermission.test";
+    private static final String NO_PERMISSION_EMAIL = "nopermission@actionpermission.test";
     private static final String TRUSTED_EDITOR_EMAIL = "trustededitor@actionpermission.test";
     private static final String TRUSTED_AUTHOR_EMAIL = "trustedauthor@actionpermission.test";
     private static final String TROUBLESHOOTER_EMAIL = "troubleshooter@actionpermission.test";
@@ -74,7 +75,7 @@ public abstract class AbstractActionPermissionTest extends Assert
     protected static final String[] LKS_ROLE_EMAILS = {
             SITE_ADMIN_EMAIL, APPLICATION_ADMIN_EMAIL, PROJECT_ADMIN_EMAIL, FOLDER_ADMIN_EMAIL, EDITOR_EMAIL,
             AUTHOR_EMAIL, READER_EMAIL, SUBMITTER_EMAIL, TRUSTED_EDITOR_EMAIL, TRUSTED_AUTHOR_EMAIL, TROUBLESHOOTER_EMAIL,
-            IMPERSONATING_TROUBLESHOOTER_EMAIL
+            IMPERSONATING_TROUBLESHOOTER_EMAIL, NO_PERMISSION_EMAIL
     };
 
     protected static Container _c;
@@ -181,6 +182,21 @@ public abstract class AbstractActionPermissionTest extends Assert
         {}
 
         return users;
+    }
+
+    public void assertForNoPermission(User user, PermissionCheckableAction... actions)
+    {
+        for (PermissionCheckableAction action : actions)
+        {
+            assertPermission(_c, action, user);
+
+            assertPermission(_c, action,
+                _users.get(READER_EMAIL), _users.get(AUTHOR_EMAIL), _users.get(EDITOR_EMAIL),
+                _users.get(FOLDER_ADMIN_EMAIL), _users.get(PROJECT_ADMIN_EMAIL),
+                _users.get(APPLICATION_ADMIN_EMAIL), _users.get(SITE_ADMIN_EMAIL),
+                _users.get(SUBMITTER_EMAIL)
+            );
+        }
     }
 
     public void assertForReadPermission(User user, PermissionCheckableAction... actions)

--- a/api/src/org/labkey/api/security/permissions/AdminOperationsPermission.java
+++ b/api/src/org/labkey/api/security/permissions/AdminOperationsPermission.java
@@ -16,7 +16,7 @@
 package org.labkey.api.security.permissions;
 
 /**
- * Describes the ability to manage operational site administration settings, such as arbitrary paths on the server's
+ * Provides the ability to manage operational site administration settings, such as arbitrary paths on the server's
  * underlying file system. Use {@see org.labkey.api.security.permissions.ApplicationAdminPermission} for gating
  * access to server-wide settings that don't have the potential to access these underlying server resources.
  */

--- a/api/src/org/labkey/api/security/permissions/AdminPermission.java
+++ b/api/src/org/labkey/api/security/permissions/AdminPermission.java
@@ -25,11 +25,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Describes the ability to perform administration. Note that this is distinct from {@link org.labkey.api.security.roles.SiteAdminRole},
+ * Provides the ability to perform administration. Note that this is distinct from {@link org.labkey.api.security.roles.SiteAdminRole},
  * which is far more all-encompassing.
- *
- * User: Dave
- * Date: Apr 28, 2009
  */
 public class AdminPermission extends AbstractPermission
 {

--- a/api/src/org/labkey/api/security/permissions/CanImpersonateSiteRolesPermission.java
+++ b/api/src/org/labkey/api/security/permissions/CanImpersonateSiteRolesPermission.java
@@ -1,9 +1,0 @@
-package org.labkey.api.security.permissions;
-
-public class CanImpersonateSiteRolesPermission extends AbstractPermission
-{
-    public CanImpersonateSiteRolesPermission()
-    {
-        super("Can Impersonate Site Roles", "Allows users to impersonate site roles except for privileged roles");
-    }
-}

--- a/api/src/org/labkey/api/security/permissions/DeletePermission.java
+++ b/api/src/org/labkey/api/security/permissions/DeletePermission.java
@@ -16,9 +16,7 @@
 package org.labkey.api.security.permissions;
 
 /**
- * Describes the ability to delete some sort of object.
- * User: Dave
- * Date: Apr 27, 2009
+ * Provides the ability to delete objects
  */
 public class DeletePermission extends AbstractPermission
 {

--- a/api/src/org/labkey/api/security/permissions/ImpersonatePermission.java
+++ b/api/src/org/labkey/api/security/permissions/ImpersonatePermission.java
@@ -1,0 +1,9 @@
+package org.labkey.api.security.permissions;
+
+public class ImpersonatePermission extends AbstractPermission
+{
+    public ImpersonatePermission()
+    {
+        super("Can Impersonate", "Allows users to impersonate users, groups, and roles, except for privileged roles");
+    }
+}

--- a/api/src/org/labkey/api/security/permissions/ImpersonatePrivilegedSiteRolesPermission.java
+++ b/api/src/org/labkey/api/security/permissions/ImpersonatePrivilegedSiteRolesPermission.java
@@ -1,8 +1,8 @@
 package org.labkey.api.security.permissions;
 
-public class CanImpersonatePrivilegedSiteRolesPermission extends AbstractPermission
+public class ImpersonatePrivilegedSiteRolesPermission extends AbstractPermission
 {
-    public CanImpersonatePrivilegedSiteRolesPermission()
+    public ImpersonatePrivilegedSiteRolesPermission()
     {
         super("Can Impersonate Privileged Site Roles", "Allows users to impersonate privileged site roles including Site Admin");
     }

--- a/api/src/org/labkey/api/security/permissions/InsertPermission.java
+++ b/api/src/org/labkey/api/security/permissions/InsertPermission.java
@@ -18,9 +18,7 @@ package org.labkey.api.security.permissions;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Describes the ability to add new objects to the system.
- * User: Dave
- * Date: Apr 27, 2009
+ * Provides the ability to add new objects to the system
  */
 public class InsertPermission extends AbstractPermission
 {

--- a/api/src/org/labkey/api/security/permissions/MoveEntitiesPermission.java
+++ b/api/src/org/labkey/api/security/permissions/MoveEntitiesPermission.java
@@ -16,7 +16,7 @@
 package org.labkey.api.security.permissions;
 
 /**
- * Describes the ability to move entities between containers within the system.
+ * Provides the ability to move entities between containers within the system
  */
 public class MoveEntitiesPermission extends UpdatePermission
 {

--- a/api/src/org/labkey/api/security/permissions/ReadPermission.java
+++ b/api/src/org/labkey/api/security/permissions/ReadPermission.java
@@ -18,9 +18,7 @@ package org.labkey.api.security.permissions;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Describes the ability to view information within the system.
- * User: Dave
- * Date: Apr 23, 2009
+ * Provides the ability to view information within the system
  */
 @AllowedForReadOnlyUser
 public class ReadPermission extends AbstractPermission

--- a/api/src/org/labkey/api/security/permissions/ReadSomePermission.java
+++ b/api/src/org/labkey/api/security/permissions/ReadSomePermission.java
@@ -16,9 +16,7 @@
 package org.labkey.api.security.permissions;
 
 /**
- * Describes the ability to read a limited subset of information within a specific context.
- * User: Dave
- * Date: Apr 30, 2009
+ * Provides the ability to read a limited subset of information within a specific context
  */
 @AllowedForReadOnlyUser
 public class ReadSomePermission extends AbstractPermission

--- a/api/src/org/labkey/api/security/permissions/TroubleshooterPermission.java
+++ b/api/src/org/labkey/api/security/permissions/TroubleshooterPermission.java
@@ -17,7 +17,7 @@
 package org.labkey.api.security.permissions;
 
 /**
- * Describes the ability to view administration and configuration, but not change it.
+ * Provides the ability to view administration and configuration, but not change it
  */
 @AllowedForReadOnlyUser
 public class TroubleshooterPermission extends AbstractPermission

--- a/api/src/org/labkey/api/security/permissions/UpdatePermission.java
+++ b/api/src/org/labkey/api/security/permissions/UpdatePermission.java
@@ -18,9 +18,7 @@ package org.labkey.api.security.permissions;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Describes the ability to change existing objects within the system.
- * User: Dave
- * Date: Apr 27, 2009
+ * Provides the ability to change existing objects within the system
  */
 public class UpdatePermission extends AbstractPermission
 {

--- a/api/src/org/labkey/api/security/permissions/UserManagementPermission.java
+++ b/api/src/org/labkey/api/security/permissions/UserManagementPermission.java
@@ -16,7 +16,7 @@
 package org.labkey.api.security.permissions;
 
 /**
- * Describes the ability to manage users (create, delete, deactivate) for the server.
+ * Provides the ability to manage users (create, delete, deactivate)
  */
 public class UserManagementPermission extends AdminPermission
 {

--- a/api/src/org/labkey/api/security/roles/AbstractRootContainerRole.java
+++ b/api/src/org/labkey/api/security/roles/AbstractRootContainerRole.java
@@ -61,7 +61,9 @@ public abstract class AbstractRootContainerRole extends AbstractRole
         return resource instanceof Container && ((Container)resource).isRoot();
     }
 
-    public boolean isAvailableEverywhere()
+    // Most site roles are applicable outside the root (i.e., every container). Troubleshooters are an exception
+    // because we want them to have read in the root but not elsewhere.
+    public boolean isApplicableOutsideRoot()
     {
         return true;
     }

--- a/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
@@ -37,10 +37,10 @@ public class ApplicationAdminRole extends AbstractRootContainerRole implements A
     static Collection<Class<? extends Permission>> PERMISSIONS = Arrays.asList(
         AddUserPermission.class,
         ApplicationAdminPermission.class,
-        ImpersonatePermission.class,
         DeleteUserPermission.class,
         EnableRestrictedModules.class,
         ExemptFromAccountDisablingPermission.class,
+        ImpersonatePermission.class,
         TroubleshooterPermission.class,
         UpdateUserPermission.class,
         UserManagementPermission.class

--- a/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
@@ -17,10 +17,10 @@ package org.labkey.api.security.roles;
 
 import org.labkey.api.security.permissions.AddUserPermission;
 import org.labkey.api.security.permissions.ApplicationAdminPermission;
-import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
 import org.labkey.api.security.permissions.DeleteUserPermission;
 import org.labkey.api.security.permissions.EnableRestrictedModules;
 import org.labkey.api.security.permissions.ExemptFromAccountDisablingPermission;
+import org.labkey.api.security.permissions.ImpersonatePermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.security.permissions.UpdateUserPermission;
@@ -37,7 +37,7 @@ public class ApplicationAdminRole extends AbstractRootContainerRole implements A
     static Collection<Class<? extends Permission>> PERMISSIONS = Arrays.asList(
         AddUserPermission.class,
         ApplicationAdminPermission.class,
-        CanImpersonateSiteRolesPermission.class,
+        ImpersonatePermission.class,
         DeleteUserPermission.class,
         EnableRestrictedModules.class,
         ExemptFromAccountDisablingPermission.class,

--- a/api/src/org/labkey/api/security/roles/ImpersonatingTroubleshooterRole.java
+++ b/api/src/org/labkey/api/security/roles/ImpersonatingTroubleshooterRole.java
@@ -10,7 +10,7 @@ public class ImpersonatingTroubleshooterRole extends AbstractRootContainerRole
 {
     protected ImpersonatingTroubleshooterRole()
     {
-        super("Impersonating Troubleshooter", "Can impersonate site roles, including Site Administrator, in addition to having other standard Troubleshooter abilities.",
+        super("Impersonating Troubleshooter", "Can impersonate users, groups, and roles, including Site Administrator, in addition to having other standard Troubleshooter abilities.",
             TroubleshooterRole.PERMISSIONS,
             Set.of(
                 ExemptFromAccountDisablingPermission.class,

--- a/api/src/org/labkey/api/security/roles/ImpersonatingTroubleshooterRole.java
+++ b/api/src/org/labkey/api/security/roles/ImpersonatingTroubleshooterRole.java
@@ -1,7 +1,7 @@
 package org.labkey.api.security.roles;
 
-import org.labkey.api.security.permissions.CanImpersonatePrivilegedSiteRolesPermission;
-import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
+import org.labkey.api.security.permissions.ImpersonatePrivilegedSiteRolesPermission;
+import org.labkey.api.security.permissions.ImpersonatePermission;
 import org.labkey.api.security.permissions.ExemptFromAccountDisablingPermission;
 
 import java.util.Set;
@@ -13,9 +13,9 @@ public class ImpersonatingTroubleshooterRole extends AbstractRootContainerRole
         super("Impersonating Troubleshooter", "Can impersonate site roles, including Site Administrator, in addition to having other standard Troubleshooter abilities.",
             TroubleshooterRole.PERMISSIONS,
             Set.of(
-                CanImpersonatePrivilegedSiteRolesPermission.class,
-                CanImpersonateSiteRolesPermission.class,
-                ExemptFromAccountDisablingPermission.class
+                ExemptFromAccountDisablingPermission.class,
+                ImpersonatePrivilegedSiteRolesPermission.class,
+                ImpersonatePermission.class
             )
         );
         excludeUsers();
@@ -28,7 +28,7 @@ public class ImpersonatingTroubleshooterRole extends AbstractRootContainerRole
     }
 
     @Override
-    public boolean isAvailableEverywhere()
+    public boolean isApplicableOutsideRoot()
     {
         return false;
     }

--- a/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
@@ -19,9 +19,10 @@ import org.labkey.api.data.Container;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.AddUserPermission;
+import org.labkey.api.security.permissions.ImpersonatePermission;
 import org.labkey.api.security.permissions.Permission;
 
-import java.util.Collections;
+import java.util.List;
 
 public class ProjectAdminRole extends AbstractRole implements AdminRoleListener
 {
@@ -30,7 +31,10 @@ public class ProjectAdminRole extends AbstractRole implements AdminRoleListener
         super("Project Administrator",
             "Project Administrators have full control over the project, but not the entire system.",
             FolderAdminRole.PERMISSIONS,
-            Collections.singletonList(AddUserPermission.class)
+            List.of(
+                AddUserPermission.class,
+                ImpersonatePermission.class
+            )
         );
 
         excludeGuests();

--- a/api/src/org/labkey/api/security/roles/Role.java
+++ b/api/src/org/labkey/api/security/roles/Role.java
@@ -121,8 +121,8 @@ public interface Role extends Parameter.JdbcParameterValue
     }
 
     /**
-     * @return Whether this role is applicable to the policy. For example, some roles might only make sense in the context of a
-     * certain type of resource, such as a folder (or particular type of folder) or dataset
+     * @return Whether this role is applicable in this resource. For example, some roles might only make sense in the
+     * context of a dataset or a certain folder type. TODO: Eliminate policy parameter; no implementation uses it.
      */
     boolean isApplicable(SecurityPolicy policy, SecurableResource resource);
 

--- a/api/src/org/labkey/api/security/roles/SiteAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/SiteAdminRole.java
@@ -16,11 +16,9 @@
 package org.labkey.api.security.roles;
 
 import org.labkey.api.security.permissions.AdminOperationsPermission;
-import org.labkey.api.security.permissions.CanImpersonatePrivilegedSiteRolesPermission;
-import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
+import org.labkey.api.security.permissions.ImpersonatePrivilegedSiteRolesPermission;
 import org.labkey.api.security.permissions.CanUseSendMessageApiPermission;
 import org.labkey.api.security.permissions.EditModuleResourcesPermission;
-import org.labkey.api.security.permissions.ExemptFromAccountDisablingPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.SiteAdminPermission;
 import org.labkey.api.security.permissions.UploadFileBasedModulePermission;
@@ -37,11 +35,9 @@ public class SiteAdminRole extends AbstractRootContainerRole implements AdminRol
 {
     private static final Collection<Class<? extends Permission>> PERMISSIONS = Arrays.asList(
         AdminOperationsPermission.class,
-        CanImpersonatePrivilegedSiteRolesPermission.class,
-        CanImpersonateSiteRolesPermission.class,
+        ImpersonatePrivilegedSiteRolesPermission.class,
         CanUseSendMessageApiPermission.class,
         EmailNonUsersPermission.class,
-        ExemptFromAccountDisablingPermission.class,
         SiteAdminPermission.class,
         UploadFileBasedModulePermission.class
     );

--- a/api/src/org/labkey/api/security/roles/SiteAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/SiteAdminRole.java
@@ -35,9 +35,9 @@ public class SiteAdminRole extends AbstractRootContainerRole implements AdminRol
 {
     private static final Collection<Class<? extends Permission>> PERMISSIONS = Arrays.asList(
         AdminOperationsPermission.class,
-        ImpersonatePrivilegedSiteRolesPermission.class,
         CanUseSendMessageApiPermission.class,
         EmailNonUsersPermission.class,
+        ImpersonatePrivilegedSiteRolesPermission.class,
         SiteAdminPermission.class,
         UploadFileBasedModulePermission.class
     );

--- a/api/src/org/labkey/api/security/roles/TroubleshooterRole.java
+++ b/api/src/org/labkey/api/security/roles/TroubleshooterRole.java
@@ -39,7 +39,7 @@ public class TroubleshooterRole extends AbstractRootContainerRole
     }
 
     @Override
-    public boolean isAvailableEverywhere()
+    public boolean isApplicableOutsideRoot()
     {
         return false; // This ensures troubleshooters get these permissions (esp. ReadPermission) only in the root
     }

--- a/api/src/org/labkey/api/util/URLHelper.java
+++ b/api/src/org/labkey/api/util/URLHelper.java
@@ -915,7 +915,7 @@ public class URLHelper implements Cloneable, Serializable, JSONString
         if (devMode && "localhost".equalsIgnoreCase(host))
             return true;
 
-        // Count the dots in case there's a wild card
+        // Count the dots in case there's a wildcard
         int dotCount = StringUtils.countMatches(host, '.');
 
         return allowedHostsSupplier.get().stream()
@@ -928,14 +928,14 @@ public class URLHelper implements Cloneable, Serializable, JSONString
 
         if (allowedHost.startsWith("*."))
         {
-            // This wild-card pattern matches the host if 1) they have the same number of dots and 2) the host ends with
-            // the portion of the pattern after the wild card.
+            // This wildcard pattern matches the host if 1) they have the same number of dots and 2) the host ends with
+            // the portion of the pattern after the wildcard and dot.
             int expectedDotCount = StringUtils.countMatches(allowedHost, '.');
             ret = (dotCount == expectedDotCount && Strings.CI.endsWith(host, allowedHost.substring(2)));
         }
         else
         {
-            // Non-wild-card pattern must match the entire host
+            // Non-wildcard pattern must match the entire host
             ret = Strings.CI.equals(host, allowedHost);
         }
 
@@ -1120,8 +1120,8 @@ public class URLHelper implements Cloneable, Serializable, JSONString
             allowedHosts2.add("www.google.com");
             assertTrue(isAllowedExternalHost("www.google.com", true, ()->allowedHosts2));
 
-            // test wild cards
-            List<String> wildCardHosts = List.of(
+            // test wildcards
+            List<String> wildcardHosts = List.of(
                 "*.labkey.com",
                 "labkey.com",
                 "*.lkpoc.labkey.com",
@@ -1130,21 +1130,21 @@ public class URLHelper implements Cloneable, Serializable, JSONString
             );
 
             // good
-            assertTrue(isAllowedExternalHost("www.labkey.com", true, ()->wildCardHosts));
-            assertTrue(isAllowedExternalHost("lkpoc.labkey.com", true, ()->wildCardHosts));
-            assertTrue(isAllowedExternalHost("sub1.labkey.com", true, ()->wildCardHosts));
-            assertTrue(isAllowedExternalHost("sub2.labkey.com", true, ()->wildCardHosts));
-            assertTrue(isAllowedExternalHost("labkey.com", true, ()->wildCardHosts));
-            assertTrue(isAllowedExternalHost("sub1.lkpoc.labkey.com", true, ()->wildCardHosts));
-            assertTrue(isAllowedExternalHost("sub2.lkpoc.labkey.com", true, ()->wildCardHosts));
-            assertTrue(isAllowedExternalHost("sub1.trial.labkey.host", true, ()->wildCardHosts));
-            assertTrue(isAllowedExternalHost("sub2.trial.labkey.host", true, ()->wildCardHosts));
+            assertTrue(isAllowedExternalHost("www.labkey.com", true, ()->wildcardHosts));
+            assertTrue(isAllowedExternalHost("lkpoc.labkey.com", true, ()->wildcardHosts));
+            assertTrue(isAllowedExternalHost("sub1.labkey.com", true, ()->wildcardHosts));
+            assertTrue(isAllowedExternalHost("sub2.labkey.com", true, ()->wildcardHosts));
+            assertTrue(isAllowedExternalHost("labkey.com", true, ()->wildcardHosts));
+            assertTrue(isAllowedExternalHost("sub1.lkpoc.labkey.com", true, ()->wildcardHosts));
+            assertTrue(isAllowedExternalHost("sub2.lkpoc.labkey.com", true, ()->wildcardHosts));
+            assertTrue(isAllowedExternalHost("sub1.trial.labkey.host", true, ()->wildcardHosts));
+            assertTrue(isAllowedExternalHost("sub2.trial.labkey.host", true, ()->wildcardHosts));
 
             // bad
-            assertFalse(isAllowedExternalHost("trial.labkey.host", true, ()->wildCardHosts));
-            assertFalse(isAllowedExternalHost("sub1.sub2.lkpoc.labkey.com", true, ()->wildCardHosts));
-            assertFalse(isAllowedExternalHost("google.com", true, ()->wildCardHosts));
-            assertFalse(isAllowedExternalHost("sub1.sub2.labkey.com", true, ()->wildCardHosts));
+            assertFalse(isAllowedExternalHost("trial.labkey.host", true, ()->wildcardHosts));
+            assertFalse(isAllowedExternalHost("sub1.sub2.lkpoc.labkey.com", true, ()->wildcardHosts));
+            assertFalse(isAllowedExternalHost("google.com", true, ()->wildcardHosts));
+            assertFalse(isAllowedExternalHost("sub1.sub2.labkey.com", true, ()->wildcardHosts));
         }
     }
 }

--- a/core/src/org/labkey/core/admin/AllowListType.java
+++ b/core/src/org/labkey/core/admin/AllowListType.java
@@ -41,7 +41,7 @@ public enum AllowListType
                     </p>
                     <p>
                         Add allowed hosts based on the server name or IP address, as they will be referenced in parameters
-                        such as returnUrl. An asterisk (*) follow by a dot acts as a wild card that matches any leading
+                        such as returnUrl. An asterisk (*) follow by a dot acts as a wildcard that matches any leading
                         subdomain for that host.
                         Examples: www.myexternalhost.com, *.myexternalhost.com, or 1.2.3.4
                     </p>
@@ -75,21 +75,21 @@ public enum AllowListType
             {
                 if (AUTHORITY_VALIDATOR.isValidAuthority(host))
                 {
-                    // Validate wild card patterns
+                    // Validate wildcard patterns
                     int starCount = StringUtils.countMatches(host, '*');
                     if (starCount > 0)
                     {
                         if (starCount > 1)
                         {
-                            errors.addError(new LabKeyError(String.format("Redirect host name %1$s has multiple wild card characters", host)));
+                            errors.addError(new LabKeyError(String.format("Redirect host name %1$s has multiple wildcard characters", host)));
                         }
                         else if (!host.startsWith("*."))
                         {
-                            errors.addError(new LabKeyError(String.format("Redirect host name %1$s has an invalid wild card. The pattern must start with \"*.\".", host)));
+                            errors.addError(new LabKeyError(String.format("Redirect host name %1$s has an invalid wildcard. The pattern must start with \"*.\".", host)));
                         }
                         else if (StringUtils.countMatches(host, '.') < 2)
                         {
-                            errors.addError(new LabKeyError(String.format("Redirect host name %1$s with wild card is too short. The pattern must include at least two dots.", host)));
+                            errors.addError(new LabKeyError(String.format("Redirect host name %1$s with wildcard is too short. The pattern must include at least two dots.", host)));
                         }
                     }
                 }

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -3009,7 +3009,7 @@ public class UserController extends SpringActionController
 
             User user = context.isImpersonating() ? context.getAdminUser() : getUser();
             ApiSimpleResponse response = new ApiSimpleResponse();
-            Collection<Map<String, Object>> responseRoles = RoleImpersonationContextFactory.filterImpersonationRoles(getContainer(), user, RoleManager.getAllRoles()).stream()
+            Collection<Map<String, Object>> responseRoles = RoleImpersonationContextFactory.getValidImpersonationRoles(getContainer(), user)
                 .map(role -> {
                     Map<String, Object> map = new HashMap<>();
                     map.put("displayName", role.getDisplayName());

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -2786,18 +2786,9 @@ public class UserController extends SpringActionController
     }
 
 
-    @RequiresPermission(ImpersonatePermission.class)
+    @RequiresNoPermission // getValidImpersonationUsers() does all permission checking
     public static class GetImpersonationUsersAction extends MutatingApiAction<Object>
     {
-        @Override
-        public void checkPermissions() throws UnauthorizedException
-        {
-            // Impersonating troubleshooter role is restricted to the root, but, as a convenience, we let them
-            // impersonate from any container.
-            if (!getUser().hasRootPermission(ImpersonatePermission.class))
-                super.checkPermissions();
-        }
-
         @Override
         public ApiResponse execute(Object object, BindException errors)
         {
@@ -2888,7 +2879,7 @@ public class UserController extends SpringActionController
         public abstract @Nullable String impersonate(FORM form);
     }
 
-    @RequiresPermission(ImpersonatePermission.class)
+    @RequiresNoPermission
     public static class ImpersonateUserAction extends ImpersonateApiAction<ImpersonateUserForm>
     {
         @Override
@@ -2972,7 +2963,7 @@ public class UserController extends SpringActionController
 
     // TODO: Better instructions
     // TODO: Messages for no groups, no users
-    @RequiresPermission(ImpersonatePermission.class)
+    @RequiresNoPermission
     public static class ImpersonateGroupAction extends ImpersonateApiAction<ImpersonateGroupForm>
     {
         @Override
@@ -3247,6 +3238,15 @@ public class UserController extends SpringActionController
 
             UserController controller = new UserController();
 
+            assertForNoPermission(user,
+                new GetImpersonationUsersAction(),
+                new ImpersonateUserAction(),
+                new GetImpersonationGroupsAction(),
+                new ImpersonateGroupAction(),
+                controller.new GetImpersonationRolesAction(),
+                controller.new ImpersonateRolesAction()
+            );
+
             // @RequiresPermission(ReadPermission.class)
             assertForReadPermission(user, false,
                 new BeginAction(),
@@ -3256,15 +3256,9 @@ public class UserController extends SpringActionController
 
             // @RequiresPermission(AdminPermission.class)
             assertForAdminPermission(user,
-                controller.new ShowUsersAction(),
+                controller.new ShowUsersAction()
                 //TODO controller.new ShowUserHistoryAction(),
                 //TODO controller.new UserAccessAction(),
-                new GetImpersonationUsersAction(),
-                    new ImpersonateUserAction(),
-                    new GetImpersonationGroupsAction(),
-                    new ImpersonateGroupAction()
-//                controller.new GetImpersonationRolesAction()   Annotated as "no permission", to allow impersonation adjustments
-//                controller.new ImpersonateRolesAction()        Annotated as "no permission", to allow impersonation adjustments
             );
 
             // @RequiresPermission(UserManagementPermission.class)

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -105,8 +105,8 @@ import org.labkey.api.security.permissions.AddUserPermission;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.CanAccessLockedProjectsPermission;
-import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
 import org.labkey.api.security.permissions.DeleteUserPermission;
+import org.labkey.api.security.permissions.ImpersonatePermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdateUserPermission;
@@ -896,7 +896,7 @@ public class UserController extends SpringActionController
 
 
     @RequiresPermission(AdminPermission.class)
-    public class ShowUserHistoryAction extends SimpleViewAction
+    public class ShowUserHistoryAction extends SimpleViewAction<Object>
     {
         @Override
         public void checkPermissions() throws UnauthorizedException
@@ -2786,18 +2786,25 @@ public class UserController extends SpringActionController
     }
 
 
-    @RequiresPermission(AdminPermission.class)
+    @RequiresPermission(ImpersonatePermission.class)
     public static class GetImpersonationUsersAction extends MutatingApiAction<Object>
     {
+        @Override
+        public void checkPermissions() throws UnauthorizedException
+        {
+            // Impersonating troubleshooter role is restricted to the root, but, as a convenience, we let them
+            // impersonate from any container.
+            if (!getUser().hasRootPermission(ImpersonatePermission.class))
+                super.checkPermissions();
+        }
+
         @Override
         public ApiResponse execute(Object object, BindException errors)
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
 
             User currentUser = getUser();
-            Container project = currentUser.hasRootAdminPermission() ? null : getContainer().getProject();
-            Collection<User> users = UserImpersonationContextFactory.getValidImpersonationUsers(project, getUser());
-
+            Collection<User> users = UserImpersonationContextFactory.getValidImpersonationUsers(getContainer().getProject(), currentUser);
             Collection<Map<String, Object>> responseUsers = new LinkedList<>();
 
             for (User user : users)
@@ -2849,6 +2856,15 @@ public class UserController extends SpringActionController
     private abstract static class ImpersonateApiAction<FORM> extends MutatingApiAction<FORM>
     {
         @Override
+        public void checkPermissions() throws UnauthorizedException
+        {
+            // Impersonating troubleshooter role is restricted to the root, but, as a convenience, we let them
+            // impersonate from any container.
+            if (!getUser().hasRootPermission(ImpersonatePermission.class))
+                super.checkPermissions();
+        }
+
+        @Override
         protected String getCommandClassMethodName()
         {
             return "impersonate";
@@ -2872,9 +2888,8 @@ public class UserController extends SpringActionController
         public abstract @Nullable String impersonate(FORM form);
     }
 
-
-    @RequiresPermission(AdminPermission.class)
-    public class ImpersonateUserAction extends ImpersonateApiAction<ImpersonateUserForm>
+    @RequiresPermission(ImpersonatePermission.class)
+    public static class ImpersonateUserAction extends ImpersonateApiAction<ImpersonateUserForm>
     {
         @Override
         public @Nullable String impersonate(ImpersonateUserForm form)
@@ -2912,8 +2927,8 @@ public class UserController extends SpringActionController
         }
     }
 
-
-    @RequiresPermission(AdminPermission.class)
+    // getValidImpersonationGroups() checks permissions and returns empty for user who can't impersonate
+    @RequiresNoPermission
     public static class GetImpersonationGroupsAction extends MutatingApiAction<Object>
     {
         @Override
@@ -2957,8 +2972,8 @@ public class UserController extends SpringActionController
 
     // TODO: Better instructions
     // TODO: Messages for no groups, no users
-    @RequiresPermission(AdminPermission.class)
-    public class ImpersonateGroupAction extends ImpersonateApiAction<ImpersonateGroupForm>
+    @RequiresPermission(ImpersonatePermission.class)
+    public static class ImpersonateGroupAction extends ImpersonateApiAction<ImpersonateGroupForm>
     {
         @Override
         public @Nullable String impersonate(ImpersonateGroupForm form)
@@ -3003,7 +3018,7 @@ public class UserController extends SpringActionController
 
             User user = context.isImpersonating() ? context.getAdminUser() : getUser();
             ApiSimpleResponse response = new ApiSimpleResponse();
-            Collection<Map<String, Object>> responseRoles = RoleImpersonationContextFactory.getValidImpersonationRoles(getContainer(), user)
+            Collection<Map<String, Object>> responseRoles = RoleImpersonationContextFactory.filterImpersonationRoles(getContainer(), user, RoleManager.getAllRoles()).stream()
                 .map(role -> {
                     Map<String, Object> map = new HashMap<>();
                     map.put("displayName", role.getDisplayName());
@@ -3029,10 +3044,10 @@ public class UserController extends SpringActionController
         if (context.isImpersonating())
             user = context.getAdminUser();
 
-        if (getContainer().isRoot() && user.hasRootPermission(CanImpersonateSiteRolesPermission.class))
+        if (user.hasRootPermission(ImpersonatePermission.class))
             return context;
 
-        if (!getContainer().hasPermission(user, AdminPermission.class))
+        if (!getContainer().hasPermission(user, ImpersonatePermission.class))
             throw new UnauthorizedException();
 
         return context;
@@ -3245,9 +3260,9 @@ public class UserController extends SpringActionController
                 //TODO controller.new ShowUserHistoryAction(),
                 //TODO controller.new UserAccessAction(),
                 new GetImpersonationUsersAction(),
-                controller.new ImpersonateUserAction(),
+                    new ImpersonateUserAction(),
                     new GetImpersonationGroupsAction(),
-                controller.new ImpersonateGroupAction()
+                    new ImpersonateGroupAction()
 //                controller.new GetImpersonationRolesAction()   Annotated as "no permission", to allow impersonation adjustments
 //                controller.new ImpersonateRolesAction()        Annotated as "no permission", to allow impersonation adjustments
             );

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -98,6 +98,7 @@ import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.ValidEmail.InvalidEmailException;
 import org.labkey.api.security.impersonation.GroupImpersonationContextFactory;
 import org.labkey.api.security.impersonation.RoleImpersonationContextFactory;
+import org.labkey.api.security.impersonation.RoleImpersonationContextFactory.RoleImpersonationContext;
 import org.labkey.api.security.impersonation.UnauthorizedImpersonationException;
 import org.labkey.api.security.impersonation.UserImpersonationContextFactory;
 import org.labkey.api.security.permissions.AbstractActionPermissionTest;
@@ -2943,7 +2944,6 @@ public class UserController extends SpringActionController
         }
     }
 
-
     public static class ImpersonateGroupForm extends ReturnUrlForm
     {
         private Integer _groupId = null;
@@ -2959,7 +2959,6 @@ public class UserController extends SpringActionController
             _groupId = groupId;
         }
     }
-
 
     // TODO: Better instructions
     // TODO: Messages for no groups, no users
@@ -2997,15 +2996,16 @@ public class UserController extends SpringActionController
         }
     }
 
-
     @RequiresNoPermission
-    public class GetImpersonationRolesAction extends MutatingApiAction<Object>
+    public static class GetImpersonationRolesAction extends MutatingApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object object, BindException errors)
         {
-            PermissionsContext context = authorizeImpersonateRoles();
-            Set<Role> impersonationRoles = context.isImpersonating() ? context.getAssignedRoles(getUser(), getContainer()).collect(Collectors.toSet()) : Collections.emptySet();
+            PermissionsContext context = getUser().getPermissionsContext();
+            Set<Role> currentRoles = context.isImpersonating() && context instanceof RoleImpersonationContext ?
+                context.getAssignedRoles(getUser(), getContainer()).collect(Collectors.toSet()) :
+                Collections.emptySet();
 
             User user = context.isImpersonating() ? context.getAdminUser() : getUser();
             ApiSimpleResponse response = new ApiSimpleResponse();
@@ -3015,7 +3015,7 @@ public class UserController extends SpringActionController
                     map.put("displayName", role.getDisplayName());
                     map.put("roleName", role.getUniqueName());
                     map.put("hasRead", role.getPermissions().contains(ReadPermission.class));
-                    map.put("selected", impersonationRoles.contains(role));
+                    map.put("selected", currentRoles.contains(role));
                     return map;
                 })
                 .toList();
@@ -3026,25 +3026,6 @@ public class UserController extends SpringActionController
         }
     }
 
-
-    private PermissionsContext authorizeImpersonateRoles()
-    {
-        User user = getUser();
-        PermissionsContext context = user.getPermissionsContext();
-
-        if (context.isImpersonating())
-            user = context.getAdminUser();
-
-        if (user.hasRootPermission(ImpersonatePermission.class))
-            return context;
-
-        if (!getContainer().hasPermission(user, ImpersonatePermission.class))
-            throw new UnauthorizedException();
-
-        return context;
-    }
-
-
     public static class ImpersonateRolesForm extends ReturnUrlForm
     {
         private String[] _roleNames;
@@ -3054,23 +3035,26 @@ public class UserController extends SpringActionController
             return _roleNames;
         }
 
+        @SuppressWarnings("unused")
         public void setRoleNames(String[] roleNames)
         {
             _roleNames = roleNames;
         }
     }
 
-
-    // Permissions are checked in impersonate() to let an admin adjust an existing impersonation
+    // Permissions are checked by the RoleImpersonationFactory. This lets impersonators adjust an existing impersonation
+    // and impersonating troubleshooters impersonate in projects and folders.
     @RequiresNoPermission
-    public class ImpersonateRolesAction extends ImpersonateApiAction<ImpersonateRolesForm>
+    public static class ImpersonateRolesAction extends ImpersonateApiAction<ImpersonateRolesForm>
     {
         @Nullable
         @Override
         public String impersonate(ImpersonateRolesForm form)
         {
-            PermissionsContext context = authorizeImpersonateRoles();
-            Set<Role> currentImpersonationRoles = context.isImpersonating() ? context.getAssignedRoles(getUser(), getContainer()).collect(Collectors.toSet()) : Collections.emptySet();
+            PermissionsContext context = getUser().getPermissionsContext();
+            Set<Role> currentImpersonationRoles = context.isImpersonating() && context instanceof RoleImpersonationContext ?
+                context.getAssignedRoles(getUser(), getContainer()).collect(Collectors.toSet()) :
+                Collections.emptySet();
 
             String[] roleNames = form.getRoleNames();
 
@@ -3243,8 +3227,8 @@ public class UserController extends SpringActionController
                 new ImpersonateUserAction(),
                 new GetImpersonationGroupsAction(),
                 new ImpersonateGroupAction(),
-                controller.new GetImpersonationRolesAction(),
-                controller.new ImpersonateRolesAction()
+                new GetImpersonationRolesAction(),
+                new ImpersonateRolesAction()
             );
 
             // @RequiresPermission(ReadPermission.class)

--- a/core/webapp/Impersonate.js
+++ b/core/webapp/Impersonate.js
@@ -35,7 +35,7 @@ Ext4.define('LABKEY.Security.ImpersonateUser', {
 
     getPanel: function(){
         var instructions = LABKEY.Security.currentUser.isRootAdmin ?
-            "As a site or application administrator, you can impersonate any user on the site." +
+            "As a site administrator, application administrator, or impersonating troubleshooter, you can impersonate any user on the site." +
             (!LABKEY.Security.currentUser.isSystemAdmin ? " While impersonating you will not inherit the user's "
                 + "site-level roles (e.g., Site Administrator, Developer)." : "") :
 
@@ -191,7 +191,7 @@ Ext4.define('LABKEY.Security.ImpersonateGroup', {
 
     getPanel: function(){
         var instructions = LABKEY.Security.currentUser.isRootAdmin ?
-            "As a site or application administrator, you can impersonate any site or project group." :
+            "As a site administrator, application administrator, or impersonating troubleshooter, you can impersonate any site or project group." :
             "As a project administrator, you can impersonate any project group in this project or any site group in which you're member. While impersonating you will be restricted to this project.";
 
         var divContainer = Ext4.create('Ext.container.Container', {
@@ -315,7 +315,7 @@ Ext4.define('LABKEY.Security.ImpersonateRoles', {
 
     getPanel: function(){
         var instructions = LABKEY.Security.currentUser.canImpersonateSiteRoles ?
-            "As a site administrator, application administrator, or impersonating troubleshooter you can impersonate one or more security roles. While impersonating you will have access to " +
+            "As a site administrator, application administrator, or impersonating troubleshooter, you can impersonate one or more security roles. While impersonating you will have access to " +
                 "the entire site, limited to the permissions provided by the selected roles(s)." :
             "As a project administrator, you can impersonate one or more security roles. While impersonating you will be restricted to this project.";
 


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/837

#### Changes
- The main functional change is that Impersonating Troubleshooters can now impersonate users and groups in the root. If they happen to have read permissions in a project or folder, they can impersonate users, groups, and roles there as well.
- Internally, I've reworked impersonation permissions checking to eliminate duplicate checks. A new `ImpersonatePermission` class is now used instead of `AdminPermission` as the primary check. Action-level and manager permission checking has been removed; all permission checking is performed by each impersonation context for simplicity and consistency.
- ImpersonationTest junit test has been added to exercise and verify user, group, and role impersonation permissions rules.
- App Admins can now impersonate groups that are assigned privileged roles (Site Admin, Platform Developer, Impersonating Troubleshooter), although all privileged roles are filtered out by `GroupImpersonationContext`. This matches the behavior of when they impersonate a privileged user.
- Project Admins can now impersonate any user who has read permissions in the project. This eliminates one use of the antiquated "project users" notion. This filtering is a convenience and not a security restriction. (I can grant any user read permission in my project and then impersonate them.) For partitioned sites like Atlas, showing the whole user list to a project admin would be inconvenient. Plus, there's not much value in impersonating a user who doesn't have read permissions in the project.
- Document detailed impersonation rules via a comment in `AbstractImpersonationContext`.
- I also renamed a method, a class name, and a term for clarity:
  - `AbstractRootContainerRole.isAvailableEverywhere()` --> `isApplicableOutsideRoot()`
  - `CanImpersonatePrivilegedSiteRolesPermission` --> `ImpersonatePrivilegedSiteRolesPermission`
  - `wild-card` or `wild card` --> `wildcard`