### PR TITLE
GitHub Issue 946: SQLException logged when saved filter includes MVTC specific filters and field is no longer MVTC

### DIFF
--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -1003,6 +1003,10 @@ public abstract class CompareType
                 return null;
 
             ColumnInfo colInfo = columnMap != null ? columnMap.get(_fieldKey) : null;
+
+            if (colInfo != null && colInfo.getJdbcType() != JdbcType.ARRAY)
+                throw new RuntimeSQLException(new SQLGenerationException("Invalid filter type for column '" + _fieldKey.toDisplayString() + "'."));
+
             var alias = SimpleFilter.getAliasForColumnFilter(dialect, colInfo, _fieldKey);
 
             SQLFragment valuesFragment = dialect.array_construct(paramValues);
@@ -1040,6 +1044,10 @@ public abstract class CompareType
         public SQLFragment toSQLFragment(Map<FieldKey, ? extends ColumnInfo> columnMap, SqlDialect dialect)
         {
             ColumnInfo colInfo = columnMap != null ? columnMap.get(_fieldKey) : null;
+
+            if (colInfo != null && colInfo.getJdbcType() != JdbcType.ARRAY)
+                throw new RuntimeSQLException(new SQLGenerationException("Invalid filter type for column '" + _fieldKey.toDisplayString() + "'."));
+
             var alias = SimpleFilter.getAliasForColumnFilter(dialect, colInfo, _fieldKey);
 
             SQLFragment columnFragment = new SQLFragment().appendIdentifier(alias);
@@ -1747,6 +1755,9 @@ public abstract class CompareType
         public SQLFragment toSQLFragment(Map<FieldKey, ? extends ColumnInfo> columnMap, SqlDialect dialect)
         {
             ColumnInfo colInfo = columnMap != null ? columnMap.get(_fieldKey) : null;
+            if (colInfo != null && colInfo.getJdbcType() == JdbcType.ARRAY)
+                throw new RuntimeSQLException(new SQLGenerationException("Invalid filter type for column '" + _fieldKey.toDisplayString() + "'."));
+
             var alias = SimpleFilter.getAliasForColumnFilter(dialect, colInfo, _fieldKey);
 
             SQLFragment fragment = toWhereClause(dialect, alias);

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -2654,7 +2654,7 @@ public class DataRegion extends DisplayElement
                 StringBuilder msg;
                 if (ignoredColumns.size() == 1)
                 {
-                    msg = new StringBuilder("Ignoring filter/sort on column '" + ignoredColumns.iterator().next().toDisplayString() + "' because it does not exist.");
+                    msg = new StringBuilder("Ignoring filter/sort on column '" + ignoredColumns.iterator().next().toDisplayString() + "' because it does not exist or the filter type is invalid.");
                 }
                 else
                 {
@@ -2666,7 +2666,7 @@ public class DataRegion extends DisplayElement
                         sep = ", ";
                         msg.append("'").append(fieldKey.toDisplayString()).append("'");
                     }
-                    msg.append(" because they do not exist.");
+                    msg.append(" because they do not exist or the filter types are invalid.");
                 }
 
                 addMessage(new Message(msg.toString(), MessageType.WARNING, "filter"));

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -2055,10 +2055,12 @@ public class QueryServiceImpl implements QueryService
                 for (SimpleFilter.FilterClause clause : filterClauses)
                 {
                     boolean isArrayFilter = clause instanceof CompareType.ArrayClause;
-                    if (isArrayColumn && !isArrayFilter)
-                        throw new ApiUsageException("Array column '" + fieldKey + "' requires an array filter type");
-                    if (!isArrayColumn && isArrayFilter)
-                        throw new ApiUsageException("Non-array column '" + fieldKey + "' cannot use an array filter type");
+                    boolean invalidArrayFilter = (isArrayFilter && !isArrayColumn) || (!isArrayFilter && isArrayColumn);
+                    if (invalidArrayFilter)
+                    {
+                        unresolvedColumns.add(fieldKey);
+                        return column; // return column, but mark as unresolvedColumns to drop filters
+                    }
                 }
             }
 

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.audit.AbstractAuditHandler;
 import org.labkey.api.audit.AuditHandler;
@@ -1902,7 +1903,7 @@ public class QueryServiceImpl implements QueryService
                 continue;
             for (FieldKey fieldKey : set)
             {
-                ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager);
+                ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager, null);
                 if (col != null)
                     ret.putIfAbsent(col.getFieldKey(),col);
             }
