### PR TITLE
Add missing text descriptions for second search button

### DIFF
--- a/core/src/org/labkey/core/view/template/bootstrap/header.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/header.jsp
@@ -148,7 +148,7 @@
                     <labkey:form id="global-search-form" action="<%=urlProvider(SearchUrls.class).getSearchURL(c, null)%>" method="GET">
                         <input type="text" class="search-box" name="q" placeholder="<%=h(SearchUtils.getPlaceholder(c))%>" value="">
                         <input type="submit" hidden>
-                        <a id="a_header_search" href="#" class="btn-search fa fa-search"></a>
+                        <a id="a_header_search" href="#" class="btn-search fa fa-search" aria-label="Search"></a>
                     </labkey:form>
                     <% pageConfig.addHandler("a_header_search","click","document.getElementById('global-search-form').submit(); return false;"); %>
                 </div>


### PR DESCRIPTION
#### Rationale
I previously improved the labeling for the search header UI in https://github.com/LabKey/platform/pull/7417. There's another element that needs a label.



#### Changes
- Add a label to the button shown after the user expands the search section

#### Tasks 📍
- Manual Testing - N/A
- Needs Automation - N/A

@labkey-keegang @labkey-keith 