### PR TITLE
Make EncryptionKeyUpgradeTest work when '_mothership' project is missing

### DIFF
--- a/core/test/src/org/labkey/test/tests/upgrade/EncryptionKeyUpgradeTest.java
+++ b/core/test/src/org/labkey/test/tests/upgrade/EncryptionKeyUpgradeTest.java
@@ -73,7 +73,7 @@ public class EncryptionKeyUpgradeTest extends BaseUpgradeTest
         {
             // Just loading this page can trigger an error if there was a problem with the encryption
             assertEquals("StatusCake API key input should be present but blank",
-                    "", EditUpgradeMessagePage.beginAt(this).getStatusCakeApiKey());
+                    "", EditUpgradeMessagePage.beginAt(this, null).getStatusCakeApiKey()); // Use the root container in case the '_mothership' project doesn't exist
         }
     }
 


### PR DESCRIPTION
#### Rationale
After migrating from SQL Server, the `_mothership` project won't exist. `mothership-editUpgradeMessage.view` doesn't do any container-specific operations; it doesn't really matter what container you visit from so `EncryptionKeyUpgradeTest.testStatusCakeApiKey` can use the root container for that action.

#### Related Pull Requests
- N/A

#### Changes
- Make EditUpgradeMessage work when '_mothership' project is missing