### PR TITLE
CompareType.parseParams: fall back to regex parsing when malformed JSON is encountered

### DIFF
--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -1426,30 +1426,30 @@ public abstract class CompareType
         // check for JSON marker
         if (value.startsWith(JSON_MARKER_START) && value.endsWith(JSON_MARKER_END))
         {
-            value = value.substring(JSON_MARKER_START.length(), value.length()-JSON_MARKER_END.length());
-            if (value.startsWith("[") && value.endsWith("]"))
+            String cleanedValue = value.substring(JSON_MARKER_START.length(), value.length()-JSON_MARKER_END.length());
+            if (cleanedValue.startsWith("[") && cleanedValue.endsWith("]"))
             {
                 try
                 {
-                    // TODO what do we do with malformed parameters???
-                    JSONArray array = new JSONArray(value);
+                    JSONArray array = new JSONArray(cleanedValue);
                     for (int i = 0; i < array.length(); i++)
                     {
                         Object jsonVal = array.get(i);
                         collection.add(JSONObject.NULL.equals(jsonVal) ? null : Objects.toString(jsonVal));
                     }
+                    return;
                 }
                 catch (JSONException ex)
                 {
-                    // pass
+                    // GH Issue #948
+                    // Intentionally do nothing, so we revert to parsing by regex. Otherwise, valid filters like an IN
+                    // filter on "{json:123;abc}" will be skipped instead of parsed as ["{json:123", "abc}"]
                 }
             }
         }
