### PR TITLE
Specify client library paths in tsconfig.json

### DIFF
--- a/assay/tsconfig.json
+++ b/assay/tsconfig.json
@@ -1,5 +1,13 @@
 {
   "extends": "./node_modules/@labkey/build/webpack/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      // Point to the dist/lib folder where the .d.ts files are output
+      "@labkey/api": ["../../../../clientAPIs/labkey-api-js/dist/index"],
+      "@labkey/components": ["../../../../clientAPIs/labkey-ui-components/packages/components/dist/index"],
+      "@labkey/premium": ["../../../../clientAPIs/labkey-ui-premium/dist/index"],
+    },
+  },
   "include": ["src/client/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -1,5 +1,13 @@
 {
   "extends": "./node_modules/@labkey/build/webpack/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      // Point to the dist/lib folder where the .d.ts files are output
+      "@labkey/api": ["../../../../clientAPIs/labkey-api-js/dist/index"],
+      "@labkey/components": ["../../../../clientAPIs/labkey-ui-components/packages/components/dist/index"],
+      "@labkey/premium": ["../../../../clientAPIs/labkey-ui-premium/dist/index"],
+    },
+  },
   "include": ["src/client/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }

--- a/experiment/tsconfig.json
+++ b/experiment/tsconfig.json
@@ -1,5 +1,13 @@
 {
   "extends": "./node_modules/@labkey/build/webpack/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      // Point to the dist/lib folder where the .d.ts files are output
+      "@labkey/api": ["../../../../clientAPIs/labkey-api-js/dist/index"],
+      "@labkey/components": ["../../../../clientAPIs/labkey-ui-components/packages/components/dist/index"],
+      "@labkey/premium": ["../../../../clientAPIs/labkey-ui-premium/dist/index"],
+    },
+  },
   "include": ["src/client/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }

--- a/pipeline/tsconfig.json
+++ b/pipeline/tsconfig.json
@@ -1,5 +1,13 @@
 {
   "extends": "./node_modules/@labkey/build/webpack/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      // Point to the dist/lib folder where the .d.ts files are output
+      "@labkey/api": ["../../../../clientAPIs/labkey-api-js/dist/index"],
+      "@labkey/components": ["../../../../clientAPIs/labkey-ui-components/packages/components/dist/index"],
+      "@labkey/premium": ["../../../../clientAPIs/labkey-ui-premium/dist/index"],
+    },
+  },
   "include": ["src/client/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
#### Rationale
Introduce relative paths into module `tsconfig.json` to allow for easier code traversal in IDEs.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1950
- https://github.com/LabKey/commonAssays/pull/994
- https://github.com/LabKey/limsModules/pull/2048
- https://github.com/LabKey/platform/pull/7507
- https://github.com/LabKey/premiumModules/pull/489

#### Changes
- Add relative `compilerOptions.paths` to support source map resolution
