### PR TITLE
Empty line with mvtc column should be treated as empty line

### DIFF
--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -729,6 +729,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
                 boolean foundData = false;
                 for (int i = 0; i < _activeColumns.length; i++)
                 {
+                    boolean isEmptyArray = false;
                     ColumnDescriptor column = _activeColumns[i];
                     if (_preserveEmptyString && null == column.missingValues)
                     {
@@ -831,6 +832,12 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
                             // GitHub Issue 925: Not providing a MVTC value in an assay result throws error
                             // convert blank to empty array, not null
                             values[i] = column.converter.convert(column.clazz, fld);
+                            if (values[i] instanceof MultiChoice.Array array)
+                            {
+                                // If line is blank, array will be empty array instead of null
+                                if (array.isEmpty())
+                                    isEmptyArray = true;
+                            }
                         }
                         else
                         {
@@ -878,7 +885,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
                             values[i] = column.errorValues;
                     }
 
-                    if (values[i] != null)
+                    if (values[i] != null && !isEmptyArray)
                         foundData = true;
                 }
 

--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -832,7 +832,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
                             // GitHub Issue 925: Not providing a MVTC value in an assay result throws error
                             // convert blank to empty array, not null
                             values[i] = column.converter.convert(column.clazz, fld);
-                            if (values[i] instanceof MultiChoice.Array array)
+                            if (values[i] instanceof MultiChoice.Array array) // TODO: make this more generic? instanceof List and/or instanceof java.sql.Array?
                             {
                                 // If line is blank, array will be empty array instead of null
                                 if (array.isEmpty())


### PR DESCRIPTION
#### Rationale
Blank MVTC will be parsed as empty array [] during import. This resulted in blank row being treated as a nonblank row with non-null MVTC field. Empty MV array should not flag a line as non blank. 

[SMSampleTypeMultiChoiceTest](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SampleManagerFPostgres/3890598?buildTab=tests&status=failed&name=SMSampleTypeMultiChoiceTest) & [SMSourceTypeMultiChoiceTest](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SampleManagerGPostgres/3890599?buildTab=tests&status=failed&name=SMSourceTypeMultiChoiceTest)
Extra lines in the Excel file are creating unexpected rows during import.
#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7490

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->