@@ -1911,11 +1912,29 @@ public class QueryServiceImpl implements QueryService
 
         if (filter != null)
         {
-            for (FieldKey fieldKey : filter.getWhereParamFieldKeys())
+            if (filter instanceof SimpleFilter simpleFilter)
             {
-                ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager);
-                if (col != null)
-                    ret.putIfAbsent(col.getFieldKey(),col);
+                Map<FieldKey, List<SimpleFilter.FilterClause>> clausesByField = new HashMap<>();
+                for (SimpleFilter.FilterClause clause : simpleFilter.getClauses())
+                {
+                    for (FieldKey fk : clause.getFieldKeys())
+                        clausesByField.computeIfAbsent(fk, k -> new ArrayList<>()).add(clause);
+                }
+                for (FieldKey fieldKey : simpleFilter.getWhereParamFieldKeys())
+                {
+                    ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager, clausesByField.get(fieldKey));
+                    if (col != null)
+                        ret.putIfAbsent(col.getFieldKey(), col);
+                }
+            }
+            else
+            {
+                for (FieldKey fieldKey : filter.getWhereParamFieldKeys())
+                {
+                    ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager, null);
+                    if (col != null)
+                        ret.putIfAbsent(col.getFieldKey(), col);
+                }
             }
         }
 
@@ -1923,7 +1942,7 @@ public class QueryServiceImpl implements QueryService
         {
             for (Sort.SortField field : sort.getSortList())
             {
-                ColumnInfo col = resolveFieldKey(field.getFieldKey(), table, columnMap, unresolvedColumns, manager);
+                ColumnInfo col = resolveFieldKey(field.getFieldKey(), table, columnMap, unresolvedColumns, manager, null);
                 if (col != null)
                 {
                     ret.putIfAbsent(col.getFieldKey(),col);
@@ -1970,7 +1989,7 @@ public class QueryServiceImpl implements QueryService
 
             for (FieldKey key : sortFieldKeys)
             {
-                ColumnInfo sortCol = resolveFieldKey(key, col.getParentTable(), columnMap, null, manager);
+                ColumnInfo sortCol = resolveFieldKey(key, col.getParentTable(), columnMap, null, manager, null);
                 if (sortCol != null)
                 {
                     toAdd.add(sortCol);
@@ -2002,7 +2021,7 @@ public class QueryServiceImpl implements QueryService
         }
     }
 
-    private ColumnInfo resolveFieldKey(FieldKey fieldKey, TableInfo table, Map<FieldKey, ColumnInfo> columnMap, Set<FieldKey> unresolvedColumns, AliasManager manager)
+    private ColumnInfo resolveFieldKey(FieldKey fieldKey, TableInfo table, Map<FieldKey, ColumnInfo> columnMap, Set<FieldKey> unresolvedColumns, AliasManager manager, @Nullable List<SimpleFilter.FilterClause> filterClauses)
     {
         if (fieldKey == null) // TODO: Can this resolve "selectionMethods/selectionMethodId$Sname"?
             return null;
@@ -2029,6 +2048,19 @@ public class QueryServiceImpl implements QueryService
         {
             assert Table.checkColumn(table, column, "ensureRequiredColumns():");
             assert fieldKey.getTable() == null || columnMap.containsKey(fieldKey);
+
+            if (filterClauses != null)
+            {
+                boolean isArrayColumn = column.getJdbcType() == JdbcType.ARRAY;
+                for (SimpleFilter.FilterClause clause : filterClauses)
+                {
+                    boolean isArrayFilter = clause instanceof CompareType.ArrayClause;
+                    if (isArrayColumn && !isArrayFilter)
+                        throw new ApiUsageException("Array column '" + fieldKey + "' requires an array filter type");
+                    if (!isArrayColumn && isArrayFilter)
+                        throw new ApiUsageException("Non-array column '" + fieldKey + "' cannot use an array filter type");
+                }
+            }
 
             // getColumn() might return a column with a different field key than we asked for!
             if (!column.getFieldKey().equals(fieldKey))


### PR DESCRIPTION
#### Rationale
When an array operator is used on a non-array column, or vice-versa, sql exception thrown due to the type mismatch. See #[946](https://github.com/LabKey/internal-issues/issues/946)

This PR adds validation of column type against filter type for CompareTypes, so we don't proceed to generate bad sql.  

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2916

#### Changes
- disallow non-array filter types for array columns
- disallow array filter types for non-array columns

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->