### PR TITLE
CAS IdP page now informs about redirect hosts requirement

### DIFF
--- a/api/src/org/labkey/api/admin/AdminUrls.java
+++ b/api/src/org/labkey/api/admin/AdminUrls.java
@@ -67,6 +67,8 @@ public interface AdminUrls extends UrlProvider
     ActionURL getSystemMaintenanceURL();
     ActionURL getCspReportToURL();
 
+    ActionURL getAllowedExternalRedirectHostsURL();
+
     /**
      * Simply adds an "Admin Console" link to nav trail if invoked in the root container. Otherwise, root is unchanged.
      */

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -891,6 +891,13 @@ public class AdminController extends SpringActionController
             return new ActionURL(ContentSecurityPolicyReportToAction.class, ContainerManager.getRoot());
         }
 
+        @Override
+        public ActionURL getAllowedExternalRedirectHostsURL()
+        {
+            return new ActionURL(AllowListAction.class, ContainerManager.getRoot())
+                .addParameter("type", AllowListType.Redirect.name());
+        }
+
         public static ActionURL getDeprecatedFeaturesURL()
         {
             return new ActionURL(OptionalFeaturesAction.class, ContainerManager.getRoot()).addParameter("type", FeatureType.Deprecated.name());


### PR DESCRIPTION
#### Rationale
Simply adds a note with a link to the CAS Identity Provider page: "Note that you must add the host names for every service that uses this CAS identity provider to the Allowed Redirect Hosts list."

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/485