### PR TITLE
GitHub Issue 950: cross folder export/import roundtripping problems for MVTC with commas and quotes

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -3242,8 +3242,7 @@ public class ExpDataIterators
             if (data instanceof MultiChoice.Array array)
             {
                 // GitHub Issue 950: cross folder export/import roundtripping problems for MVTC with commas and quotes
-                String displayVal = PageFlowUtil.joinValuesToStringForExport(array);
-                return _tsvWriter.quoteValue(displayVal.trim());
+                return _tsvWriter.quoteValue(array.toString().trim());
             }
 
             return data;

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -42,6 +42,7 @@ import org.labkey.api.data.DbScope;
 import org.labkey.api.data.ExpDataFileConverter;
 import org.labkey.api.data.ImportAliasable;
 import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.MultiChoice;
 import org.labkey.api.data.NameGenerator;
 import org.labkey.api.data.RemapCache;
 import org.labkey.api.data.SimpleFilter;
@@ -116,6 +117,7 @@ import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.logging.LogHelper;
@@ -3237,6 +3239,13 @@ public class ExpDataIterators
                 return DateUtil.formatIsoDateLongTime(d, true);
             if (data instanceof String s)
                 return _tsvWriter.quoteValue(s.trim());
+            if (data instanceof MultiChoice.Array array)
+            {
+                // GitHub Issue 950: cross folder export/import roundtripping problems for MVTC with commas and quotes
+                String displayVal = PageFlowUtil.joinValuesToStringForExport(array);
+                return _tsvWriter.quoteValue(displayVal.trim());
+            }
+
             return data;
         }
 


### PR DESCRIPTION
#### Rationale
Cross folder/type import writes data file into partitions. When writing MVTC fields, we need to make sure the array is converted to exportable string and escaped properly.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7523
- https://github.com/LabKey/limsModules/pull/2058

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->