### PR TITLE
Conditionalize postgres-specific upgrade checks

### DIFF
--- a/core/test/src/org/labkey/test/tests/upgrade/EncryptionKeyUpgradeTest.java
+++ b/core/test/src/org/labkey/test/tests/upgrade/EncryptionKeyUpgradeTest.java
@@ -3,6 +3,8 @@ package org.labkey.test.tests.upgrade;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.Locators;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.WebTestHelper.DatabaseType;
 import org.labkey.test.pages.ConfigureReportsAndScriptsPage;
 import org.labkey.test.pages.ConfigureReportsAndScriptsPage.EngineType;
 import org.labkey.test.pages.admin.RConfigurationPage;
@@ -42,10 +44,13 @@ public class EncryptionKeyUpgradeTest extends BaseUpgradeTest
                 .setEngineOverrides(DUMMY_R_SERVE, DUMMY_R_SERVE)
                 .save();
 
-        // Set StatusCake api key
-        EditUpgradeMessagePage.beginAt(this)
-                .setStatusCakeApiKey("password")
-                .save();
+        if (WebTestHelper.getDatabaseType() == DatabaseType.PostgreSQL)
+        {
+            // Set StatusCake api key
+            EditUpgradeMessagePage.beginAt(this)
+                    .setStatusCakeApiKey("password")
+                    .save();
+        }
     }
 
     @Test
@@ -64,9 +69,12 @@ public class EncryptionKeyUpgradeTest extends BaseUpgradeTest
     @Test
     public void testStatusCakeApiKey()
     {
-        // Just loading this page can trigger an error if there was a problem with the encryption
-        assertEquals("StatusCake API key input should be present but blank",
-                "", EditUpgradeMessagePage.beginAt(this).getStatusCakeApiKey());
+        if (WebTestHelper.getDatabaseType() == DatabaseType.PostgreSQL)
+        {
+            // Just loading this page can trigger an error if there was a problem with the encryption
+            assertEquals("StatusCake API key input should be present but blank",
+                    "", EditUpgradeMessagePage.beginAt(this).getStatusCakeApiKey());
+        }
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Setting up a SQL Migration test pipeline using our existing upgrade tests. Some parts require postgres and should be skipped otherwise.

#### Related Pull Requests
- N/A

#### Changes
- Conditionalize postgres-specific checks