### PR TITLE
Update activemq dependency to 5.19.2

### DIFF
--- a/pipeline/gradle.properties
+++ b/pipeline/gradle.properties
@@ -1,4 +1,4 @@
-activemqVersion=5.18.7
+activemqVersion=5.19.2
 
 geronimoJ2eeConnector15SpecVersion=1.0.1
 


### PR DESCRIPTION
#### Rationale
Latest ActiveMQ `5.*` release.

#### Related Pull Requests
- N/A

#### Changes
- Update activemq dependency to 5.19.2