### PR TITLE
Update search behavior for restricted issues.

### DIFF
--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -948,6 +948,11 @@ public class IssueManager
         public void accept(SearchService.TaskIndexingQueue a)
         {
             User user = new LimitedUser(UserManager.getGuestUser(), ReaderRole.class);
+            if (IssuesListDefService.get().getRestrictedIssueProvider() != null)
+            {
+                // Pass in an admin user to allow all restricted issues to be indexed by the crawler
+                user = User.getAdminServiceUser();
+            }
             indexIssues(a, user, _ids);
         }
     }
@@ -968,16 +973,9 @@ public class IssueManager
 
         for (Integer id : ids)
         {
-            try
-            {
-                IssueObject issue = IssueManager.getIssue(container, user, id);
-                if (issue != null)
-                    queueIssue(queue, id, issue.getProperties(), issue.getCommentObjects());
-            }
-            catch (UnauthorizedException e)
-            {
-                // Issue 51607 ignore restricted issue failures
-            }
+            IssueObject issue = IssueManager.getIssue(container, user, id, false);
+            if (issue != null)
+                queueIssue(queue, id, issue.getProperties(), issue.getCommentObjects());
         }
     }
 
@@ -1015,6 +1013,8 @@ public class IssueManager
             public HttpView getCustomSearchResult(User user, @NotNull String resourceIdentifier)
             {
                 int issueId;
+                boolean isRestricted = false;       // controls rendering for a restricted issue
+
                 try
                 {
                     issueId = Integer.parseInt(resourceIdentifier);
@@ -1024,23 +1024,34 @@ public class IssueManager
                     return null;
                 }
 
-                final IssueObject issue = getIssue(null, user, issueId, false);
+                IssueObject issue = getIssue(null, user, issueId, false);
                 if (null == issue)
-                    return null;
+                {
+                    if (IssuesListDefService.get().getRestrictedIssueProvider() != null)
+                    {
+                        // allow users to see the summary of a restricted issue, but there will be limited
+                        // information that is rendered.
+                        issue = getIssue(null, User.getAdminServiceUser(), issueId, false);
+                        isRestricted = true;
+                    }
+
+                    if (issue == null)
+                        return null;
+                }
                 Container c = issue.lookupContainer();
                 if (null == c || !c.hasPermission(user, ReadPermission.class))
                     return null;
 
-                return new IssueSummaryView(issue);
+                return new IssueSummaryView(issue, isRestricted);
             }
         };
     }
 
     public static class IssueSummaryView extends JspView
     {
-        IssueSummaryView(IssueObject issue)
+        IssueSummaryView(IssueObject issue, boolean isRestricted)
         {
-            super("/org/labkey/issue/view/searchSummary.jsp", issue);
+            super("/org/labkey/issue/view/searchSummary.jsp", new Pair<>(issue, isRestricted));
         }
     }
 

--- a/issues/src/org/labkey/issue/view/searchSummary.jsp
+++ b/issues/src/org/labkey/issue/view/searchSummary.jsp
@@ -23,12 +23,15 @@
 <%@ page import="java.util.regex.Matcher" %>
 <%@ page import="java.util.regex.Pattern" %>
 <%@ page import="org.apache.commons.lang3.Strings" %>
+<%@ page import="org.labkey.api.util.Pair" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    JspView<IssueObject> me = HttpView.currentView();
-    final IssueObject issue = me.getModelBean();
+    JspView<Pair<IssueObject, Boolean>> me = HttpView.currentView();
+    final Pair<IssueObject, Boolean> rec = me.getModelBean();
     final User user = getUser();
+    final IssueObject issue = rec.first;
+    final Boolean isRestricted = rec.second;
     final boolean isClosed = Strings.CI.equals(issue.getStatus(),"closed");
     final boolean isOpen = Strings.CI.equals(issue.getStatus(),"open");
 %>
@@ -47,29 +50,36 @@
     <%
         StringBuilder html = new StringBuilder();
         boolean hasTextComment = false;
-        for (IssueObject.CommentObject comment : issue.getCommentObjects())
+        if (isRestricted)
         {
-            String s = comment.getHtmlComment().toString();
-            String pattern1 = "<div class=\"labkey-wiki\">";
-            String pattern2 = "</div>";
-            String regexString = Pattern.quote(pattern1) + "(?s)(.*?)" + Pattern.quote(pattern2);
-            Pattern p = Pattern.compile(regexString);
-            Matcher matcher = p.matcher(s);
-            while (matcher.find())
+            html.append("<div class=\"labkey-error\">Restricted Issue: You do not have access. Contact your administrator for access.</div>");
+        }
+        else
+        {
+            for (IssueObject.CommentObject comment : issue.getCommentObjects())
             {
-                String commentContentText = matcher.group(1);
-                if (!StringUtils.isEmpty(commentContentText))
+                String s = comment.getHtmlComment().toString();
+                String pattern1 = "<div class=\"labkey-wiki\">";
+                String pattern2 = "</div>";
+                String regexString = Pattern.quote(pattern1) + "(?s)(.*?)" + Pattern.quote(pattern2);
+                Pattern p = Pattern.compile(regexString);
+                Matcher matcher = p.matcher(s);
+                while (matcher.find())
                 {
-                    hasTextComment = true;
-                    html.append(commentContentText);
-                    html.append("<br>");
-                    if (html.length() > 500)
-                        break;
+                    String commentContentText = matcher.group(1);
+                    if (!StringUtils.isEmpty(commentContentText))
+                    {
+                        hasTextComment = true;
+                        html.append(commentContentText);
+                        html.append("<br>");
+                        if (html.length() > 500)
+                            break;
+                    }
                 }
             }
         }
 
-    if (hasTextComment) { %>
+    if (hasTextComment && !isRestricted) { %>
         <label style="text-decoration: underline">Comments</label>
     <% } %>
     <div style="max-height:4em; overflow-y:hidden; word-wrap:break-word; white-space: normal; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;"><%= unsafe(html.toString()) %></div>


### PR DESCRIPTION
#### Rationale
Restricted issues were previously not getting indexed by the crawler because the search user did not have access to all of the issues. If the index were deleted, these issues would never reappear in the index unless they were resaved by a user with access. 

This change ensures that all restricted issues can be indexed by the crawler. Additionally any restricted issues that appear in the search summary will not render any comments. Instead, a warning will be displayed to inform the user that they do not have access to that restricted issue. As was the behavior prior, clicking on the details link will generate an unauthorized exception. 