-        else
-        {
-            String[] st = value.split("\\s*" + separator + "\\s*", -1);
-            Collections.addAll(collection, st);
-        }
+
+        String[] st = value.split("\\s*" + separator + "\\s*", -1);
+        Collections.addAll(collection, st);
     }
 
     protected static Set<String> parseParams(Object value_, String separator)

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.23.0"
+        "@labkey/components": "7.23.3-fb-gh-948.0"
       },
       "devDependencies": {
         "@labkey/build": "9.0.0",
@@ -2722,9 +2722,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.49.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.0.tgz",
-      "integrity": "sha512-vMqR7ReTWb0hhe39PXygFFV0Fy3ncJStsltULecZt+tUEe246VyXAcPeRv9KDE0biBIVDr1f3csOIffAcx9lQw==",
+      "version": "1.49.1-fb-gh-948.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1-fb-gh-948.0.tgz",
+      "integrity": "sha512-Az/oivAvIZi5nIw2adW1vhCTipKEvfhYR5kEX3PXaxZGqBm7AMYnc6K4nn4cFlTkSn9WDjKVWiyt8BVWmL1bjA==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2765,13 +2765,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.0.tgz",
-      "integrity": "sha512-r5C46FXzIMmpmXssJcVVPoQl0aJhwXyM+/gSMM4cNFMtwyi2Ou44E1LikKnS41VLy9thujWVsJ0iX/qjD13rkQ==",
+      "version": "7.23.3-fb-gh-948.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.3-fb-gh-948.0.tgz",
+      "integrity": "sha512-KaVb0tYVDb7YuJeKnWwsmehqJB78g/0jcZ0NqD1FFfynBxw9WcCdTlhDXOuGKsUHHGw3f35Ed7jdLm7NojoFEg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.49.0",
+        "@labkey/api": "1.49.1-fb-gh-948.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.23.3-fb-gh-948.0"
+        "@labkey/components": "7.23.5"
       },
       "devDependencies": {
         "@labkey/build": "9.0.0",
@@ -2722,9 +2722,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.49.1-fb-gh-948.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1-fb-gh-948.0.tgz",
-      "integrity": "sha512-Az/oivAvIZi5nIw2adW1vhCTipKEvfhYR5kEX3PXaxZGqBm7AMYnc6K4nn4cFlTkSn9WDjKVWiyt8BVWmL1bjA==",
+      "version": "1.49.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1.tgz",
+      "integrity": "sha512-ClFIyggEDH4PC+HB4tnZpaOfIls4MgJugS4TmE6Y5xmVzBm8L442aF/gJFMqcZQ1MMNTP7swRHbfvSvJN5Cmyw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2765,13 +2765,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.23.3-fb-gh-948.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.3-fb-gh-948.0.tgz",
-      "integrity": "sha512-KaVb0tYVDb7YuJeKnWwsmehqJB78g/0jcZ0NqD1FFfynBxw9WcCdTlhDXOuGKsUHHGw3f35Ed7jdLm7NojoFEg==",
+      "version": "7.23.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.5.tgz",
+      "integrity": "sha512-JABXXE84xShDhlENS8mEAp8BBnbLv9gmb05SVsJiq7tRnQZzSY1/pFfyGRY7m2fEWsxf6j4wDzlpH5odig8exg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.49.1-fb-gh-948.0",
+        "@labkey/api": "1.49.1",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "7.23.0"
+    "@labkey/components": "7.23.3-fb-gh-948.0"
   },
   "devDependencies": {
     "@labkey/build": "9.0.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "7.23.3-fb-gh-948.0"
+    "@labkey/components": "7.23.5"
   },
   "devDependencies": {
     "@labkey/build": "9.0.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.23.3-fb-gh-948.0",
+        "@labkey/components": "7.23.5",
         "@labkey/themes": "1.7.0"
       },
       "devDependencies": {
@@ -3717,9 +3717,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.49.1-fb-gh-948.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1-fb-gh-948.0.tgz",
-      "integrity": "sha512-Az/oivAvIZi5nIw2adW1vhCTipKEvfhYR5kEX3PXaxZGqBm7AMYnc6K4nn4cFlTkSn9WDjKVWiyt8BVWmL1bjA==",
+      "version": "1.49.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1.tgz",
+      "integrity": "sha512-ClFIyggEDH4PC+HB4tnZpaOfIls4MgJugS4TmE6Y5xmVzBm8L442aF/gJFMqcZQ1MMNTP7swRHbfvSvJN5Cmyw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3760,13 +3760,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.23.3-fb-gh-948.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.3-fb-gh-948.0.tgz",
-      "integrity": "sha512-KaVb0tYVDb7YuJeKnWwsmehqJB78g/0jcZ0NqD1FFfynBxw9WcCdTlhDXOuGKsUHHGw3f35Ed7jdLm7NojoFEg==",
+      "version": "7.23.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.5.tgz",
+      "integrity": "sha512-JABXXE84xShDhlENS8mEAp8BBnbLv9gmb05SVsJiq7tRnQZzSY1/pFfyGRY7m2fEWsxf6j4wDzlpH5odig8exg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.49.1-fb-gh-948.0",
+        "@labkey/api": "1.49.1",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.23.0",
+        "@labkey/components": "7.23.3-fb-gh-948.0",
         "@labkey/themes": "1.7.0"
       },
       "devDependencies": {
@@ -3717,9 +3717,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.49.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.0.tgz",
-      "integrity": "sha512-vMqR7ReTWb0hhe39PXygFFV0Fy3ncJStsltULecZt+tUEe246VyXAcPeRv9KDE0biBIVDr1f3csOIffAcx9lQw==",
+      "version": "1.49.1-fb-gh-948.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1-fb-gh-948.0.tgz",
+      "integrity": "sha512-Az/oivAvIZi5nIw2adW1vhCTipKEvfhYR5kEX3PXaxZGqBm7AMYnc6K4nn4cFlTkSn9WDjKVWiyt8BVWmL1bjA==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3760,13 +3760,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.0.tgz",
-      "integrity": "sha512-r5C46FXzIMmpmXssJcVVPoQl0aJhwXyM+/gSMM4cNFMtwyi2Ou44E1LikKnS41VLy9thujWVsJ0iX/qjD13rkQ==",
+      "version": "7.23.3-fb-gh-948.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.3-fb-gh-948.0.tgz",
+      "integrity": "sha512-KaVb0tYVDb7YuJeKnWwsmehqJB78g/0jcZ0NqD1FFfynBxw9WcCdTlhDXOuGKsUHHGw3f35Ed7jdLm7NojoFEg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.49.0",
+        "@labkey/api": "1.49.1-fb-gh-948.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "7.23.0",
+    "@labkey/components": "7.23.3-fb-gh-948.0",
     "@labkey/themes": "1.7.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "7.23.3-fb-gh-948.0",
+    "@labkey/components": "7.23.5",
     "@labkey/themes": "1.7.0"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.23.0"
+        "@labkey/components": "7.23.3-fb-gh-948.0"
       },
       "devDependencies": {
         "@labkey/build": "9.0.0",
@@ -3568,9 +3568,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.49.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.0.tgz",
-      "integrity": "sha512-vMqR7ReTWb0hhe39PXygFFV0Fy3ncJStsltULecZt+tUEe246VyXAcPeRv9KDE0biBIVDr1f3csOIffAcx9lQw==",
+      "version": "1.49.1-fb-gh-948.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1-fb-gh-948.0.tgz",
+      "integrity": "sha512-Az/oivAvIZi5nIw2adW1vhCTipKEvfhYR5kEX3PXaxZGqBm7AMYnc6K4nn4cFlTkSn9WDjKVWiyt8BVWmL1bjA==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3611,13 +3611,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.0.tgz",
-      "integrity": "sha512-r5C46FXzIMmpmXssJcVVPoQl0aJhwXyM+/gSMM4cNFMtwyi2Ou44E1LikKnS41VLy9thujWVsJ0iX/qjD13rkQ==",
+      "version": "7.23.3-fb-gh-948.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.3-fb-gh-948.0.tgz",
+      "integrity": "sha512-KaVb0tYVDb7YuJeKnWwsmehqJB78g/0jcZ0NqD1FFfynBxw9WcCdTlhDXOuGKsUHHGw3f35Ed7jdLm7NojoFEg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.49.0",
+        "@labkey/api": "1.49.1-fb-gh-948.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.23.3-fb-gh-948.0"
+        "@labkey/components": "7.23.5"
       },
       "devDependencies": {
         "@labkey/build": "9.0.0",
@@ -3568,9 +3568,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.49.1-fb-gh-948.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1-fb-gh-948.0.tgz",
-      "integrity": "sha512-Az/oivAvIZi5nIw2adW1vhCTipKEvfhYR5kEX3PXaxZGqBm7AMYnc6K4nn4cFlTkSn9WDjKVWiyt8BVWmL1bjA==",
+      "version": "1.49.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1.tgz",
+      "integrity": "sha512-ClFIyggEDH4PC+HB4tnZpaOfIls4MgJugS4TmE6Y5xmVzBm8L442aF/gJFMqcZQ1MMNTP7swRHbfvSvJN5Cmyw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3611,13 +3611,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.23.3-fb-gh-948.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.3-fb-gh-948.0.tgz",
-      "integrity": "sha512-KaVb0tYVDb7YuJeKnWwsmehqJB78g/0jcZ0NqD1FFfynBxw9WcCdTlhDXOuGKsUHHGw3f35Ed7jdLm7NojoFEg==",
+      "version": "7.23.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.5.tgz",
+      "integrity": "sha512-JABXXE84xShDhlENS8mEAp8BBnbLv9gmb05SVsJiq7tRnQZzSY1/pFfyGRY7m2fEWsxf6j4wDzlpH5odig8exg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.49.1-fb-gh-948.0",
+        "@labkey/api": "1.49.1",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.23.0"
+    "@labkey/components": "7.23.3-fb-gh-948.0"
   },
   "devDependencies": {
     "@labkey/build": "9.0.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.23.3-fb-gh-948.0"
+    "@labkey/components": "7.23.5"
   },
   "devDependencies": {
     "@labkey/build": "9.0.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.23.0"
+        "@labkey/components": "7.23.3-fb-gh-948.0"
       },
       "devDependencies": {
         "@labkey/build": "9.0.0",
@@ -2882,9 +2882,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.49.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.0.tgz",
-      "integrity": "sha512-vMqR7ReTWb0hhe39PXygFFV0Fy3ncJStsltULecZt+tUEe246VyXAcPeRv9KDE0biBIVDr1f3csOIffAcx9lQw==",
+      "version": "1.49.1-fb-gh-948.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1-fb-gh-948.0.tgz",
+      "integrity": "sha512-Az/oivAvIZi5nIw2adW1vhCTipKEvfhYR5kEX3PXaxZGqBm7AMYnc6K4nn4cFlTkSn9WDjKVWiyt8BVWmL1bjA==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2925,13 +2925,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.0.tgz",
-      "integrity": "sha512-r5C46FXzIMmpmXssJcVVPoQl0aJhwXyM+/gSMM4cNFMtwyi2Ou44E1LikKnS41VLy9thujWVsJ0iX/qjD13rkQ==",
+      "version": "7.23.3-fb-gh-948.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.3-fb-gh-948.0.tgz",
+      "integrity": "sha512-KaVb0tYVDb7YuJeKnWwsmehqJB78g/0jcZ0NqD1FFfynBxw9WcCdTlhDXOuGKsUHHGw3f35Ed7jdLm7NojoFEg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.49.0",
+        "@labkey/api": "1.49.1-fb-gh-948.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.23.3-fb-gh-948.0"
+        "@labkey/components": "7.23.5"
       },
       "devDependencies": {
         "@labkey/build": "9.0.0",
@@ -2882,9 +2882,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.49.1-fb-gh-948.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1-fb-gh-948.0.tgz",
-      "integrity": "sha512-Az/oivAvIZi5nIw2adW1vhCTipKEvfhYR5kEX3PXaxZGqBm7AMYnc6K4nn4cFlTkSn9WDjKVWiyt8BVWmL1bjA==",
+      "version": "1.49.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.49.1.tgz",
+      "integrity": "sha512-ClFIyggEDH4PC+HB4tnZpaOfIls4MgJugS4TmE6Y5xmVzBm8L442aF/gJFMqcZQ1MMNTP7swRHbfvSvJN5Cmyw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2925,13 +2925,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.23.3-fb-gh-948.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.3-fb-gh-948.0.tgz",
-      "integrity": "sha512-KaVb0tYVDb7YuJeKnWwsmehqJB78g/0jcZ0NqD1FFfynBxw9WcCdTlhDXOuGKsUHHGw3f35Ed7jdLm7NojoFEg==",
+      "version": "7.23.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.23.5.tgz",
+      "integrity": "sha512-JABXXE84xShDhlENS8mEAp8BBnbLv9gmb05SVsJiq7tRnQZzSY1/pFfyGRY7m2fEWsxf6j4wDzlpH5odig8exg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.49.1-fb-gh-948.0",
+        "@labkey/api": "1.49.1",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "7.23.3-fb-gh-948.0"
+    "@labkey/components": "7.23.5"
   },
   "devDependencies": {
     "@labkey/build": "9.0.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "7.23.0"
+    "@labkey/components": "7.23.3-fb-gh-948.0"
   },
   "devDependencies": {
     "@labkey/build": "9.0.0",


### PR DESCRIPTION
#### Rationale
This PR fixes the server side of the issue outlined in labkey/internal-issues#948

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/210
* https://github.com/LabKey/labkey-ui-components/pull/1958
* https://github.com/LabKey/labkey-ui-premium/pull/911
* https://github.com/LabKey/limsModules/pull/2049
* https://github.com/LabKey/platform/pull/7508

#### Changes
- CompareType.parseParams: fall back to regex parsing when malformed JSON is encountered
- Bump @labkey/components to get client side fix from @labkey/api

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->