### PR TITLE
Fix Windows FileLike path resolution for background R report outputs

### DIFF
--- a/api/src/org/labkey/api/reports/report/ScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ScriptEngineReport.java
@@ -60,7 +60,6 @@ import org.labkey.api.reports.report.r.view.TextOutput;
 import org.labkey.api.reports.report.r.view.TsvOutput;
 import org.labkey.api.thumbnail.Thumbnail;
 import org.labkey.api.util.FileUtil;
-import org.labkey.api.util.Path;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.VBox;
@@ -71,7 +70,6 @@ import org.labkey.vfs.FileLike;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.sql.ResultSetMetaData;
@@ -218,27 +216,32 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
         return getReportDirFileLike(executingContainerId, isPipeline);
     }
 
-    protected FileLike getReportDirFileLike(@NotNull String executingContainerId, boolean isPipeline)
+    protected FileLike getBackgroundOutputDirFileLike(@NotNull String executingContainerId)
     {
         FileLike tempRoot = getTempRootFileLike(getDescriptor());
         String reportId = FileUtil.makeLegalName(String.valueOf(getDescriptor().getReportId())).replaceAll(" ", "_");
+
+        // Build FileLike paths from VFS path segments instead of File.separator so Windows
+        // backslashes do not get folded into a single org.labkey.api.util.Path segment.
+        return tempRoot.resolveChild(executingContainerId).resolveChild("Report_" + reportId);
+    }
+
+    protected FileLike getReportDirFileLike(@NotNull String executingContainerId, boolean isPipeline)
+    {
         FileLike tempFolder;
 
         try
         {
+            tempFolder = getBackgroundOutputDirFileLike(executingContainerId);
+
             if (isPipeline)
             {
                 String identifier = RReportJob.getJobIdentifier();
                 if (identifier != null)
-                    tempFolder = FileUtil.appendPath(tempRoot,
-                            Path.parse(executingContainerId + File.separator + "Report_" + reportId + File.separator + identifier));
-                else
-                    tempFolder = FileUtil.appendPath(tempRoot,
-                            Path.parse(executingContainerId + File.separator + "Report_" + reportId));
+                    tempFolder = tempFolder.resolveChild(identifier);
             }
             else
-                tempFolder = FileUtil.appendPath(tempRoot,
-                        Path.parse(executingContainerId + File.separator + "Report_" + reportId + File.separator + Thread.currentThread().getId()));
+                tempFolder = tempFolder.resolveChild(String.valueOf(Thread.currentThread().getId()));
 
             FileUtil.mkdirs(tempFolder);
             return tempFolder;

--- a/api/src/org/labkey/api/reports/report/r/RReport.java
+++ b/api/src/org/labkey/api/reports/report/r/RReport.java
@@ -697,6 +697,20 @@ public class RReport extends ExternalScriptEngineReport
     }
 
     @Override
+    protected FileLike getBackgroundOutputDirFileLike(@NotNull String executingContainerId)
+    {
+        FileLike reportDir = null;
+
+        if (getKnitrFormat() != RReportDescriptor.KnitrFormat.None)
+            reportDir = getCacheDir(executingContainerId);
+
+        if (reportDir != null)
+            return reportDir;
+
+        return super.getBackgroundOutputDirFileLike(executingContainerId);
+    }
+
+    @Override
     public void clearCache()
     {
         if (getKnitrFormat() == RReportDescriptor.KnitrFormat.None)

--- a/api/src/org/labkey/api/reports/report/r/RReportJob.java
+++ b/api/src/org/labkey/api/reports/report/r/RReportJob.java
@@ -39,11 +39,9 @@ import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.view.ViewContext;
 import org.labkey.vfs.FileLike;
-import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.io.Serializable;
-import java.nio.file.CopyOption;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -276,16 +274,15 @@ public class RReportJob extends PipelineJob implements Serializable
             {
                 // write the output substitution map to disk so we can render the view later
                 FileLike reportDir = report.getReportDirFileLike(getJob().getContainerId());
+                FileLike parentDir = report.getBackgroundOutputDirFileLike(getJob().getContainerId());
                 FileLike substitutionMap;
 
-                String reportDirName = reportDir.toNioPathForRead().getFileName().toString();
-                if (reportDirName.equals(getJobIdentifier()))
+                if (!reportDir.equals(parentDir))
                 {
-                    FileLike parentDir = FileSystemLike.wrapFile(reportDir.toNioPathForRead().getParent().toFile());
                     // clean up the destination folder
                     for (FileLike file : parentDir.getChildren())
                     {
-                        if (!file.isDirectory() && !"log".equalsIgnoreCase(FileUtil.getExtension(file)))
+                        if (!file.isFile() && !"log".equalsIgnoreCase(FileUtil.getExtension(file)))
                         {
                             getJob().debug("deleting parent file=" + file);
                             file.delete();

--- a/api/src/org/labkey/api/reports/report/r/RReportJob.java
+++ b/api/src/org/labkey/api/reports/report/r/RReportJob.java
@@ -285,7 +285,7 @@ public class RReportJob extends PipelineJob implements Serializable
                     // clean up the destination folder
                     for (FileLike file : parentDir.getChildren())
                     {
-                        if (!file.isDirectory() && !"log".equalsIgnoreCase(FileUtil.getExtension(file)))
+                        if (file.isFile() && !"log".equalsIgnoreCase(FileUtil.getExtension(file)))
                         {
                             getJob().debug("deleting parent file=" + file);
                             file.delete();

--- a/api/src/org/labkey/api/reports/report/r/RReportJob.java
+++ b/api/src/org/labkey/api/reports/report/r/RReportJob.java
@@ -39,6 +39,7 @@ import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.view.ViewContext;
 import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.io.Serializable;
@@ -277,14 +278,18 @@ public class RReportJob extends PipelineJob implements Serializable
                 FileLike reportDir = report.getReportDirFileLike(getJob().getContainerId());
                 FileLike substitutionMap;
 
-                if (reportDir.getName().equals(getJobIdentifier()))
+                String reportDirName = reportDir.toNioPathForRead().getFileName().toString();
+                if (reportDirName.equals(getJobIdentifier()))
                 {
-                    FileLike parentDir = reportDir.getParent();
+                    FileLike parentDir = FileSystemLike.wrapFile(reportDir.toNioPathForRead().getParent().toFile());
                     // clean up the destination folder
                     for (FileLike file : parentDir.getChildren())
                     {
                         if (!file.isDirectory() && !"log".equalsIgnoreCase(FileUtil.getExtension(file)))
+                        {
+                            getJob().debug("deleting parent file=" + file);
                             file.delete();
+                        }
                     }
 
                     // rewrite the parameter replacement files to point to the destination folder
@@ -294,6 +299,7 @@ public class RReportJob extends PipelineJob implements Serializable
                         for (FileLike file : replacement.getFiles())
                         {
                             FileLike newFile = parentDir.resolveChild(file.getName());
+                            getJob().debug("move replacement file  =" + replacement.getName() + " from=" + file + " to=" + newFile);
                             file.move(newFile);
                             newFiles.add(newFile);
                         }
@@ -317,6 +323,7 @@ public class RReportJob extends PipelineJob implements Serializable
                             {
                                 newFile = FileUtil.createTempFile(LOG_FILE_PREFIX, ".log", parentDir);
                                 getJob().setLogFile(newFile);
+                                getJob().debug("copy log file from=" + file + " to=" + newFile);
                                 FileUtil.copyFile(file, newFile, StandardCopyOption.REPLACE_EXISTING);
                             }
                             // report.log != getLogFile(), just regular file
@@ -325,16 +332,19 @@ public class RReportJob extends PipelineJob implements Serializable
                                 String logFileContent = PageFlowUtil.getStreamContentsAsString(file.openInputStream());
                                 if (!StringUtils.isEmpty(logFileContent))
                                     getJob().info("REPORT.LOG CONTENTS:\n" + logFileContent);
+                                getJob().debug("move log file from=" + file + " to=" + newFile);
                                 file.move(newFile);
                             }
                         }
                         else
                         {
+                            getJob().debug("move file from=" + file + " to=" + newFile);
                             file.move(newFile);
                         }
                     }
+                    getJob().debug("delete reportDir=" + reportDir);
                     FileUtil.deleteDir(reportDir);
-                    substitutionMap = reportDir.getParent().resolveChild(RReport.SUBSTITUTION_MAP);
+                    substitutionMap = parentDir.resolveChild(RReport.SUBSTITUTION_MAP);
                 }
                 else
                     substitutionMap = reportDir.resolveChild(RReport.SUBSTITUTION_MAP);

--- a/api/src/org/labkey/api/reports/report/r/RReportJob.java
+++ b/api/src/org/labkey/api/reports/report/r/RReportJob.java
@@ -277,12 +277,15 @@ public class RReportJob extends PipelineJob implements Serializable
                 FileLike parentDir = report.getBackgroundOutputDirFileLike(getJob().getContainerId());
                 FileLike substitutionMap;
 
-                if (!reportDir.equals(parentDir))
+                // ScriptEngineReport#getReportDirFileLike() appends the ThreadLocal job identifier only
+                // when background execution needs a per-job child directory under parentDir.
+                boolean hasJobSpecificReportDir = !reportDir.equals(parentDir);
+                if (hasJobSpecificReportDir)
                 {
                     // clean up the destination folder
                     for (FileLike file : parentDir.getChildren())
                     {
-                        if (!file.isFile() && !"log".equalsIgnoreCase(FileUtil.getExtension(file)))
+                        if (!file.isDirectory() && !"log".equalsIgnoreCase(FileUtil.getExtension(file)))
                         {
                             getJob().debug("deleting parent file=" + file);
                             file.delete();


### PR DESCRIPTION
#### Rationale
Test failure: https://teamcity.labkey.org/buildConfiguration/LabKey_263Release_Premium_CommunitySqlserver_DailyASqlserver/3903944?buildTab=tests&status=failed&name=DataReportsTest.doRReportsTest&expandedTest=build%3A%28id%3A3903944%29%2Cid%3A2000000031

This failure revealed an underlying path-resolution bug: on Windows, FileLike’s internal LabKey Path was getting malformed because Path.parse() was fed a backslash-separated string (resulting in report dir path like so: /reports_temp/851e5acd-09f3-103f-a81c-b7028cf24fe8\Report_db_182\46502904-09f4-103g-a81c-b6028cf24fe8).
FileLike's getName() and getParent() were therefore computing against the wrong path.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7524 <-- original approved PR targeting develop, but this fix needs to go in 26.3

#### Changes
- Fix R report output directory resolution
- Add debug logs

### Testing
- [x] Run Test on Mac @labkey-danield 