### PR TITLE
Delete all attachments when deleting multi-folder lists

### DIFF
--- a/core/src/org/labkey/core/query/DocumentsTable.java
+++ b/core/src/org/labkey/core/query/DocumentsTable.java
@@ -2,6 +2,7 @@ package org.labkey.core.query;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.attachments.AttachmentService;
+import org.labkey.api.collections.CsvSet;
 import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ContainerFilter;
@@ -11,6 +12,7 @@ import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.query.AliasManager;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.UserIdQueryForeignKey;
 
@@ -26,7 +28,6 @@ public class DocumentsTable extends FilteredTable<CoreQuerySchema>
         getMutableColumnOrThrow("ModifiedBy").setHidden(true);
         getMutableColumnOrThrow("Modified").setHidden(true);
         MutableColumnInfo owner = getMutableColumnOrThrow("Owner");
-        owner.setHidden(true);
         owner.setFk(new UserIdQueryForeignKey(_userSchema));
         getMutableColumnOrThrow("Parent").setHidden(true);
         getMutableColumnOrThrow("DocumentSize").setFormat("#,##0");
@@ -34,8 +35,14 @@ public class DocumentsTable extends FilteredTable<CoreQuerySchema>
         getMutableColumnOrThrow("LastIndexed").setHidden(true);
         addColumn(new BaseColumnInfo("ParentDescription", this, JdbcType.VARCHAR));
         BaseColumnInfo orphaned = new BaseColumnInfo("Orphaned", this, JdbcType.BOOLEAN);
-        orphaned.setHidden(true);
         addColumn(orphaned);
+
+        setDefaultVisibleColumns(
+            new CsvSet("CreatedBy, Created, Container, DocumentName, DocumentSize, DocumentType, ParentType, ParentDescription")
+                .stream()
+                .map(FieldKey::fromParts)
+                .toList()
+        );
     }
 
     @Override

--- a/list/src/org/labkey/list/model/ListDefinitionImpl.java
+++ b/list/src/org/labkey/list/model/ListDefinitionImpl.java
@@ -576,10 +576,10 @@ public class ListDefinitionImpl implements ListDefinition
         try (DbScope.Transaction transaction = (table != null) ? table.getSchema().getScope().ensureTransaction() :
              ExperimentService.get().ensureTransaction())
         {
-            // remove related attachments, discussions, and indices
+            // remove related full-text search docs and attachments
             ListManager.get().deleteIndexedList(this);
             if (qus instanceof ListQueryUpdateService listQus)
-                listQus.deleteRelatedListData(user, getContainer());
+                listQus.deleteRelatedListData(null);
 
             // then delete the list itself
             ListManager.get().deleteListDef(getContainer(), getListId());

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -26,6 +26,7 @@ import org.labkey.api.audit.AbstractAuditTypeProvider;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CsvSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -90,6 +91,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.labkey.api.util.IntegerUtils.isIntegral;
 
@@ -759,45 +761,39 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         return result;
     }
 
+    record ListRow(Container container, String entityId){}
 
-    // Deletes attachments & discussions, and removes list documents from full-text search index.
-    public void deleteRelatedListData(final User user, final Container container)
+    // Delete attachments and remove documents from the full-text search index. If Container is non-null, delete only
+    // from that container (truncate case). If container is null, delete from all containers (delete list case).
+    public void deleteRelatedListData(final @Nullable Container container)
     {
         // Unindex all item docs and the entire list doc
         ListManager.get().deleteIndexedList(_list);
 
-        // Delete attachments and discussions associated with a list in batches of 1,000
-        new TableSelector(getDbTable(), Collections.singleton("entityId"), SimpleFilter.createContainerFilter(container), null).forEachBatch(String.class, 1000, new ForEachBatchBlock<>()
-        {
-            @Override
-            public boolean accept(String entityId)
-            {
-                return null != entityId;
-            }
-
-            @Override
-            public void exec(List<String> entityIds)
-            {
-                // delete the related list data for this block
-                deleteRelatedListData(user, container, entityIds);
-            }
-        });
-    }
-
-    // delete the related list data for this block of entityIds
-    private void deleteRelatedListData(User user, Container container, List<String> entityIds)
-    {
-        // Build up set of entityIds and AttachmentParents
-        List<AttachmentParent> attachmentParents = new ArrayList<>();
-
-        // Delete Attachments
         if (hasAttachmentProperties())
         {
-            for (String entityId : entityIds)
+            SimpleFilter filter = null != container ? SimpleFilter.createContainerFilter(container) : null;
+
+            // Delete attachments associated with a list in batches of 1,000
+            new TableSelector(getDbTable(), new CsvSet("Container, EntityId"), filter, null).forEachBatch(ListRow.class, 1000, new ForEachBatchBlock<>()
             {
-                attachmentParents.add(new ListItemAttachmentParent(entityId, container));
-            }
-            AttachmentService.get().deleteAttachments(attachmentParents);
+                @Override
+                public boolean accept(ListRow row)
+                {
+                    return null != row.entityId();
+                }
+
+                @Override
+                public void exec(List<ListRow> rows)
+                {
+                    // delete the related attachments for this block
+                    AttachmentService.get().deleteAttachments(
+                        rows.stream()
+                            .map(row -> new ListItemAttachmentParent(row.entityId(), row.container()))
+                            .collect(Collectors.toList())
+                    );
+                }
+            });
         }
     }
 
@@ -807,7 +803,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         int result;
         try (DbScope.Transaction transaction = getDbTable().getSchema().getScope().ensureTransaction())
         {
-            deleteRelatedListData(user, container);
+            deleteRelatedListData(container);
             result = super.truncateRows(getListUser(user, container), container);
             transaction.addCommitTask(() -> ListManager.get().addAuditEvent(_list, user, "Deleted " + result + " rows from list."), DbScope.CommitTaskOption.POSTCOMMIT);
             transaction.commit();


### PR DESCRIPTION
#### Rationale
We were orphaning attachments in multi-folder lists: https://github.com/LabKey/internal-issues/issues/984

#### Changes
- Delete attachments in all containers, not just the definition container
- Unhide a couple useful columns in the Documents table