### PR TITLE
Update @labkey/api

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.26.2-fb-package-updates-0326.0"
+        "@labkey/components": "7.26.4"
       },
       "devDependencies": {
         "@labkey/build": "9.1.0",
@@ -2722,9 +2722,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.50.1-fb-package-updates-0326.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.1-fb-package-updates-0326.0.tgz",
-      "integrity": "sha512-nJjR31pzNwRIRfFHBMdfB0bKTdldfRNrzwA8m+Dr8ATxMaKNx+MAUgJCUHqZqJwVUdX3JifWfgzLyrkPQ4uM3g==",
+      "version": "1.51.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.0.tgz",
+      "integrity": "sha512-pyYXCNbFF3HZQ8KVapcwBl/7cHlVDz0ysPlCRBUQ9czX6s2yLwiho0OWkBd9MpbGVkqGFihbTUsUAU+Y5rz5Pw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2765,13 +2765,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.26.2-fb-package-updates-0326.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.2-fb-package-updates-0326.0.tgz",
-      "integrity": "sha512-O6iGsBoyYfKHVp/v79eRvqtWkYULorOp4f4Hr07WSABkw+F+z4gCVH5TLMlUZAhKmoj9U7DeZafMn/ODWievPg==",
+      "version": "7.26.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.4.tgz",
+      "integrity": "sha512-pJ/P/qEiOdV2QYtLC+aDHcxUlroo5ENkYToYqb83+N4ksgmRYmv4oaTi0sIvXH0xSpRn3b31qys7gcHbL0yIbA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.50.1-fb-package-updates-0326.0",
+        "@labkey/api": "1.51.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.26.1"
+        "@labkey/components": "7.26.2-fb-package-updates-0326.0"
       },
       "devDependencies": {
         "@labkey/build": "9.1.0",
@@ -2722,9 +2722,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.50.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.0.tgz",
-      "integrity": "sha512-1fiVQOP5UXvj1JW0LyJDtu3N8bgP95D9f7E+23w7BapabIT2xCvBj4YGRQZCvgSbW6pa+fH2Ayw542OFDWwfvA==",
+      "version": "1.50.1-fb-package-updates-0326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.1-fb-package-updates-0326.0.tgz",
+      "integrity": "sha512-nJjR31pzNwRIRfFHBMdfB0bKTdldfRNrzwA8m+Dr8ATxMaKNx+MAUgJCUHqZqJwVUdX3JifWfgzLyrkPQ4uM3g==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2765,13 +2765,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.26.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.1.tgz",
-      "integrity": "sha512-XfGooUwkx4U8MNMPwtOOO/KYrsTEDj8OR2PzSfn6Qon4JmmyUG+/OGzm82skp/vkXKRGyjpECms9Ueh6YCIMmw==",
+      "version": "7.26.2-fb-package-updates-0326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.2-fb-package-updates-0326.0.tgz",
+      "integrity": "sha512-O6iGsBoyYfKHVp/v79eRvqtWkYULorOp4f4Hr07WSABkw+F+z4gCVH5TLMlUZAhKmoj9U7DeZafMn/ODWievPg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.50.0",
+        "@labkey/api": "1.50.1-fb-package-updates-0326.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "7.26.1"
+    "@labkey/components": "7.26.2-fb-package-updates-0326.0"
   },
   "devDependencies": {
     "@labkey/build": "9.1.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "7.26.2-fb-package-updates-0326.0"
+    "@labkey/components": "7.26.4"
   },
   "devDependencies": {
     "@labkey/build": "9.1.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.26.2-fb-package-updates-0326.0",
+        "@labkey/components": "7.26.4",
         "@labkey/themes": "1.8.0"
       },
       "devDependencies": {
@@ -3716,9 +3716,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.50.1-fb-package-updates-0326.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.1-fb-package-updates-0326.0.tgz",
-      "integrity": "sha512-nJjR31pzNwRIRfFHBMdfB0bKTdldfRNrzwA8m+Dr8ATxMaKNx+MAUgJCUHqZqJwVUdX3JifWfgzLyrkPQ4uM3g==",
+      "version": "1.51.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.0.tgz",
+      "integrity": "sha512-pyYXCNbFF3HZQ8KVapcwBl/7cHlVDz0ysPlCRBUQ9czX6s2yLwiho0OWkBd9MpbGVkqGFihbTUsUAU+Y5rz5Pw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3759,13 +3759,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.26.2-fb-package-updates-0326.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.2-fb-package-updates-0326.0.tgz",
-      "integrity": "sha512-O6iGsBoyYfKHVp/v79eRvqtWkYULorOp4f4Hr07WSABkw+F+z4gCVH5TLMlUZAhKmoj9U7DeZafMn/ODWievPg==",
+      "version": "7.26.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.4.tgz",
+      "integrity": "sha512-pJ/P/qEiOdV2QYtLC+aDHcxUlroo5ENkYToYqb83+N4ksgmRYmv4oaTi0sIvXH0xSpRn3b31qys7gcHbL0yIbA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.50.1-fb-package-updates-0326.0",
+        "@labkey/api": "1.51.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.26.1",
+        "@labkey/components": "7.26.2-fb-package-updates-0326.0",
         "@labkey/themes": "1.8.0"
       },
       "devDependencies": {
@@ -3716,9 +3716,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.50.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.0.tgz",
-      "integrity": "sha512-1fiVQOP5UXvj1JW0LyJDtu3N8bgP95D9f7E+23w7BapabIT2xCvBj4YGRQZCvgSbW6pa+fH2Ayw542OFDWwfvA==",
+      "version": "1.50.1-fb-package-updates-0326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.1-fb-package-updates-0326.0.tgz",
+      "integrity": "sha512-nJjR31pzNwRIRfFHBMdfB0bKTdldfRNrzwA8m+Dr8ATxMaKNx+MAUgJCUHqZqJwVUdX3JifWfgzLyrkPQ4uM3g==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3759,13 +3759,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.26.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.1.tgz",
-      "integrity": "sha512-XfGooUwkx4U8MNMPwtOOO/KYrsTEDj8OR2PzSfn6Qon4JmmyUG+/OGzm82skp/vkXKRGyjpECms9Ueh6YCIMmw==",
+      "version": "7.26.2-fb-package-updates-0326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.2-fb-package-updates-0326.0.tgz",
+      "integrity": "sha512-O6iGsBoyYfKHVp/v79eRvqtWkYULorOp4f4Hr07WSABkw+F+z4gCVH5TLMlUZAhKmoj9U7DeZafMn/ODWievPg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.50.0",
+        "@labkey/api": "1.50.1-fb-package-updates-0326.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "7.26.2-fb-package-updates-0326.0",
+    "@labkey/components": "7.26.4",
     "@labkey/themes": "1.8.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "7.26.1",
+    "@labkey/components": "7.26.2-fb-package-updates-0326.0",
     "@labkey/themes": "1.8.0"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.26.1"
+        "@labkey/components": "7.26.2-fb-package-updates-0326.0"
       },
       "devDependencies": {
         "@labkey/build": "9.1.0",
@@ -3566,9 +3566,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.50.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.0.tgz",
-      "integrity": "sha512-1fiVQOP5UXvj1JW0LyJDtu3N8bgP95D9f7E+23w7BapabIT2xCvBj4YGRQZCvgSbW6pa+fH2Ayw542OFDWwfvA==",
+      "version": "1.50.1-fb-package-updates-0326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.1-fb-package-updates-0326.0.tgz",
+      "integrity": "sha512-nJjR31pzNwRIRfFHBMdfB0bKTdldfRNrzwA8m+Dr8ATxMaKNx+MAUgJCUHqZqJwVUdX3JifWfgzLyrkPQ4uM3g==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3609,13 +3609,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.26.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.1.tgz",
-      "integrity": "sha512-XfGooUwkx4U8MNMPwtOOO/KYrsTEDj8OR2PzSfn6Qon4JmmyUG+/OGzm82skp/vkXKRGyjpECms9Ueh6YCIMmw==",
+      "version": "7.26.2-fb-package-updates-0326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.2-fb-package-updates-0326.0.tgz",
+      "integrity": "sha512-O6iGsBoyYfKHVp/v79eRvqtWkYULorOp4f4Hr07WSABkw+F+z4gCVH5TLMlUZAhKmoj9U7DeZafMn/ODWievPg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.50.0",
+        "@labkey/api": "1.50.1-fb-package-updates-0326.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.26.2-fb-package-updates-0326.0"
+        "@labkey/components": "7.26.4"
       },
       "devDependencies": {
         "@labkey/build": "9.1.0",
@@ -3566,9 +3566,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.50.1-fb-package-updates-0326.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.1-fb-package-updates-0326.0.tgz",
-      "integrity": "sha512-nJjR31pzNwRIRfFHBMdfB0bKTdldfRNrzwA8m+Dr8ATxMaKNx+MAUgJCUHqZqJwVUdX3JifWfgzLyrkPQ4uM3g==",
+      "version": "1.51.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.0.tgz",
+      "integrity": "sha512-pyYXCNbFF3HZQ8KVapcwBl/7cHlVDz0ysPlCRBUQ9czX6s2yLwiho0OWkBd9MpbGVkqGFihbTUsUAU+Y5rz5Pw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3609,13 +3609,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.26.2-fb-package-updates-0326.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.2-fb-package-updates-0326.0.tgz",
-      "integrity": "sha512-O6iGsBoyYfKHVp/v79eRvqtWkYULorOp4f4Hr07WSABkw+F+z4gCVH5TLMlUZAhKmoj9U7DeZafMn/ODWievPg==",
+      "version": "7.26.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.4.tgz",
+      "integrity": "sha512-pJ/P/qEiOdV2QYtLC+aDHcxUlroo5ENkYToYqb83+N4ksgmRYmv4oaTi0sIvXH0xSpRn3b31qys7gcHbL0yIbA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.50.1-fb-package-updates-0326.0",
+        "@labkey/api": "1.51.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.26.2-fb-package-updates-0326.0"
+    "@labkey/components": "7.26.4"
   },
   "devDependencies": {
     "@labkey/build": "9.1.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.26.1"
+    "@labkey/components": "7.26.2-fb-package-updates-0326.0"
   },
   "devDependencies": {
     "@labkey/build": "9.1.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.26.2-fb-package-updates-0326.0"
+        "@labkey/components": "7.26.4"
       },
       "devDependencies": {
         "@labkey/build": "9.1.0",
@@ -2882,9 +2882,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.50.1-fb-package-updates-0326.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.1-fb-package-updates-0326.0.tgz",
-      "integrity": "sha512-nJjR31pzNwRIRfFHBMdfB0bKTdldfRNrzwA8m+Dr8ATxMaKNx+MAUgJCUHqZqJwVUdX3JifWfgzLyrkPQ4uM3g==",
+      "version": "1.51.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.0.tgz",
+      "integrity": "sha512-pyYXCNbFF3HZQ8KVapcwBl/7cHlVDz0ysPlCRBUQ9czX6s2yLwiho0OWkBd9MpbGVkqGFihbTUsUAU+Y5rz5Pw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2925,13 +2925,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.26.2-fb-package-updates-0326.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.2-fb-package-updates-0326.0.tgz",
-      "integrity": "sha512-O6iGsBoyYfKHVp/v79eRvqtWkYULorOp4f4Hr07WSABkw+F+z4gCVH5TLMlUZAhKmoj9U7DeZafMn/ODWievPg==",
+      "version": "7.26.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.4.tgz",
+      "integrity": "sha512-pJ/P/qEiOdV2QYtLC+aDHcxUlroo5ENkYToYqb83+N4ksgmRYmv4oaTi0sIvXH0xSpRn3b31qys7gcHbL0yIbA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.50.1-fb-package-updates-0326.0",
+        "@labkey/api": "1.51.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.26.1"
+        "@labkey/components": "7.26.2-fb-package-updates-0326.0"
       },
       "devDependencies": {
         "@labkey/build": "9.1.0",
@@ -2882,9 +2882,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.50.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.0.tgz",
-      "integrity": "sha512-1fiVQOP5UXvj1JW0LyJDtu3N8bgP95D9f7E+23w7BapabIT2xCvBj4YGRQZCvgSbW6pa+fH2Ayw542OFDWwfvA==",
+      "version": "1.50.1-fb-package-updates-0326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.50.1-fb-package-updates-0326.0.tgz",
+      "integrity": "sha512-nJjR31pzNwRIRfFHBMdfB0bKTdldfRNrzwA8m+Dr8ATxMaKNx+MAUgJCUHqZqJwVUdX3JifWfgzLyrkPQ4uM3g==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2925,13 +2925,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.26.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.1.tgz",
-      "integrity": "sha512-XfGooUwkx4U8MNMPwtOOO/KYrsTEDj8OR2PzSfn6Qon4JmmyUG+/OGzm82skp/vkXKRGyjpECms9Ueh6YCIMmw==",
+      "version": "7.26.2-fb-package-updates-0326.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.26.2-fb-package-updates-0326.0.tgz",
+      "integrity": "sha512-O6iGsBoyYfKHVp/v79eRvqtWkYULorOp4f4Hr07WSABkw+F+z4gCVH5TLMlUZAhKmoj9U7DeZafMn/ODWievPg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.50.0",
+        "@labkey/api": "1.50.1-fb-package-updates-0326.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "7.26.2-fb-package-updates-0326.0"
+    "@labkey/components": "7.26.4"
   },
   "devDependencies": {
     "@labkey/build": "9.1.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "7.26.1"
+    "@labkey/components": "7.26.2-fb-package-updates-0326.0"
   },
   "devDependencies": {
     "@labkey/build": "9.1.0",


### PR DESCRIPTION
#### Rationale
Bump `@labkey/api` dependency to the latest version.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/212
- https://github.com/LabKey/labkey-ui-components/pull/1968
- https://github.com/LabKey/labkey-ui-premium/pull/921
- https://github.com/LabKey/limsModules/pull/2077
- https://github.com/LabKey/platform/pull/7533

#### Changes
- Bump `@labkey/api` by way of `@labkey/components`
