### PR TITLE
GitHub 895: Search: Over indexing Assay Batch

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpProtocol.java
+++ b/api/src/org/labkey/api/exp/api/ExpProtocol.java
@@ -99,7 +99,7 @@ public interface ExpProtocol extends ExpObject
     String getContact();
 
     List<? extends ExpProtocol> getChildProtocols();
-    List<? extends ExpExperiment> getBatches();
+    List<? extends ExpExperiment> getBatches(@Nullable Container c);
 
     void setEntityId(String entityId);
     String getEntityId();

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -379,12 +379,25 @@ public class AssayManager implements AssayService
     @Override
     public @NotNull List<ExpProtocol> getAssayProtocols(Container container)
     {
+        return getAssayProtocols(container, false);
+    }
+
+    private @NotNull List<ExpProtocol> getAssayProtocols(Container container, boolean currentOnly)
+    {
         List<ExpProtocol> allProtocols = new ArrayList<>();
 
-        for (Container containerInScope : container.getContainersFor(ContainerType.DataType.protocol))
+        if (currentOnly)
         {
-            List<ExpProtocol> ids = PROTOCOL_CACHE.get(containerInScope);
+            List<ExpProtocol> ids = PROTOCOL_CACHE.get(container);
             allProtocols.addAll(ids);
+        }
+        else
+        {
+            for (Container containerInScope : container.getContainersFor(ContainerType.DataType.protocol))
+            {
+                List<ExpProtocol> ids = PROTOCOL_CACHE.get(containerInScope);
+                allProtocols.addAll(ids);
+            }
         }
 
         Collections.sort(allProtocols);
@@ -622,14 +635,14 @@ public class AssayManager implements AssayService
     }
 
     /**
-     * Creates a single document per assay design/folder combo, with some simple assay info (name, description), plus
-     * the names and comments from all the runs.
+     * Creates a single document per assay design, with some simple assay info (name, description).
+     * Note: the document for an assay protocol will just be associated with the protocol's container
      */
     @Override
     public void indexAssays(SearchService.TaskIndexingQueue queue)
     {
-        List<ExpProtocol> protocols = getAssayProtocols(queue.getContainer());
-
+        // GitHub Issue 895: for the assay protocol search document just user the current container's protocols
+        List<ExpProtocol> protocols = getAssayProtocols(queue.getContainer(), true);
         for (ExpProtocol protocol : protocols)
             indexAssay(queue, protocol);
     }
@@ -728,7 +741,7 @@ public class AssayManager implements AssayService
     {
         if (shouldIndexProtocolBatches(protocol))
         {
-            for (ExpExperiment batch : protocol.getBatches())
+            for (ExpExperiment batch : protocol.getBatches(queue.getContainer()))
             {
                 if (modifiedSince == null || modifiedSince.before(batch.getModified()))
                     indexAssayBatch(queue, batch);

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -674,22 +674,6 @@ public class AssayManager implements AssayService
         m.put(SearchService.PROPERTY.keywordsMed.toString(), keywords);
         m.put(SearchService.PROPERTY.categories.toString(), ASSAY_CATEGORY.getName());
 
-        ExperimentService.get().getExpRuns(c, protocol, null)
-            .forEach(run -> {
-                StringBuilder runKeywords = new StringBuilder();
-
-                runKeywords.append(" ");
-                runKeywords.append(run.getName());
-
-                if (null != run.getComments())
-                {
-                    runKeywords.append(" ");
-                    runKeywords.append(run.getComments());
-                }
-
-                body.append(runKeywords);
-            });
-
         String docId = protocol.getDocumentId();
         WebdavResource r = new SimpleDocumentResource(new Path(docId), docId, c.getEntityId(), "text/plain", body.toString(), assayBeginURL, createdBy, created, modifiedBy, modified, m);
         queue.addResource(r);

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -386,18 +386,11 @@ public class AssayManager implements AssayService
     {
         List<ExpProtocol> allProtocols = new ArrayList<>();
 
-        if (currentOnly)
+        Collection<Container> containerScopes = currentOnly ? List.of(container) : container.getContainersFor(ContainerType.DataType.protocol);
+        for (Container containerInScope : containerScopes)
         {
-            List<ExpProtocol> ids = PROTOCOL_CACHE.get(container);
+            List<ExpProtocol> ids = PROTOCOL_CACHE.get(containerInScope);
             allProtocols.addAll(ids);
-        }
-        else
-        {
-            for (Container containerInScope : container.getContainersFor(ContainerType.DataType.protocol))
-            {
-                List<ExpProtocol> ids = PROTOCOL_CACHE.get(containerInScope);
-                allProtocols.addAll(ids);
-            }
         }
 
         Collections.sort(allProtocols);

--- a/experiment/src/org/labkey/experiment/api/ExpProtocolImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpProtocolImpl.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.Filter;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlSelector;

--- a/experiment/src/org/labkey/experiment/api/ExpProtocolImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpProtocolImpl.java
@@ -329,9 +329,12 @@ public class ExpProtocolImpl extends ExpIdentifiableEntityImpl<Protocol> impleme
     }
 
     @Override
-    public List<ExpExperimentImpl> getBatches()
+    public List<ExpExperimentImpl> getBatches(@Nullable Container c)
     {
-        Filter filter = new SimpleFilter(FieldKey.fromParts("BatchProtocolId"), getRowId());
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("BatchProtocolId"), getRowId());
+        // GitHub Issue 895: add param option to get just the assay batches for a specific container
+        if (c != null)
+            filter.addCondition(FieldKey.fromParts("container"), c);
         return ExpExperimentImpl.fromExperiments(new TableSelector(ExperimentServiceImpl.get().getTinfoExperiment(), filter, null).getArray(Experiment.class));
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4528,7 +4528,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
             for (ExpProtocol protocolToDelete : expProtocols)
             {
-                for (ExpExperiment batch : protocolToDelete.getBatches())
+                for (ExpExperiment batch : protocolToDelete.getBatches(null))
                 {
                     batch.delete(user);
                 }


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/895

When enumerating documents for search, we are getting all in-scope assay protocols for a given container (which includes the current container plus project and shared containers). We are then getting all assay batches for those protocols and indexing them. This means that for every container where an assay protocol is in-scope, all assay batches for that protocol are getting indexed. This PR updates that to do the same as the assay run document provider and filter the "get runs" call to just those assay runs in the given container.

#### Changes
- Assay batch search indexing to include container filtering to prevent indexing all batches for an assay protocol for all containers in scope
- Assay design search document provider update to not include run info