### PR TITLE
Improve accessibility - remove inappropriate role="presentation" on tabs

### DIFF
--- a/core/src/org/labkey/core/view/template/bootstrap/navigation.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/navigation.jsp
@@ -114,8 +114,8 @@
                             if (show && null != tab.getText() && !tab.getText().isEmpty())
                             {
                 %>
-                <li role="presentation" class="<%= unsafe(tab.isSelected() ? "active" : "") %>">
-                    <a href="<%=h(tab.getHref())%>" id="<%=h(tab.getText().replace(" ", ""))%>Tab">
+                <li class="<%= unsafe(tab.isSelected() ? "active" : "") %>">
+                    <a href="<%=h(tab.getHref())%>" id="<%=h(tab.getText().replace(" ", ""))%>Tab"<%= unsafe(tab.isSelected() ? " aria-current=\"page\"" : "") %>>
                         <% if (tab.isDisabled()) { %>
                         <i class="fa fa-eye-slash"></i>
                         <% } %>
@@ -141,7 +141,7 @@
                     {
                         HtmlString plus = HtmlString.unsafe("<i class=\"fa fa-plus\" style=\"font-size: 12px;\"></i>");
                 %>
-                <li role="presentation">
+                <li>
                     <%=simpleLink(plus).id("addTab").title("Add New Tab").onClick("LABKEY.Portal.addTab();")%>
                 </li>
                 <%
@@ -160,7 +160,7 @@
                                 if (tab.isSelected())
                                 {
                 %>
-                <li role="presentation" class="dropdown active">
+                <li class="dropdown active">
                     <a data-target="#" class="dropdown-toggle" data-toggle="dropdown">
                         <%=h(tab.getText())%>&nbsp;
                         <span class="fa fa-chevron-down" style="font-size: 12px;"></span>
@@ -181,7 +181,7 @@
                                 {
                         %>
                         <li>
-                            <a href="<%=h(tab.getHref())%>">
+                            <a href="<%=h(tab.getHref())%>"<%= unsafe(tab.isSelected() ? " aria-current=\"page\"" : "") %>>
                                 <% if (tab.isSelected())
                                    {
                                         %><b><%=h(tab.getText())%></b><%


### PR DESCRIPTION
#### Rationale
We are inappropriately tagging our folder portal tabs with `role="presentation"`. You're not allowed to use it on an `<li>` without a similar tag on a parent element like the `<ul>`.

Since these tabs are full-page navigations instead of in-page replacements, it seems the most appropriate thing is to simply remove this incorrect attribute.

https://www.w3.org/WAI/ARIA/apg/practices/hiding-semantics/

#### Changes
- Remove `role="presentation"` from folder portal tabs
- Signify the active tab using `aria-current="page"`

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->