### PR TITLE
Deprecate R report sharing

### DIFF
--- a/api/src/org/labkey/api/reports/ReportService.java
+++ b/api/src/org/labkey/api/reports/ReportService.java
@@ -47,6 +47,8 @@ import java.util.List;
 
 public interface ReportService
 {
+    String R_REPORT_CUSTOM_SHARING = "rReportCustomSharing";
+
     // this logger is to enable all report loggers in the admin ui (org.labkey.api.reports.*)
     @SuppressWarnings({"UnusedDeclaration", "SSBasedInspection"})
     Logger packageLogger = LogManager.getLogger(ReportService.class.getPackageName());

--- a/api/src/org/labkey/api/reports/report/r/RReport.java
+++ b/api/src/org/labkey/api/reports/report/r/RReport.java
@@ -46,6 +46,7 @@ import org.labkey.api.reports.report.view.ScriptReportBean;
 import org.labkey.api.rstudio.RStudioService;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.thumbnail.Thumbnail;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
@@ -73,6 +74,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static org.labkey.api.reports.ReportService.R_REPORT_CUSTOM_SHARING;
 
 public class RReport extends ExternalScriptEngineReport
 {
@@ -925,8 +928,12 @@ public class RReport extends ExternalScriptEngineReport
     @Override
     public boolean allowShareButton(User user, Container container)
     {
-        // allow sharing if this R report is a DB report and the user canShare
-        return !getDescriptor().isModuleBased() && canShare(user, container);
+        if (OptionalFeatureService.get().isFeatureEnabled(R_REPORT_CUSTOM_SHARING))
+        {
+            // allow sharing if this R report is a DB report and the user canShare
+            return !getDescriptor().isModuleBased() && canShare(user, container);
+        }
+        return false;
     }
 
     public static class TestCase extends Assert

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -31,6 +31,7 @@ import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.views.DataViewService;
 import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.mcp.McpService;
 import org.labkey.api.message.digest.DailyMessageDigest;
 import org.labkey.api.message.digest.ReportAndDatasetChangeDigestProvider;
 import org.labkey.api.migration.DatabaseMigrationService;
@@ -40,7 +41,6 @@ import org.labkey.api.module.AdminLinkManager;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleContext;
-import org.labkey.api.mcp.McpService;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.JavaExportScriptFactory;
@@ -77,6 +77,7 @@ import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.PlatformDeveloperRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
+import org.labkey.api.settings.OptionalFeatureFlag;
 import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.stats.AnalyticsProviderRegistry;
 import org.labkey.api.stats.SummaryStatisticRegistry;
@@ -145,6 +146,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.labkey.api.query.QueryService.USE_ROW_BY_ROW_UPDATE;
+import static org.labkey.query.reports.ReportServiceImpl.R_REPORT_CUSTOM_SHARING;
 
 public class QueryModule extends DefaultModule
 {
@@ -346,6 +348,13 @@ public class QueryModule extends DefaultModule
         Role trustedAnalystRole = RoleManager.getRole("org.labkey.api.security.roles.TrustedAnalystRole");
         if (null != trustedAnalystRole)
             trustedAnalystRole.addPermission(EditQueriesPermission.class);
+
+        OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(R_REPORT_CUSTOM_SHARING,
+                "Restore custom R report sharing",
+                "Allows R reports to be shared on a per user basis. This option will be removed in LabKey Server 26.7.",
+                false,
+                false,
+                OptionalFeatureService.FeatureType.Deprecated));
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Puts the R report sharing UI under a deprecated feature flag. We'll plan to remove this feature in `26.7`.

