### PR TITLE
Triggers: support managing columns for data iteration

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -38,6 +38,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.collections.CollectionUtils;
+import org.labkey.api.collections.DeltaTrackingMap;
 import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.collections.Sampler;
 import org.labkey.api.collections.SwapQueue;
@@ -385,6 +386,7 @@ public class ApiModule extends CodeOnlyModule
             DatabaseCache.TestCase.class,
             DateUtil.TestCase.class,
             DbScope.DialectTestCase.class,
+            DeltaTrackingMap.TestCase.class,
             DetailsURL.TestCase.class,
             DiskCachingDataIterator.DiskTestCase.class,
             EmailTemplate.TestCase.class,

--- a/api/src/org/labkey/api/admin/FolderImportContext.java
+++ b/api/src/org/labkey/api/admin/FolderImportContext.java
@@ -40,10 +40,6 @@ import java.util.Set;
 
 import static org.labkey.api.exp.XarContext.XAR_JOB_ID_NAME;
 
-/**
- * User: cnathe
- * Date: Jan 18, 2012
- */
 public class FolderImportContext extends AbstractFolderContext
 {
     private FileLike _folderXml;
@@ -56,8 +52,6 @@ public class FolderImportContext extends AbstractFolderContext
     private static final String FOLDER_IMPORT_DB_SEQUENCE_PREFIX = "FolderImportJobCounter-";
 
     private boolean _isNewFolderImport; // if we know the target folder is empty, can skip certain merge logic
-
-    public static final String IS_NEW_FOLDER_IMPORT_KEY = "isNewFolderImport";
 
     /** Required for xstream serialization on Java 7 */
     @SuppressWarnings({"UnusedDeclaration"})

--- a/api/src/org/labkey/api/collections/DeltaTrackingMap.java
+++ b/api/src/org/labkey/api/collections/DeltaTrackingMap.java
@@ -1,0 +1,432 @@
+package org.labkey.api.collections;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A lightweight Map proxy that tracks structural modifications (additions and removals)
+ * without requiring deep copies or full iteration of the underlying map.
+ * <p>
+ * This class is highly optimized for "happy path" data-processing scenarios where structural
+ * changes are rare. Tracking sets are allocated lazily only upon the first actual addition
+ * or removal. Standard value updates to existing keys pass through with zero allocation overhead.
+ * <p>
+ * <b>Example Usage:</b>
+ * <pre>{@code
+ * Map<String, Object> baseRow = new CaseInsensitiveHashMap<>();
+ * baseRow.put("ColumnA", "Value1");
+ *
+ * DeltaTrackingMap<Object> trackedRow = new DeltaTrackingMap<>(baseRow);
+ *
+ * // Updating an existing key (zero tracking overhead)
+ * trackedRow.put("ColumnA", "NewValue");
+ *
+ * // Adding a new key
+ * trackedRow.put("ColumnB", "Value2");
+ *
+ * // Removing a key
+ * trackedRow.remove("ColumnA");
+ *
+ * if (trackedRow.hasStructuralChanges())
+ * {
+ *     Set<String> added = trackedRow.getAddedKeys();     // Contains ["ColumnB"]
+ *     Set<String> removed = trackedRow.getRemovedKeys(); // Contains ["ColumnA"]
+ *
+ *     // Reset tracking state if you need to pass the map to another processor
+ *     trackedRow.resetTracking();
+ * }
+ * }</pre>
+ *
+ * @param <V> the type of mapped values
+ */
+public class DeltaTrackingMap<V> implements Map<String, V>
+{
+    private final Map<String, V> delegate;
+    private Set<String> added = null;
+    private Set<String> removed = null;
+
+    public DeltaTrackingMap(Map<String, V> delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public V put(String key, V value)
+    {
+        boolean isNew = !delegate.containsKey(key);
+        V prev = delegate.put(key, value);
+
+        if (isNew)
+        {
+            // If it was previously removed, an add operation cancels out the removal
+            if (removed != null && removed.contains(key))
+                removed.remove(key);
+            else
+            {
+                if (added == null)
+                    added = Sets.newCaseInsensitiveHashSet();
+                added.add(key);
+            }
+        }
+
+        return prev;
+    }
+
+    @Override
+    public V remove(Object key)
+    {
+        boolean exists = delegate.containsKey(key);
+        V prev = delegate.remove(key);
+
+        if (exists && key instanceof String strKey)
+        {
+            // If it was just added, a remove cancels out the add operation
+            if (added != null && added.contains(strKey))
+                added.remove(strKey);
+            else
+            {
+                if (removed == null)
+                    removed = Sets.newCaseInsensitiveHashSet();
+                removed.add(strKey);
+            }
+        }
+
+        return prev;
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends V> m)
+    {
+        for (Entry<? extends String, ? extends V> entry : m.entrySet())
+            put(entry.getKey(), entry.getValue());
+    }
+
+    @Override
+    public void clear()
+    {
+        // Snapshot keys first to avoid ConcurrentModificationException during removal
+        for (String key : new ArrayList<>(delegate.keySet()))
+            remove(key);
+    }
+
+    // --- State Checking and Reset ---
+
+    public boolean hasStructuralChanges()
+    {
+        return (added != null && !added.isEmpty()) || (removed != null && !removed.isEmpty());
+    }
+
+    public Set<String> getAddedKeys()
+    {
+        return added != null ? Collections.unmodifiableSet(added) : Collections.emptySet();
+    }
+
+    public Set<String> getRemovedKeys()
+    {
+        return removed != null ? Collections.unmodifiableSet(removed) : Collections.emptySet();
+    }
+
+    public void resetTracking()
+    {
+        if (added != null) added.clear();
+        if (removed != null) removed.clear();
+    }
+
+    // --- Standard Delegated Methods ---
+
+    @Override
+    public int size()
+    {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key)
+    {
+        return delegate.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value)
+    {
+        return delegate.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key)
+    {
+        return delegate.get(key);
+    }
+
+    @Override
+    public @NotNull Set<String> keySet()
+    {
+        return delegate.keySet();
+    }
+
+    @Override
+    public @NotNull Collection<V> values()
+    {
+        return delegate.values();
+    }
+
+    @Override
+    public @NotNull Set<Entry<String, V>> entrySet()
+    {
+        return delegate.entrySet();
+    }
+
+    public static class TestCase extends Assert
+    {
+        private static DeltaTrackingMap<String> createTracker()
+        {
+            Map<String, String> baseMap = new CaseInsensitiveHashMap<>();
+            baseMap.put("ExistingKey1", "Value1");
+            baseMap.put("ExistingKey2", "Value2");
+            baseMap.put("ExistingKey3", "Value3");
+            return new DeltaTrackingMap<>(baseMap);
+        }
+
+        @Test
+        public void testNoStructuralChanges()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+
+            // Updating an existing key should not trigger structural changes
+            map.put("ExistingKey1", "NewValue1");
+            // Case-insensitive update of an existing key
+            map.put("existingkey2", "NewValue2");
+
+            assertFalse("Updates to existing keys should not flag structural changes", map.hasStructuralChanges());
+            assertTrue(map.getAddedKeys().isEmpty());
+            assertTrue(map.getRemovedKeys().isEmpty());
+        }
+
+        @Test
+        public void testAdditions()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+
+            map.put("NewKey1", "NewValue");
+            assertTrue("Adding a key should flag structural changes", map.hasStructuralChanges());
+            assertTrue(map.getAddedKeys().contains("NewKey1"));
+            assertTrue(map.getRemovedKeys().isEmpty());
+
+            // Case-insensitive check of the tracking set
+            assertTrue(map.getAddedKeys().contains("newkey1"));
+        }
+
+        @Test
+        public void testRemovals()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+
+            map.remove("ExistingKey1");
+            assertTrue("Removing a key should flag structural changes", map.hasStructuralChanges());
+            assertTrue(map.getRemovedKeys().contains("ExistingKey1"));
+            assertTrue(map.getAddedKeys().isEmpty());
+
+            // Case-insensitive remove and check
+            map.remove("existingkey2");
+            assertTrue(map.getRemovedKeys().contains("ExistingKey2"));
+            assertEquals(2, map.getRemovedKeys().size());
+        }
+
+        @Test
+        public void testCancellations()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+
+            // Remove then Add (Cancels the removal)
+            map.remove("ExistingKey1");
+            assertTrue(map.getRemovedKeys().contains("ExistingKey1"));
+
+            map.put("ExistingKey1", "RestoredValue");
+            assertFalse("Adding back a removed key should cancel the structural change", map.hasStructuralChanges());
+            assertTrue(map.getRemovedKeys().isEmpty());
+            assertTrue(map.getAddedKeys().isEmpty());
+
+            // Add then Remove (Cancels the addition)
+            map.put("TemporaryKey", "TempValue");
+            assertTrue(map.getAddedKeys().contains("TemporaryKey"));
+
+            map.remove("TemporaryKey");
+            assertFalse("Removing a newly added key should cancel the structural change", map.hasStructuralChanges());
+            assertTrue(map.getRemovedKeys().isEmpty());
+            assertTrue(map.getAddedKeys().isEmpty());
+        }
+
+        @Test
+        public void testBulkOperations()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+
+            // test putAll()
+            Map<String, String> bulkAdds = new CaseInsensitiveHashMap<>();
+            bulkAdds.put("ExistingKey1", "UpdatedValue"); // Update
+            bulkAdds.put("NewBulk1", "V1");               // Add
+            bulkAdds.put("NewBulk2", "V2");               // Add
+
+            map.putAll(bulkAdds);
+            assertTrue(map.hasStructuralChanges());
+            assertEquals("Should only track the 2 new keys", 2, map.getAddedKeys().size());
+            assertTrue(map.getAddedKeys().contains("NewBulk1"));
+            assertTrue(map.getAddedKeys().contains("NewBulk2"));
+
+            map.resetTracking();
+
+            // test clear()
+            map.clear();
+            assertTrue(map.hasStructuralChanges());
+            assertEquals("Should track all keys removed during clear", 5, map.getRemovedKeys().size());
+            assertTrue(map.isEmpty());
+        }
+
+        @Test
+        public void testResetTracking()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+
+            map.put("NewKey", "Val");
+            map.remove("ExistingKey1");
+
+            assertTrue(map.hasStructuralChanges());
+            assertEquals(1, map.getAddedKeys().size());
+            assertEquals(1, map.getRemovedKeys().size());
+
+            map.resetTracking();
+
+            assertFalse(map.hasStructuralChanges());
+            assertTrue(map.getAddedKeys().isEmpty());
+            assertTrue(map.getRemovedKeys().isEmpty());
+        }
+
+        @Test
+        public void testEncapsulationOfTrackingSets()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+            map.put("NewKey", "Val");
+
+            Set<String> addedKeys = map.getAddedKeys();
+            try
+            {
+                addedKeys.remove("NewKey");
+                fail("getAddedKeys() should return an unmodifiable set to prevent internal state corruption.");
+            }
+            catch (UnsupportedOperationException e)
+            {
+                // Expected behavior
+            }
+        }
+
+        @Test
+        public void testCrossCaseCancellations()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+
+            // 1. Remove Exact, Add Lowercase (Cancels the removal)
+            map.remove("ExistingKey1");
+            map.put("existingkey1", "RestoredValue"); // Different casing than original
+
+            assertFalse("Adding back a removed key with different casing should cancel the structural change", map.hasStructuralChanges());
+            assertTrue(map.getRemovedKeys().isEmpty());
+            assertTrue(map.getAddedKeys().isEmpty());
+
+            // 2. Add Exact, Remove Lowercase (Cancels the addition)
+            map.put("TemporaryKey", "TempValue");
+            map.remove("temporarykey"); // Different casing than addition
+
+            assertFalse("Removing a newly added key with different casing should cancel the structural change", map.hasStructuralChanges());
+            assertTrue(map.getRemovedKeys().isEmpty());
+            assertTrue(map.getAddedKeys().isEmpty());
+        }
+
+        @Test
+        public void testNullValues()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+
+            // Adding a new key with a null value
+            map.put("NullValueKey", null);
+            assertTrue(map.hasStructuralChanges());
+            assertTrue(map.getAddedKeys().contains("NullValueKey"));
+
+            // Updating an existing key to null
+            map.put("ExistingKey1", null);
+            assertEquals("Updating existing key to null should not trigger structural changes", 1, map.getAddedKeys().size());
+            assertTrue(map.getRemovedKeys().isEmpty());
+        }
+
+        @Test
+        public void testNonStringRemoval()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+
+            // Verify passing a non-String doesn't throw a ClassCastException.
+            String result = map.remove(12345);
+            assertNull(result);
+            assertFalse("Removing a non-existent, non-string key should do nothing", map.hasStructuralChanges());
+        }
+
+        @Test
+        public void testWithLinkedHashMap()
+        {
+            // Use a standard, case-sensitive map which preserves insertion order
+            Map<String, String> baseMap = new LinkedHashMap<>();
+            baseMap.put("FirstKey", "V1");
+            baseMap.put("SecondKey", "V2");
+
+            DeltaTrackingMap<String> map = new DeltaTrackingMap<>(baseMap);
+
+            // Verify standard tracking works normally
+            map.put("ThirdKey", "V3");
+            map.remove("FirstKey");
+
+            assertTrue(map.hasStructuralChanges());
+            assertEquals(1, map.getAddedKeys().size());
+            assertTrue(map.getAddedKeys().contains("ThirdKey"));
+
+            assertEquals(1, map.getRemovedKeys().size());
+            assertTrue(map.getRemovedKeys().contains("FirstKey"));
+
+            // Verify underlying map features (iteration order) are preserved
+            map.put("FourthKey", "V4");
+
+            String[] expectedOrder = {"SecondKey", "ThirdKey", "FourthKey"};
+            int i = 0;
+            for (String key : map.keySet())
+            {
+                assertEquals("Iteration order should match LinkedHashMap's insertion order", expectedOrder[i], key);
+                i++;
+            }
+
+            map.resetTracking();
+
+            map.put("secondkey", "V-lower");
+
+            assertEquals("LinkedHashMap treats different casing as distinct keys", 4, map.size());
+            assertTrue("Tracker flagged the new key", map.getAddedKeys().contains("secondkey"));
+
+            map.remove("SecondKey");
+
+            assertEquals(3, map.size());
+            assertFalse(map.containsKey("SecondKey"));
+            assertTrue(map.containsKey("secondkey"));
+            assertFalse("Tracker lost the state because case-insensitive matching cancelled out the add/remove", map.hasStructuralChanges());
+        }
+    }
+}

--- a/api/src/org/labkey/api/collections/DeltaTrackingMap.java
+++ b/api/src/org/labkey/api/collections/DeltaTrackingMap.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -24,7 +25,7 @@ import java.util.Set;
  * Map<String, Object> baseRow = new CaseInsensitiveHashMap<>();
  * baseRow.put("ColumnA", "Value1");
  *
- * DeltaTrackingMap<Object> trackedRow = new DeltaTrackingMap<>(baseRow);
+ * DeltaTrackingMap<Object> trackedRow = DeltaTrackingMap.wrap(baseRow);
  *
  * // Updating an existing key (zero tracking overhead)
  * trackedRow.put("ColumnA", "NewValue");
@@ -58,6 +59,11 @@ public class DeltaTrackingMap<V> implements Map<String, V>
         this.delegate = delegate;
     }
 
+    protected Set<String> newTrackingSet()
+    {
+        return new HashSet<>();
+    }
+
     @Override
     public V put(String key, V value)
     {
@@ -72,7 +78,7 @@ public class DeltaTrackingMap<V> implements Map<String, V>
             else
             {
                 if (added == null)
-                    added = Sets.newCaseInsensitiveHashSet();
+                    added = newTrackingSet();
                 added.add(key);
             }
         }
@@ -94,7 +100,7 @@ public class DeltaTrackingMap<V> implements Map<String, V>
             else
             {
                 if (removed == null)
-                    removed = Sets.newCaseInsensitiveHashSet();
+                    removed = newTrackingSet();
                 removed.add(strKey);
             }
         }
@@ -202,6 +208,41 @@ public class DeltaTrackingMap<V> implements Map<String, V>
         return Collections.unmodifiableSet(delegate.entrySet());
     }
 
+    /**
+     * Returns a {@link CaseInsensitive} wrapper when the delegate implements
+     * {@link CaseInsensitiveCollection}, and a plain {@link DeltaTrackingMap} otherwise.
+     * Prefer this over calling a constructor directly when the case-sensitivity of the
+     * delegate is not known at compile time.
+     */
+    public static <V> DeltaTrackingMap<V> wrap(Map<String, V> delegate)
+    {
+        if (delegate instanceof CaseInsensitiveCollection)
+            return new DeltaTrackingMap.CaseInsensitive<>(delegate);
+        return new DeltaTrackingMap<>(delegate);
+    }
+
+    /**
+     * A case-insensitive variant of {@link DeltaTrackingMap} that also implements
+     * {@link CaseInsensitiveCollection}. Use this when wrapping a case-insensitive delegate such
+     * as {@link CaseInsensitiveHashMap} so that downstream code relying on
+     * {@code instanceof CaseInsensitiveCollection} continues to work correctly.
+     *
+     * @param <V> the type of mapped values
+     */
+    public static class CaseInsensitive<V> extends DeltaTrackingMap<V> implements CaseInsensitiveCollection
+    {
+        public CaseInsensitive(Map<String, V> delegate)
+        {
+            super(delegate);
+        }
+
+        @Override
+        protected Set<String> newTrackingSet()
+        {
+            return new CaseInsensitiveHashSet();
+        }
+    }
+
     public static class TestCase extends Assert
     {
         private static DeltaTrackingMap<String> createTracker()
@@ -210,7 +251,7 @@ public class DeltaTrackingMap<V> implements Map<String, V>
             baseMap.put("ExistingKey1", "Value1");
             baseMap.put("ExistingKey2", "Value2");
             baseMap.put("ExistingKey3", "Value3");
-            return new DeltaTrackingMap<>(baseMap);
+            return new DeltaTrackingMap.CaseInsensitive<>(baseMap);
         }
 
         @Test
@@ -437,6 +478,58 @@ public class DeltaTrackingMap<V> implements Map<String, V>
         }
 
         @Test
+        public void testCaseSensitiveDelegateTracking()
+        {
+            // A case-sensitive delegate must use case-sensitive tracking sets so that
+            // differently cased variants of a key are treated as independent entries.
+            Map<String, String> baseMap = new LinkedHashMap<>();
+            baseMap.put("Key", "Value");
+            DeltaTrackingMap<String> map = new DeltaTrackingMap<>(baseMap);
+
+            // "key" is a brand-new key in a case-sensitive map — must be tracked as an addition
+            map.put("key", "lowerValue");
+            assertTrue(map.hasStructuralChanges());
+            assertEquals(1, map.getAddedKeys().size());
+            assertTrue("Added 'key'", map.getAddedKeys().contains("key"));
+            assertFalse("'Key' was not added", map.getAddedKeys().contains("Key"));
+
+            // Removing "Key" (original casing) must NOT cancel the tracking of the added "key"
+            map.remove("Key");
+            assertEquals("'key' (added) and 'Key' (removed) are independent", 1, map.getAddedKeys().size());
+            assertTrue(map.getAddedKeys().contains("key"));
+            assertEquals(1, map.getRemovedKeys().size());
+            assertTrue(map.getRemovedKeys().contains("Key"));
+            assertFalse("'key' was not removed", map.getRemovedKeys().contains("key"));
+        }
+
+        @Test
+        public void testEntrySetValueUpdate()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+
+            // Get the entry for "ExistingKey1" and update its value directly
+            Map.Entry<String, String> found = null;
+            for (Map.Entry<String, String> e : map.entrySet())
+            {
+                if ("ExistingKey1".equals(e.getKey()))
+                {
+                    found = e;
+                    break;
+                }
+            }
+            assertNotNull(found);
+
+            String oldValue = found.setValue("UpdatedViaEntry");
+            assertEquals("Value1", oldValue);
+            assertEquals("UpdatedViaEntry", map.get("ExistingKey1"));
+
+            // entry.setValue() is a value-only mutation; no key was added or removed
+            assertFalse("entry.setValue() on an existing key must not flag structural changes", map.hasStructuralChanges());
+            assertTrue(map.getAddedKeys().isEmpty());
+            assertTrue(map.getRemovedKeys().isEmpty());
+        }
+
+        @Test
         public void testWithLinkedHashMap()
         {
             // Use a standard, case-sensitive map which preserves insertion order
@@ -480,7 +573,16 @@ public class DeltaTrackingMap<V> implements Map<String, V>
             assertEquals(3, map.size());
             assertFalse(map.containsKey("SecondKey"));
             assertTrue(map.containsKey("secondkey"));
-            assertFalse("Tracker lost the state because case-insensitive matching cancelled out the add/remove", map.hasStructuralChanges());
+
+            // With a case-sensitive delegate, "secondkey" (added) and "SecondKey" (removed)
+            // are different keys and must be tracked independently — no cancellation.
+            assertTrue("Case-sensitive delegate: add and remove of differently-cased keys must not cancel", map.hasStructuralChanges());
+            assertEquals(1, map.getAddedKeys().size());
+            assertTrue(map.getAddedKeys().contains("secondkey"));
+            assertFalse(map.getAddedKeys().contains("SecondKey"));
+            assertEquals(1, map.getRemovedKeys().size());
+            assertTrue(map.getRemovedKeys().contains("SecondKey"));
+            assertFalse(map.getRemovedKeys().contains("secondkey"));
         }
     }
 }

--- a/api/src/org/labkey/api/collections/DeltaTrackingMap.java
+++ b/api/src/org/labkey/api/collections/DeltaTrackingMap.java
@@ -172,22 +172,34 @@ public class DeltaTrackingMap<V> implements Map<String, V>
         return delegate.get(key);
     }
 
+    /**
+     * Returns an unmodifiable view of the key set. Use {@link #put} and {@link #remove} to
+     * mutate the map so that structural changes are correctly tracked.
+     */
     @Override
     public @NotNull Set<String> keySet()
     {
-        return delegate.keySet();
+        return Collections.unmodifiableSet(delegate.keySet());
     }
 
+    /**
+     * Returns an unmodifiable view of the values collection. Use {@link #put} and {@link #remove} to
+     * mutate the map so that structural changes are correctly tracked.
+     */
     @Override
     public @NotNull Collection<V> values()
     {
-        return delegate.values();
+        return Collections.unmodifiableCollection(delegate.values());
     }
 
+    /**
+     * Returns an unmodifiable view of the entry set. Use {@link #put} and {@link #remove} to
+     * mutate the map so that structural changes are correctly tracked.
+     */
     @Override
     public @NotNull Set<Entry<String, V>> entrySet()
     {
-        return delegate.entrySet();
+        return Collections.unmodifiableSet(delegate.entrySet());
     }
 
     public static class TestCase extends Assert
@@ -331,6 +343,48 @@ public class DeltaTrackingMap<V> implements Map<String, V>
             {
                 // Expected behavior
             }
+        }
+
+        @Test
+        public void testMapViewsAreUnmodifiable()
+        {
+            DeltaTrackingMap<String> map = createTracker();
+
+            // keySet().remove() must not bypass tracking
+            try
+            {
+                map.keySet().remove("ExistingKey1");
+                fail("keySet() should return an unmodifiable view.");
+            }
+            catch (UnsupportedOperationException e)
+            {
+                // Expected behavior
+            }
+            assertFalse("keySet().remove() must not have modified the map", map.hasStructuralChanges());
+            assertTrue(map.containsKey("ExistingKey1"));
+
+            // entrySet() iterator remove() must not bypass tracking
+            try
+            {
+                map.entrySet().iterator().remove();
+                fail("entrySet() should return an unmodifiable view.");
+            }
+            catch (UnsupportedOperationException e)
+            {
+                // Expected behavior
+            }
+
+            // values() remove() must not bypass tracking
+            try
+            {
+                map.values().remove("Value1");
+                fail("values() should return an unmodifiable view.");
+            }
+            catch (UnsupportedOperationException e)
+            {
+                // Expected behavior
+            }
+            assertFalse("No mutations should have been tracked", map.hasStructuralChanges());
         }
 
         @Test

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -2019,7 +2019,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                 break;
 
             // trackedRow should only be null when not manageColumns
-            if (trackedRow != null)
+            if (trackedRow != null && script.isManagedColumnsEnabled())
             {
                 var managed = script.getManagedColumns();
                 var managedCols = managed != null ? managed.getColumns(type) : null;

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -2009,7 +2009,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
         if (newRow != null && manageColumns)
         {
-            trackedRow = new DeltaTrackingMap<>(newRow);
+            trackedRow = DeltaTrackingMap.wrap(newRow);
             newRowTracked = trackedRow;
         }
 

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -62,6 +62,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.settings.AppProps;
 import org.labkey.api.sql.LabKeySql;
 import org.labkey.api.study.assay.FileLinkDisplayColumn;
 import org.labkey.api.util.ConfigurationException;
@@ -1887,7 +1888,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     }
 
     @Override
-    public @Nullable Set<String> getTriggerManagedColumns(@Nullable Container c)
+    public @Nullable Set<String> getTriggerManagedColumns(@Nullable Container c, QueryUpdateService.InsertOption insertOption)
     {
         var triggers = getTriggers(c);
         if (triggers.isEmpty())
@@ -1900,8 +1901,10 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             if (managedColumns == null)
                 continue;
 
-            columns.addAll(managedColumns.insert());
-            columns.addAll(managedColumns.update());
+            if (insertOption.updateOnly)
+                columns.addAll(managedColumns.update());
+            else
+                columns.addAll(managedColumns.insert());
         }
 
         return columns.isEmpty() ? null : columns;
@@ -1968,7 +1971,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
     @Override
     public void fireRowTrigger(Container c, User user, TriggerType type, boolean before, int rowNumber,
-                               @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord)
+                               @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord, boolean manageColumns)
             throws ValidationException
     {
         ValidationException errors = new ValidationException();
@@ -2024,7 +2027,11 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                         if (!removed.isEmpty())
                             diffs.add("remove: " + String.join(", ", removed));
 
-                        errors.addGlobalError("Trigger '" + script.getName() + "' attempted to " + String.join(", ", diffs) + ". Declare columns via getManagedColumns() to include them in the column set.");
+                        String message = "Trigger '" + script.getName() + "' attempted to " + String.join(", ", diffs) + ". Declare managed columns to include them in the column set.";
+                        if (manageColumns)
+                            errors.addGlobalError(message);
+                        else
+                            LOG.warn(message + " This will be an error if invoked via data iteration.");
                     }
                 }
 
@@ -2034,7 +2041,13 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                     for (var col : managedCols)
                     {
                         if (!newRow.containsKey(col))
-                            errors.addFieldError(col, "Trigger '" + script.getName() + "' declared column '" + col + "' in getManagedColumns() but did not set a value for it. Set null to clear or provide a value.");
+                        {
+                            String message = "Trigger '" + script.getName() + "' declared the managed column '" + col + "' but did not set a value for it. Set null to clear or provide a value.";
+                            if (manageColumns)
+                                errors.addFieldError(col, message);
+                            else
+                                LOG.warn(message + " This will be an error if invoked via data iteration.");
+                        }
                     }
                 }
             }

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -63,7 +63,6 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.sql.LabKeySql;
 import org.labkey.api.study.assay.FileLinkDisplayColumn;
 import org.labkey.api.util.ConfigurationException;
@@ -1952,7 +1951,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     }
 
     @Override
-    public final void fireBatchTrigger(Container c, User user, TriggerType type, boolean before, BatchValidationException batchErrors, Map<String, Object> extraContext)
+    public final void fireBatchTrigger(Container c, User user, TriggerType type, @Nullable QueryUpdateService.InsertOption insertOption, boolean before, BatchValidationException batchErrors, Map<String, Object> extraContext)
             throws BatchValidationException
     {
         assert batchErrors != null;
@@ -1971,9 +1970,19 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     }
 
     @Override
-    public void fireRowTrigger(Container c, User user, TriggerType type, boolean before, int rowNumber,
-                               @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord, boolean manageColumns)
-            throws ValidationException
+    public void fireRowTrigger(
+        Container c,
+        User user,
+        TriggerType type,
+        @Nullable QueryUpdateService.InsertOption insertOption,
+        boolean before,
+        int rowNumber,
+        @Nullable Map<String, Object> newRow,
+        @Nullable Map<String, Object> oldRow,
+        Map<String, Object> extraContext,
+        @Nullable Map<String, Object> existingRecord,
+        boolean manageColumns
+    ) throws ValidationException
     {
         ValidationException errors = new ValidationException();
         errors.setSchemaName(getPublicSchemaName());
@@ -1998,7 +2007,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             if (trackedRow != null)
                 trackedRow.resetTracking();
 
-            script.rowTrigger(this, c, user, type, before, rowNumber, newRowTracked, oldRow, errors, extraContext, existingRecord);
+            script.rowTrigger(this, c, user, type, insertOption, before, rowNumber, newRowTracked, oldRow, errors, extraContext, existingRecord);
             if (errors.hasErrors())
                 break;
 

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -1987,8 +1987,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         @Nullable Map<String, Object> newRow,
         @Nullable Map<String, Object> oldRow,
         Map<String, Object> extraContext,
-        @Nullable Map<String, Object> existingRecord,
-        boolean manageColumns
+        @Nullable Map<String, Object> existingRecord
     ) throws ValidationException
     {
         ValidationException errors = new ValidationException();
@@ -2002,8 +2001,9 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         // Wrap the row once before the loop
         DeltaTrackingMap<Object> trackedRow = null;
         Map<String, Object> newRowTracked = newRow;
+        boolean manageColumns = before && insertOption != null && isTriggerManagedColumnsEnabled();
 
-        if (newRow != null && before && isTriggerManagedColumnsEnabled())
+        if (newRow != null && manageColumns)
         {
             trackedRow = new DeltaTrackingMap<>(newRow);
             newRowTracked = trackedRow;
@@ -2018,6 +2018,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             if (errors.hasErrors())
                 break;
 
+            // trackedRow should only be null when not manageColumns
             if (trackedRow != null)
             {
                 var managed = script.getManagedColumns();
@@ -2050,13 +2051,8 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                             diffs.add("remove: " + removed.stream().map(col -> "'" + col + "'").collect(Collectors.joining(", ")));
 
                         String message = "Trigger '" + script.getName() + "' attempted to " + String.join(", ", diffs) + ". Declare managed columns to include them in the column set.";
-                        if (manageColumns)
-                        {
-                            errors.addGlobalError(message);
-                            break;
-                        }
-
-                        LOG.warn(message + " This will be an error if invoked via data iteration.");
+                        errors.addGlobalError(message);
+                        break;
                     }
                 }
 
@@ -2070,15 +2066,10 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                     {
                         if (!newRowTracked.containsKey(col))
                         {
+                            // Not using errors.addFieldError() here as the managed column may not be visible
                             String message = "Trigger '" + script.getName() + "' declared the managed column '" + col + "' but did not set a value for it. Set null to clear or provide a value.";
-                            if (manageColumns)
-                            {
-                                // Not using errors.addFieldError() here as the managed column may not be visible
-                                errors.addGlobalError(message);
-                                break;
-                            }
-
-                            LOG.warn(message + " This will be an error if invoked via data iteration.");
+                            errors.addGlobalError(message);
+                            break;
                         }
                     }
                 }

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -30,6 +30,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
 import org.labkey.api.collections.NamedObjectList;
+import org.labkey.api.collections.Sets;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.triggers.ScriptTriggerFactory;
 import org.labkey.api.data.triggers.Trigger;
@@ -1884,6 +1885,24 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         return true;
     }
 
+    @Override
+    public @Nullable Set<String> getTriggerManagedColumns(@Nullable Container c)
+    {
+        var triggers = getTriggers(c);
+        if (triggers.isEmpty())
+            return null;
+
+        var columns = triggers.stream()
+                .map(Trigger::getManagedColumns)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .toList();
+
+        if (columns.isEmpty())
+            return null;
+
+        return Sets.newCaseInsensitiveHashSet(columns);
+    }
 
     private Collection<Trigger> _triggers = null;
 
@@ -1959,7 +1978,63 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
         for (Trigger script : triggers)
         {
+            var managed = before ? script.getManagedColumns() : null;
+
+            // Inject sentinel for each declared column absent from the row; the trigger must handle it
+            if (newRow != null && managed != null && before)
+            {
+                for (var col : managed)
+                    newRow.putIfAbsent(col, Trigger.COLUMN_SENTINEL);
+            }
+
+            // Snapshot keys after injection — trigger may update values but must not alter the key set
+            var keysBeforeTrigger = newRow != null && before ? Set.copyOf(newRow.keySet()) : null;
+
             script.rowTrigger(this, c, user, type, before, rowNumber, newRow, oldRow, errors, extraContext, existingRecord);
+            if (errors.hasErrors())
+                break;
+
+            if (newRow != null && before)
+            {
+                // Verify the trigger did not add or remove columns that are not managed
+                if (!newRow.keySet().equals(keysBeforeTrigger))
+                {
+                    var added = Sets.newCaseInsensitiveHashSet(newRow.keySet());
+                    added.removeAll(keysBeforeTrigger);
+
+                    var removed = Sets.newCaseInsensitiveHashSet(keysBeforeTrigger);
+                    removed.removeAll(newRow.keySet());
+
+                    // managed column removals are intentional
+                    if (managed != null)
+                    {
+                        added.removeAll(managed);
+                        removed.removeAll(managed);
+                    }
+
+                    if (!added.isEmpty() || !removed.isEmpty())
+                    {
+                        var diffs = new ArrayList<String>();
+                        if (!added.isEmpty())
+                            diffs.add("add: " + String.join(", ", added));
+                        if (!removed.isEmpty())
+                            diffs.add("remove: " + String.join(", ", removed));
+
+                        errors.addGlobalError("Trigger '" + script.getName() + "' attempted to " + String.join(", ", diffs) + ". Declare columns via getManagedColumns() to include them in the column set.");
+                    }
+                }
+
+                // Verify the trigger handled every declared column it was responsible for
+                if (managed != null)
+                {
+                    for (var col : managed)
+                    {
+                        if (newRow.get(col) == Trigger.COLUMN_SENTINEL)
+                            errors.addFieldError(col, "Trigger '" + script.getName() + "' declared column '" + col + "' in getManagedColumns() but did not set a value for it. Set null to clear or provide a value.");
+                    }
+                }
+            }
+
             if (errors.hasErrors())
                 break;
         }

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -1911,6 +1911,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     }
 
     private Collection<Trigger> _triggers = null;
+    private Boolean _isTriggerManagedColumnsEnabled = null;
 
     @NotNull
     public final Collection<Trigger> getTriggers(@Nullable Container c)
@@ -1922,6 +1923,12 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         return _triggers;
     }
 
+    private boolean isTriggerManagedColumnsEnabled()
+    {
+        if (_isTriggerManagedColumnsEnabled == null)
+            _isTriggerManagedColumnsEnabled = QueryService.get().isTriggerManagedColumnsEnabled();
+        return _isTriggerManagedColumnsEnabled;
+    }
 
     @NotNull
     private final Collection<Trigger> loadTriggers(@Nullable Container c)
@@ -1996,7 +2003,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         DeltaTrackingMap<Object> trackedRow = null;
         Map<String, Object> newRowTracked = newRow;
 
-        if (newRow != null && before)
+        if (newRow != null && before && isTriggerManagedColumnsEnabled())
         {
             trackedRow = new DeltaTrackingMap<>(newRow);
             newRowTracked = trackedRow;

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -1897,6 +1897,10 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         var columns = new CaseInsensitiveHashSet();
         for (var trigger : triggers)
         {
+            // Trigger is disabled, do not modify the column set
+            if (!trigger.isManagedColumnsEnabled())
+                continue;
+
             var managedColumns = trigger.getManagedColumns();
             if (managedColumns == null)
                 continue;

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -2051,13 +2051,19 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
                         String message = "Trigger '" + script.getName() + "' attempted to " + String.join(", ", diffs) + ". Declare managed columns to include them in the column set.";
                         if (manageColumns)
+                        {
                             errors.addGlobalError(message);
-                        else
-                            LOG.warn(message + " This will be an error if invoked via data iteration.");
+                            break;
+                        }
+
+                        LOG.warn(message + " This will be an error if invoked via data iteration.");
                     }
                 }
 
-                // Verify the trigger handles every managed column
+                if (errors.hasErrors())
+                    break;
+
+                // Verify the trigger handles all managed columns
                 if (managedCols != null)
                 {
                     for (var col : managedCols)
@@ -2066,9 +2072,13 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                         {
                             String message = "Trigger '" + script.getName() + "' declared the managed column '" + col + "' but did not set a value for it. Set null to clear or provide a value.";
                             if (manageColumns)
-                                errors.addFieldError(col, message);
-                            else
-                                LOG.warn(message + " This will be an error if invoked via data iteration.");
+                            {
+                                // Not using errors.addFieldError() here as the managed column may not be visible
+                                errors.addGlobalError(message);
+                                break;
+                            }
+
+                            LOG.warn(message + " This will be an error if invoked via data iteration.");
                         }
                     }
                 }

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
 import org.labkey.api.collections.NamedObjectList;
@@ -1892,16 +1893,18 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         if (triggers.isEmpty())
             return null;
 
-        var columns = triggers.stream()
-                .map(Trigger::getManagedColumns)
-                .filter(Objects::nonNull)
-                .flatMap(Collection::stream)
-                .toList();
+        var columns = new CaseInsensitiveHashSet();
+        for (var trigger : triggers)
+        {
+            var managedColumns = trigger.getManagedColumns();
+            if (managedColumns == null)
+                continue;
 
-        if (columns.isEmpty())
-            return null;
+            columns.addAll(managedColumns.insert());
+            columns.addAll(managedColumns.update());
+        }
 
-        return Sets.newCaseInsensitiveHashSet(columns);
+        return columns.isEmpty() ? null : columns;
     }
 
     private Collection<Trigger> _triggers = null;
@@ -1978,15 +1981,6 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
         for (Trigger script : triggers)
         {
-            var managed = before ? script.getManagedColumns() : null;
-
-            // Inject sentinel for each declared column absent from the row; the trigger must handle it
-            if (newRow != null && managed != null && before)
-            {
-                for (var col : managed)
-                    newRow.putIfAbsent(col, Trigger.COLUMN_SENTINEL);
-            }
-
             // Snapshot keys after injection — trigger may update values but must not alter the key set
             var keysBeforeTrigger = newRow != null && before ? Set.copyOf(newRow.keySet()) : null;
 
@@ -1996,6 +1990,11 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
             if (newRow != null && before)
             {
+                var managed = script.getManagedColumns();
+                Set<String> managedCols = null;
+                if (managed != null)
+                    managedCols = managed.getColumns(type);
+
                 // Verify the trigger did not add or remove columns that are not managed
                 if (!newRow.keySet().equals(keysBeforeTrigger))
                 {
@@ -2006,10 +2005,15 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                     removed.removeAll(newRow.keySet());
 
                     // managed column removals are intentional
-                    if (managed != null)
+                    if (managedCols != null)
                     {
-                        added.removeAll(managed);
-                        removed.removeAll(managed);
+                        added.removeAll(managedCols);
+                        removed.removeAll(managedCols);
+                        if (managed.ignored() != null)
+                        {
+                            added.removeAll(managed.ignored());
+                            removed.removeAll(managed.ignored());
+                        }
                     }
 
                     if (!added.isEmpty() || !removed.isEmpty())
@@ -2024,12 +2028,12 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                     }
                 }
 
-                // Verify the trigger handled every declared column it was responsible for
-                if (managed != null)
+                // Verify that update triggers handle every managed column
+                if (managedCols != null && type == TriggerType.UPDATE)
                 {
-                    for (var col : managed)
+                    for (var col : managedCols)
                     {
-                        if (newRow.get(col) == Trigger.COLUMN_SENTINEL)
+                        if (!newRow.containsKey(col))
                             errors.addFieldError(col, "Trigger '" + script.getName() + "' declared column '" + col + "' in getManagedColumns() but did not set a value for it. Set null to clear or provide a value.");
                     }
                 }

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -2050,8 +2050,8 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                     }
                 }
 
-                // Verify that update triggers handle every managed column
-                if (managedCols != null && type == TriggerType.UPDATE)
+                // Verify the trigger handles every managed column
+                if (managedCols != null)
                 {
                     for (var col : managedCols)
                     {

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -30,6 +30,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
+import org.labkey.api.collections.DeltaTrackingMap;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.collections.Sets;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -1982,32 +1983,36 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
         Collection<Trigger> triggers = getTriggers(c);
 
+        // Wrap the row once before the loop
+        DeltaTrackingMap<Object> trackedRow = null;
+        Map<String, Object> newRowTracked = newRow;
+
+        if (newRow != null && before)
+        {
+            trackedRow = new DeltaTrackingMap<>(newRow);
+            newRowTracked = trackedRow;
+        }
+
         for (Trigger script : triggers)
         {
-            // Snapshot keys after injection — trigger may update values but must not alter the key set
-            var keysBeforeTrigger = newRow != null && before ? Set.copyOf(newRow.keySet()) : null;
+            if (trackedRow != null)
+                trackedRow.resetTracking();
 
-            script.rowTrigger(this, c, user, type, before, rowNumber, newRow, oldRow, errors, extraContext, existingRecord);
+            script.rowTrigger(this, c, user, type, before, rowNumber, newRowTracked, oldRow, errors, extraContext, existingRecord);
             if (errors.hasErrors())
                 break;
 
-            if (newRow != null && before)
+            if (trackedRow != null)
             {
                 var managed = script.getManagedColumns();
-                Set<String> managedCols = null;
-                if (managed != null)
-                    managedCols = managed.getColumns(type);
+                var managedCols = managed != null ? managed.getColumns(type) : null;
 
                 // Verify the trigger did not add or remove columns that are not managed
-                if (!newRow.keySet().equals(keysBeforeTrigger))
+                if (trackedRow.hasStructuralChanges())
                 {
-                    var added = Sets.newCaseInsensitiveHashSet(newRow.keySet());
-                    added.removeAll(keysBeforeTrigger);
+                    var added = Sets.newCaseInsensitiveHashSet(trackedRow.getAddedKeys());
+                    var removed = Sets.newCaseInsensitiveHashSet(trackedRow.getRemovedKeys());
 
-                    var removed = Sets.newCaseInsensitiveHashSet(keysBeforeTrigger);
-                    removed.removeAll(newRow.keySet());
-
-                    // managed column removals are intentional
                     if (managedCols != null)
                     {
                         added.removeAll(managedCols);
@@ -2022,10 +2027,11 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                     if (!added.isEmpty() || !removed.isEmpty())
                     {
                         var diffs = new ArrayList<String>();
+
                         if (!added.isEmpty())
-                            diffs.add("add: " + String.join(", ", added));
+                            diffs.add("add: " + added.stream().map(col -> "'" + col + "'").collect(Collectors.joining(", ")));
                         if (!removed.isEmpty())
-                            diffs.add("remove: " + String.join(", ", removed));
+                            diffs.add("remove: " + removed.stream().map(col -> "'" + col + "'").collect(Collectors.joining(", ")));
 
                         String message = "Trigger '" + script.getName() + "' attempted to " + String.join(", ", diffs) + ". Declare managed columns to include them in the column set.";
                         if (manageColumns)
@@ -2040,7 +2046,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                 {
                     for (var col : managedCols)
                     {
-                        if (!newRow.containsKey(col))
+                        if (!newRowTracked.containsKey(col))
                         {
                             String message = "Trigger '" + script.getName() + "' declared the managed column '" + col + "' but did not set a value for it. Set null to clear or provide a value.";
                             if (manageColumns)

--- a/api/src/org/labkey/api/data/SchemaTableInfo.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfo.java
@@ -913,7 +913,7 @@ public class SchemaTableInfo implements TableInfo, UpdateableTableInfo, AuditCon
     }
 
     @Override
-    public void fireRowTrigger(Container c, User user, TriggerType type, @Nullable QueryUpdateService.InsertOption insertOption, boolean before, int rowNumber, Map<String, Object> newRow, Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord, boolean manageColumns)
+    public void fireRowTrigger(Container c, User user, TriggerType type, @Nullable QueryUpdateService.InsertOption insertOption, boolean before, int rowNumber, Map<String, Object> newRow, Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord)
     {
         throw new UnsupportedOperationException("Table triggers not yet supported on schema tables");
     }

--- a/api/src/org/labkey/api/data/SchemaTableInfo.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfo.java
@@ -907,13 +907,13 @@ public class SchemaTableInfo implements TableInfo, UpdateableTableInfo, AuditCon
     }
 
     @Override
-    public void fireBatchTrigger(Container c, User user, TriggerType type, boolean before, BatchValidationException errors, Map<String, Object> extraContext)
+    public void fireBatchTrigger(Container c, User user, TriggerType type, @Nullable QueryUpdateService.InsertOption insertOption, boolean before, BatchValidationException errors, Map<String, Object> extraContext)
     {
         throw new UnsupportedOperationException("Table triggers not yet supported on schema tables");
     }
 
     @Override
-    public void fireRowTrigger(Container c, User user, TriggerType type, boolean before, int rowNumber, Map<String, Object> newRow, Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord, boolean manageColumns)
+    public void fireRowTrigger(Container c, User user, TriggerType type, @Nullable QueryUpdateService.InsertOption insertOption, boolean before, int rowNumber, Map<String, Object> newRow, Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord, boolean manageColumns)
     {
         throw new UnsupportedOperationException("Table triggers not yet supported on schema tables");
     }

--- a/api/src/org/labkey/api/data/SchemaTableInfo.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfo.java
@@ -913,7 +913,7 @@ public class SchemaTableInfo implements TableInfo, UpdateableTableInfo, AuditCon
     }
 
     @Override
-    public void fireRowTrigger(Container c, User user, TriggerType type, boolean before, int rowNumber, Map<String, Object> newRow, Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord)
+    public void fireRowTrigger(Container c, User user, TriggerType type, boolean before, int rowNumber, Map<String, Object> newRow, Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord, boolean manageColumns)
     {
         throw new UnsupportedOperationException("Table triggers not yet supported on schema tables");
     }

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -40,7 +40,6 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.HasPermission;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
@@ -569,9 +568,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
                                 @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext)
             throws ValidationException
     {
-        // In production, columns are not managed for non-data iterator invoked triggers and will log a warning.
-        // In development, columns are managed for all non-data iterator triggers and will throw an error.
-        fireRowTrigger(c, user, type, null, before, rowNumber, newRow, oldRow, extraContext, null, AppProps.getInstance().isDevMode());
+        fireRowTrigger(c, user, type, null, before, rowNumber, newRow, oldRow, extraContext, null);
     }
 
     /**
@@ -610,7 +607,6 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
      * @param oldRow The previous row for UPDATE and DELETE
      * @param extraContext Optional additional bindings to set in the script's context when evaluating.
      * @param existingRecord Optional existing record for the row, used for merge operation to differentiate new vs existing row
-     * @param manageColumns Whether to manage columns for the row.
      * @throws ValidationException if the trigger function returns false or the errors map isn't empty.
      */
     void fireRowTrigger(
@@ -623,8 +619,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
         @Nullable Map<String, Object> newRow,
         @Nullable Map<String, Object> oldRow,
         Map<String, Object> extraContext,
-        @Nullable Map<String, Object> existingRecord,
-        boolean manageColumns
+        @Nullable Map<String, Object> existingRecord
     ) throws ValidationException;
 
     /**

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -509,7 +509,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
 
     /**
      * Executes any trigger scripts for this table.
-     *
+     * <p>
      * The trigger should be called once before and once after an entire set of rows for each of the
      * INSERT, UPDATE, DELETE trigger types.  A trigger script may set up data structures to be used
      * during validation.  In particular, the trigger script might want to do a query to populate a set of
@@ -556,12 +556,13 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
      * @param c The current Container.
      * @param user the current user
      * @param type The TriggerType for the event.
+     * @param insertOption The insertOption that invoked this trigger. Will be null when invoked outside a data iterator.
      * @param before true if the trigger is before the event, false if after the event.
      * @param errors Any errors created by the validation script will be added to the errors collection.
      * @param extraContext Optional additional bindings to set in the script's context when evaluating.
      * @throws BatchValidationException if the trigger function returns false or the errors map isn't empty.
      */
-    void fireBatchTrigger(Container c, User user, TriggerType type, boolean before, BatchValidationException errors, Map<String, Object> extraContext)
+    void fireBatchTrigger(Container c, User user, TriggerType type, @Nullable QueryUpdateService.InsertOption insertOption, boolean before, BatchValidationException errors, Map<String, Object> extraContext)
             throws BatchValidationException;
 
     default void fireRowTrigger(Container c, User user, TriggerType type, boolean before, int rowNumber,
@@ -570,7 +571,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     {
         // In production, columns are not managed for non-data iterator invoked triggers and will log a warning.
         // In development, columns are managed for all non-data iterator triggers and will throw an error.
-        fireRowTrigger(c, user, type, before, rowNumber, newRow, oldRow, extraContext, null, AppProps.getInstance().isDevMode());
+        fireRowTrigger(c, user, type, null, before, rowNumber, newRow, oldRow, extraContext, null, AppProps.getInstance().isDevMode());
     }
 
     /**
@@ -603,6 +604,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
      * @param c The current Container.
      * @param user the current user
      * @param type The TriggerType for the event.
+     * @param insertOption The insertOption that invoked this trigger. Will be null when invoked outside a data iterator.
      * @param before true if the trigger is before the event, false if after the event.
      * @param newRow The new row for INSERT and UPDATE.
      * @param oldRow The previous row for UPDATE and DELETE
@@ -615,6 +617,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
         Container c,
         User user,
         TriggerType type,
+        @Nullable QueryUpdateService.InsertOption insertOption,
         boolean before,
         int rowNumber,
         @Nullable Map<String, Object> newRow,

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -40,6 +40,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.HasPermission;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
@@ -564,10 +565,12 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
             throws BatchValidationException;
 
     default void fireRowTrigger(Container c, User user, TriggerType type, boolean before, int rowNumber,
-                        @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext)
+                                @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext)
             throws ValidationException
     {
-        fireRowTrigger(c, user, type, before, rowNumber, newRow, oldRow, extraContext, null);
+        // In production, columns are not managed for non-data iterator invoked triggers and will log a warning.
+        // In development, columns are managed for all non-data iterator triggers and will throw an error.
+        fireRowTrigger(c, user, type, before, rowNumber, newRow, oldRow, extraContext, null, AppProps.getInstance().isDevMode());
     }
 
     /**
@@ -605,11 +608,21 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
      * @param oldRow The previous row for UPDATE and DELETE
      * @param extraContext Optional additional bindings to set in the script's context when evaluating.
      * @param existingRecord Optional existing record for the row, used for merge operation to differentiate new vs existing row
+     * @param manageColumns Whether to manage columns for the row.
      * @throws ValidationException if the trigger function returns false or the errors map isn't empty.
      */
-    void fireRowTrigger(Container c, User user, TriggerType type, boolean before, int rowNumber,
-                        @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord)
-            throws ValidationException;
+    void fireRowTrigger(
+        Container c,
+        User user,
+        TriggerType type,
+        boolean before,
+        int rowNumber,
+        @Nullable Map<String, Object> newRow,
+        @Nullable Map<String, Object> oldRow,
+        Map<String, Object> extraContext,
+        @Nullable Map<String, Object> existingRecord,
+        boolean manageColumns
+    ) throws ValidationException;
 
     /**
      * Return true if there are trigger scripts associated with this table.
@@ -627,7 +640,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     /**
      * Returns the full set of columns managed by triggers for this TableInfo.
      */
-    default @Nullable Set<String> getTriggerManagedColumns(@Nullable Container c)
+    default @Nullable Set<String> getTriggerManagedColumns(@Nullable Container c, QueryUpdateService.InsertOption insertOption)
     {
         return null;
     }

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -571,7 +571,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     {
         // In production, columns are not managed for non-data iterator invoked triggers and will log a warning.
         // In development, columns are managed for all non-data iterator triggers and will throw an error.
-        fireRowTrigger(c, user, type, null, before, rowNumber, newRow, oldRow, extraContext, null, AppProps.getInstance().isDevMode());
+        fireRowTrigger(c, user, type, null, before, rowNumber, newRow, oldRow, extraContext, null, AppProps.getInstance().isDevMode() && QueryService.get().isTriggerManagedColumnsEnabled());
     }
 
     /**

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -619,7 +619,18 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     /**
      * Return true if all trigger scripts support streaming.
      */
-    default boolean canStreamTriggers(Container c) { return false; }
+    default boolean canStreamTriggers(Container c)
+    {
+        return false;
+    }
+
+    /**
+     * Returns the full set of columns managed by triggers for this TableInfo.
+     */
+    default @Nullable Set<String> getTriggerManagedColumns(@Nullable Container c)
+    {
+        return null;
+    }
 
     /**
      * Reset the trigger script context by reloading them. Note there could still be caches that need to be reset
@@ -632,9 +643,12 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     /**
      * Returns true if the underlying database table has triggers.
      */
-    default boolean hasDbTriggers() { return false; }
+    default boolean hasDbTriggers()
+    {
+        return false;
+    }
 
-    /* for asserting that tableinfo is not changed unexpectedly */
+    /* for asserting that the TableInfo is not changed unexpectedly */
     void setLocked(boolean b);
     boolean isLocked();
 

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -571,7 +571,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     {
         // In production, columns are not managed for non-data iterator invoked triggers and will log a warning.
         // In development, columns are managed for all non-data iterator triggers and will throw an error.
-        fireRowTrigger(c, user, type, null, before, rowNumber, newRow, oldRow, extraContext, null, AppProps.getInstance().isDevMode() && QueryService.get().isTriggerManagedColumnsEnabled());
+        fireRowTrigger(c, user, type, null, before, rowNumber, newRow, oldRow, extraContext, null, AppProps.getInstance().isDevMode());
     }
 
     /**

--- a/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
@@ -65,7 +65,7 @@ public class ScriptTrigger implements Trigger
     @NotNull protected final Container _container;
     @NotNull protected final TableInfo _table;
     @NotNull protected final ScriptReference _script;
-    @Nullable protected ManagedColumns _managedColumns = null;
+    @Nullable protected volatile ManagedColumns _managedColumns = null;
 
     protected ScriptTrigger(@NotNull Container c, @NotNull TableInfo table, @NotNull ScriptReference script)
     {

--- a/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
@@ -17,6 +17,7 @@ package org.labkey.api.data.triggers;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.Sets;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
@@ -44,25 +45,26 @@ import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
  * Implements a trigger for table operations backed by JavaScript code.
- * User: kevink
- * Date: 12/21/15
  */
 public class ScriptTrigger implements Trigger
 {
     public static final String SERVER_CONTEXT_KEY = "~~ServerContext~~";
-    public static final String SERVER_CONTEXT_SCRIPTNAME = "serverContext";
+    public static final String SERVER_CONTEXT_SCRIPT_NAME = "serverContext";
 
     @NotNull protected final Container _container;
     @NotNull protected final TableInfo _table;
     @NotNull protected final ScriptReference _script;
+    @Nullable protected ManagedColumns _managedColumns = null;
 
     protected ScriptTrigger(@NotNull Container c, @NotNull TableInfo table, @NotNull ScriptReference script)
     {
@@ -112,6 +114,38 @@ public class ScriptTrigger implements Trigger
         return false;
     }
 
+    @Override
+    public @Nullable ManagedColumns getManagedColumns()
+    {
+        if (_managedColumns == null)
+            _managedColumns = resolveManagedColumns();
+
+        return _managedColumns;
+    }
+
+    private @NotNull ManagedColumns resolveManagedColumns()
+    {
+        var user = _table.getUserSchema() != null ? _table.getUserSchema().getUser() : null;
+        var result = _invokeTableScript(_container, user, Object.class, "managedColumns", null, () -> null);
+        if (result instanceof Map<?, ?> map)
+        {
+            var insert = managedColumnsFromScriptMap(map, "insert");
+            var update = managedColumnsFromScriptMap(map, "update");
+            var ignored = managedColumnsFromScriptMap(map, "ignored");
+
+            return new ManagedColumns(insert, update, ignored);
+        }
+
+        return ManagedColumns.empty();
+    }
+
+    private @NotNull Set<String> managedColumnsFromScriptMap(@NotNull Map<?, ?> map, String key)
+    {
+        if (map.get(key) instanceof List<?> columns)
+            return Sets.newCaseInsensitiveHashSet((List<String>) columns);
+        return Collections.emptySet();
+    }
+
     /**
      * To avoid leaking PHI through log files, avoid including the full row info in the error detail when any of the
      * columns in the target table is considered PHI
@@ -137,20 +171,12 @@ public class ScriptTrigger implements Trigger
         invokeTableScript(table, c, user, "complete", errors, extraContext, () -> null, event.name().toLowerCase());
     }
 
-
     @Override
     public void beforeInsert(TableInfo table, Container c,
                              User user, @Nullable Map<String, Object> newRow,
                              ValidationException errors, Map<String, Object> extraContext)
     {
-        invokeTableScript(table,
-                c,
-                user,
-                "beforeInsert",
-                errors,
-                extraContext,
-                filterErrorDetailByPhi(table, () -> "New row data: " + newRow),
-                newRow);
+        invokeTableScript(table, c, user, "beforeInsert", errors, extraContext, filterErrorDetailByPhi(table, () -> "New row data: " + newRow), newRow);
     }
 
     @Override
@@ -193,7 +219,6 @@ public class ScriptTrigger implements Trigger
         invokeTableScript(table, c, user, "afterDelete", errors, extraContext, filterErrorDetailByPhi(table, () -> "Old row: "  + oldRow), oldRow);
     }
 
-
     protected void invokeTableScript(TableInfo table, Container c, User user, String methodName, BatchValidationException errors, Map<String, Object> extraContext, Supplier<String> errorDetail, Object... args)
     {
         Object[] allArgs = Arrays.copyOf(args, args.length+1);
@@ -205,7 +230,6 @@ public class ScriptTrigger implements Trigger
             errors.addRowError(new ValidationException("script error: " + methodName + " trigger closed the connection, possibly due to constraint violation"));
     }
 
-
     protected void invokeTableScript(TableInfo table, Container c, User user, String methodName, ValidationException errors, Map<String, Object> extraContext, Supplier<String> errorDetail, Object... args)
     {
         Object[] allArgs = Arrays.copyOf(args, args.length+1);
@@ -216,7 +240,6 @@ public class ScriptTrigger implements Trigger
         if (isConnectionClosed(table.getSchema().getScope()))
             errors.addGlobalError("script error: " + methodName + " trigger closed the connection, possibly due to constraint violation");
     }
-
 
     private boolean _hasFn(Container c, User user, String methodName)
     {
@@ -294,7 +317,7 @@ public class ScriptTrigger implements Trigger
 
         public ServerContextModuleScript(Script serverContext) throws URISyntaxException
         {
-            super(serverContext, new URI(BASE_URI + SERVER_CONTEXT_SCRIPTNAME + ".js"), new URI(BASE_URI));
+            super(serverContext, new URI(BASE_URI + SERVER_CONTEXT_SCRIPT_NAME + ".js"), new URI(BASE_URI));
         }
 
         public static ServerContextModuleScript create(Script serverContext)
@@ -316,7 +339,7 @@ public class ScriptTrigger implements Trigger
         Context ctx = Context.enter();
         try
         {
-            return ctx.compileString("module.exports = " + jsCode, "serverContext.js", 1, null);
+            return ctx.compileString("module.exports = " + jsCode, SERVER_CONTEXT_SCRIPT_NAME + ".js", 1, null);
         }
         finally
         {
@@ -328,7 +351,6 @@ public class ScriptTrigger implements Trigger
     {
         R apply(ScriptReference scriptReference) throws NoSuchMethodException, ScriptException;
     }
-
 
     private boolean isConnectionClosed(DbScope scope)
     {
@@ -359,7 +381,6 @@ public class ScriptTrigger implements Trigger
     @Override
     public int hashCode()
     {
-
         return Objects.hash(_container, _table, _script);
     }
 }

--- a/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.script.ScriptReference;
 import org.labkey.api.security.User;
@@ -173,7 +174,7 @@ public class ScriptTrigger implements Trigger
 
     @Override
     public void beforeInsert(TableInfo table, Container c,
-                             User user, @Nullable Map<String, Object> newRow,
+                             User user, @Nullable QueryUpdateService.InsertOption insertOption, @Nullable Map<String, Object> newRow,
                              ValidationException errors, Map<String, Object> extraContext)
     {
         invokeTableScript(table, c, user, "beforeInsert", errors, extraContext, filterErrorDetailByPhi(table, () -> "New row data: " + newRow), newRow);

--- a/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
@@ -182,7 +182,7 @@ public class ScriptTrigger implements Trigger
 
     @Override
     public void beforeUpdate(TableInfo table, Container c,
-                             User user, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow,
+                             User user, @Nullable QueryUpdateService.InsertOption insertOption, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow,
                              ValidationException errors, Map<String, Object> extraContext)
     {
         invokeTableScript(table, c, user, "beforeUpdate", errors, extraContext, filterErrorDetailByPhi(table, () -> "New row: " + newRow + ". Old row: "  + oldRow), newRow, oldRow);

--- a/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
@@ -66,6 +66,7 @@ public class ScriptTrigger implements Trigger
     @NotNull protected final TableInfo _table;
     @NotNull protected final ScriptReference _script;
     @Nullable protected volatile ManagedColumns _managedColumns = null;
+    protected volatile Boolean _isManagedColumnsEnabled = null;
 
     protected ScriptTrigger(@NotNull Container c, @NotNull TableInfo table, @NotNull ScriptReference script)
     {
@@ -119,25 +120,34 @@ public class ScriptTrigger implements Trigger
     public @Nullable ManagedColumns getManagedColumns()
     {
         if (_managedColumns == null)
-            _managedColumns = resolveManagedColumns();
+        {
+            var user = _table.getUserSchema() != null ? _table.getUserSchema().getUser() : null;
+            var result = _invokeTableScript(_container, user, Object.class, "managedColumns", null, () -> null);
+            _isManagedColumnsEnabled = !(result instanceof Boolean enabled) || enabled;
+
+            if (result instanceof Map<?, ?> map)
+            {
+                var insert = managedColumnsFromScriptMap(map, "insert");
+                var update = managedColumnsFromScriptMap(map, "update");
+                var ignored = managedColumnsFromScriptMap(map, "ignored");
+
+                _managedColumns = new ManagedColumns(insert, update, ignored);
+            }
+            else
+                _managedColumns = ManagedColumns.empty();
+        }
 
         return _managedColumns;
     }
 
-    private @NotNull ManagedColumns resolveManagedColumns()
+    @Override
+    public boolean isManagedColumnsEnabled()
     {
-        var user = _table.getUserSchema() != null ? _table.getUserSchema().getUser() : null;
-        var result = _invokeTableScript(_container, user, Object.class, "managedColumns", null, () -> null);
-        if (result instanceof Map<?, ?> map)
-        {
-            var insert = managedColumnsFromScriptMap(map, "insert");
-            var update = managedColumnsFromScriptMap(map, "update");
-            var ignored = managedColumnsFromScriptMap(map, "ignored");
+        // Ensure the flag is initialized
+        if (_isManagedColumnsEnabled == null)
+            getManagedColumns();
 
-            return new ManagedColumns(insert, update, ignored);
-        }
-
-        return ManagedColumns.empty();
+        return _isManagedColumnsEnabled;
     }
 
     private @NotNull Set<String> managedColumnsFromScriptMap(@NotNull Map<?, ?> map, String key)

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -165,12 +165,14 @@ public interface Trigger
      * This method is a no-op when {@code insertOption} is {@code null}, which signals a non-data-iterator
      * operation where managed-column enforcement does not apply.
      *
+     * @param table          the table the trigger is operating on; used to determine the operations supported by the table
      * @param newRow         the incoming row map to be inserted; modified in place to add missing managed columns
      * @param existingRecord the existing database row for MERGE operations; an empty map indicates no
      *                       matching row yet (new record); must be non-null when {@code insertOption.mergeRows} is true
      * @param insertOption   the insert mode in effect, or {@code null} for non-data-iterator operations
      */
     default void setInsertManagedColumns(
+        @NotNull TableInfo table,
         Map<String, Object> newRow,
         @Nullable Map<String, Object> existingRecord,
         @Nullable QueryUpdateService.InsertOption insertOption
@@ -184,7 +186,7 @@ public interface Trigger
         // then throw an error to avoid overwriting managed values to null.
         // existingRow == null indicated the existing row was not queried, so throw an error
         // existingRecord.isEmpty() indicates a new record, so do not throw an error
-        if (insertOption != null && insertOption.mergeRows && existingRecord == null)
+        if (insertOption != null && existingRecord == null && insertOption.mergeRows && table.supportsInsertOption(insertOption))
             throw new IllegalArgumentException("An existing record must be supplied for all MERGE triggers");
 
         setManagedColumns(newRow, existingRecord, TableInfo.TriggerType.INSERT);

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -174,7 +174,7 @@ public interface Trigger
         if (insertOption != null && insertOption.mergeRows && existingRecord == null)
             throw new IllegalArgumentException("An existing record must be supplied for all MERGE triggers");
 
-        setManagedColumns(newRow, null, TableInfo.TriggerType.INSERT);
+        setManagedColumns(newRow, existingRecord, TableInfo.TriggerType.INSERT);
     }
 
     /**

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -209,7 +209,7 @@ public interface Trigger
                     beforeInsert(table, c, user, insertOption, newRow, errors, extraContext, existingRecord);
                     break;
                 case UPDATE:
-                    beforeUpdate(table, c, user, newRow, oldRow, errors, extraContext);
+                    beforeUpdate(table, c, user, insertOption, newRow, oldRow, errors, extraContext);
                     break;
                 case DELETE:
                     beforeDelete(table, c, user, oldRow, errors, extraContext);
@@ -247,7 +247,7 @@ public interface Trigger
     }
 
     default void beforeUpdate(TableInfo table, Container c,
-                              User user, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow,
+                              User user, @Nullable QueryUpdateService.InsertOption insertOption, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow,
                               ValidationException errors, Map<String, Object> extraContext) throws ValidationException
     {
     }

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -28,6 +28,7 @@ import org.labkey.api.util.UnexpectedException;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -104,6 +105,11 @@ public interface Trigger
             return all(Sets.newCaseInsensitiveHashSet(all));
         }
 
+        public static ManagedColumns empty()
+        {
+            return new ManagedColumns(Collections.emptySet(), Collections.emptySet(), null);
+        }
+
         public @Nullable Set<String> getColumns(TableInfo.TriggerType type)
         {
             if (type == TableInfo.TriggerType.INSERT)
@@ -129,12 +135,12 @@ public interface Trigger
         return null;
     }
 
-    default void setInsertManagedColumns(@NotNull Map<String, Object> newRow)
+    default void setInsertManagedColumns(Map<String, Object> newRow)
     {
         setManagedColumns(newRow, null, TableInfo.TriggerType.INSERT);
     }
 
-    default void setUpdateManagedColumns(@NotNull Map<String, Object> newRow, @NotNull Map<String, Object> oldRow)
+    default void setUpdateManagedColumns(Map<String, Object> newRow, @NotNull Map<String, Object> oldRow)
     {
         if (oldRow == null)
             throw new IllegalArgumentException("oldRow must be non-null for UPDATE triggers");
@@ -144,6 +150,9 @@ public interface Trigger
 
     private void setManagedColumns(Map<String, Object> newRow, Map<String, Object> oldRow, TableInfo.TriggerType type)
     {
+        if (newRow == null)
+            return;
+
         var managedCols = getManagedColumns();
         if (managedCols == null)
             return;

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -138,16 +138,25 @@ public interface Trigger
 
     default void setInsertManagedColumns(Map<String, Object> newRow, @Nullable Map<String, Object> existingRecord, @Nullable QueryUpdateService.InsertOption insertOption)
     {
+        // A null insertOption indicates a non-data iterator operation
+        if (insertOption == null)
+            return;
+
         // If this is a merge operation and the existingRecord is not supplied,
         // then throw an error to avoid overwriting managed values to null.
-        if (insertOption != null && insertOption.mergeRows && (existingRecord == null || existingRecord.isEmpty()))
+        // existingRecord.isEmpty() indicates a new record.
+        if (insertOption.mergeRows && existingRecord == null)
             throw new IllegalArgumentException("existingRecord must be non-null for MERGE triggers");
 
         setManagedColumns(newRow, null, TableInfo.TriggerType.INSERT);
     }
 
-    default void setUpdateManagedColumns(Map<String, Object> newRow, @NotNull Map<String, Object> oldRow)
+    default void setUpdateManagedColumns(Map<String, Object> newRow, @NotNull Map<String, Object> oldRow, @Nullable QueryUpdateService.InsertOption insertOption)
     {
+        // A null insertOption indicates a non-data iterator operation
+        if (insertOption == null)
+            return;
+
         if (oldRow == null)
             throw new IllegalArgumentException("oldRow must be non-null for UPDATE triggers");
 

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -136,7 +136,31 @@ public interface Trigger
         return null;
     }
 
-    default void setInsertManagedColumns(Map<String, Object> newRow, @Nullable Map<String, Object> existingRecord, @Nullable QueryUpdateService.InsertOption insertOption)
+    /**
+     * Ensures all columns declared by {@link #getManagedColumns()} are present in {@code newRow}
+     * before INSERT trigger fires.
+     * <p>
+     * For each managed insert column absent from {@code newRow}, this method fills in a value so the
+     * trigger's logic can rely on the column being present:
+     * <ul>
+     *   <li>For normal inserts, absent columns are initialized to {@code null}.</li>
+     *   <li>For MERGE operations ({@code insertOption.mergeRows == true}), absent columns are carried
+     *       forward from {@code existingRecord} when a matching row exists, or set to {@code null} for
+     *       genuinely new rows ({@code existingRecord.isEmpty()}).</li>
+     * </ul>
+     * This method is a no-op when {@code insertOption} is {@code null}, which signals a non-data-iterator
+     * operation where managed-column enforcement does not apply.
+     *
+     * @param newRow         the incoming row map to be inserted; modified in place to add missing managed columns
+     * @param existingRecord the existing database row for MERGE operations; an empty map indicates no
+     *                       matching row yet (new record); must be non-null when {@code insertOption.mergeRows} is true
+     * @param insertOption   the insert mode in effect, or {@code null} for non-data-iterator operations
+     */
+    default void setInsertManagedColumns(
+        Map<String, Object> newRow,
+        @Nullable Map<String, Object> existingRecord,
+        @Nullable QueryUpdateService.InsertOption insertOption
+    )
     {
         // A null insertOption indicates a non-data iterator operation
         if (insertOption == null)
@@ -144,14 +168,34 @@ public interface Trigger
 
         // If this is a merge operation and the existingRecord is not supplied,
         // then throw an error to avoid overwriting managed values to null.
-        // existingRecord.isEmpty() indicates a new record.
+        // existingRow == null indicated the existing row was not queried, so throw an error
+        // existingRecord.isEmpty() indicates a new record, so do not throw an error
         if (insertOption.mergeRows && existingRecord == null)
             throw new IllegalArgumentException("existingRecord must be non-null for MERGE triggers");
 
         setManagedColumns(newRow, null, TableInfo.TriggerType.INSERT);
     }
 
-    default void setUpdateManagedColumns(Map<String, Object> newRow, @NotNull Map<String, Object> oldRow, @Nullable QueryUpdateService.InsertOption insertOption)
+    /**
+     * Ensures all columns declared by {@link #getManagedColumns()} are present in {@code newRow}
+     * before UPDATE trigger fires.
+     * <p>
+     * For each managed update column absent from {@code newRow}, the corresponding value is carried
+     * forward from {@code oldRow}, preserving the existing database value rather than implicitly
+     * nullifying the column.
+     * <p>
+     * This method is a no-op when {@code insertOption} is {@code null}, which signals a non-data-iterator
+     * operation where managed-column enforcement does not apply.
+     *
+     * @param newRow       the incoming row map with updated values; modified in place to add missing managed columns
+     * @param oldRow       the current database row before the update; provides fallback values for absent managed columns
+     * @param insertOption the insert mode in effect, or {@code null} for non-data-iterator operations
+     */
+    default void setUpdateManagedColumns(
+        Map<String, Object> newRow,
+        @NotNull Map<String, Object> oldRow,
+        @Nullable QueryUpdateService.InsertOption insertOption
+    )
     {
         // A null insertOption indicates a non-data iterator operation
         if (insertOption == null)

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -37,20 +38,46 @@ import java.util.stream.Collectors;
  */
 public interface Trigger
 {
+    /**
+     * Sentinel value placed into the row map for each column declared by {@link #getManagedColumns()}
+     * when that column is absent from the incoming row. The trigger must replace this with a real value
+     * or {@code null} before returning; leaving the sentinel in place is a validation error.
+     */
+    Object COLUMN_SENTINEL = new Object()
+    {
+        @Override
+        public String toString()
+        {
+            return "<trigger managed column - not yet handled>";
+        }
+    };
+
     /** The trigger name. */
-    default String getName() { return getClass().getSimpleName(); }
+    default String getName()
+    {
+        return getClass().getSimpleName();
+    }
 
     /** Short description of the trigger. */
-    default String getDescription() { return null; }
+    default String getDescription()
+    {
+        return null;
+    }
 
-    /** Name of module that defines this trigger. */
-    default String getModuleName() { return null; }
+    /** Name of the module that defines this trigger. */
+    default String getModuleName()
+    {
+        return null;
+    }
 
     /**
      * For script triggers, this is the path to the trigger script.
      * For java triggers, this is the class name.
      */
-    default String getSource() { return getClass().getName(); }
+    default String getSource()
+    {
+        return getClass().getName();
+    }
 
     /**
      * The set of events that this trigger implements.
@@ -78,9 +105,49 @@ public interface Trigger
     }
 
     /**
-     * True if this TriggerScript can be used in a streaming context; triggers will be called without old row values.
+     * Returns the set of column names this trigger will read or write during row processing.
+     * <p>
+     * For each row where a declared column is absent from the input, the data iterator initializes
+     * that column to {@link #COLUMN_SENTINEL} before the trigger fires. The trigger must then
+     * explicitly set each such column to {@code null} or a real value; failure to do so produces
+     * a validation error naming this trigger and the unhandled column.
+     * <p>
+     * Columns that do not exist in the target table's schema (virtual/passthrough columns) may be
+     * declared here and will work correctly — the database writer ignores them.
      */
-    default boolean canStream() { return false; }
+    default @Nullable Set<String> getManagedColumns()
+    {
+        return null;
+    }
+
+    /**
+     * Convenience method for trigger implementations: replaces any {@link #COLUMN_SENTINEL} values
+     * in managed columns with {@code null}. Call this in early-return paths where the trigger will
+     * not produce a value for one or more of its declared columns.
+     */
+    default void clearManagedColumns(@Nullable Map<String, Object> row)
+    {
+        if (row == null)
+            return;
+
+        var managedColumns = getManagedColumns();
+        if (managedColumns == null || managedColumns.isEmpty())
+            return;
+
+        for (String col : managedColumns)
+        {
+            if (row.get(col) == COLUMN_SENTINEL)
+                row.remove(col);
+        }
+    }
+
+    /**
+     * Returns true if this TriggerScript can be used in a streaming context; triggers will be called without old row values.
+     */
+    default boolean canStream()
+    {
+        return false;
+    }
 
     default void batchTrigger(TableInfo table, Container c, User user, TableInfo.TriggerType event, boolean before, BatchValidationException errors, Map<String, Object> extraContext)
     {

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -15,8 +15,10 @@
  */
 package org.labkey.api.data.triggers;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
+import org.labkey.api.collections.Sets;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.BatchValidationException;
@@ -38,20 +40,6 @@ import java.util.stream.Collectors;
  */
 public interface Trigger
 {
-    /**
-     * Sentinel value placed into the row map for each column declared by {@link #getManagedColumns()}
-     * when that column is absent from the incoming row. The trigger must replace this with a real value
-     * or {@code null} before returning; leaving the sentinel in place is a validation error.
-     */
-    Object COLUMN_SENTINEL = new Object()
-    {
-        @Override
-        public String toString()
-        {
-            return "<trigger managed column - not yet handled>";
-        }
-    };
-
     /** The trigger name. */
     default String getName()
     {
@@ -104,41 +92,68 @@ public interface Trigger
         }
     }
 
+    record ManagedColumns(@NotNull Set<String> insert, @NotNull Set<String> update, @Nullable Set<String> ignored)
+    {
+        public static ManagedColumns all(@NotNull Set<String> all)
+        {
+            return new ManagedColumns(all, all, null);
+        }
+
+        public static ManagedColumns all(@NotNull String... all)
+        {
+            return all(Sets.newCaseInsensitiveHashSet(all));
+        }
+
+        public @Nullable Set<String> getColumns(TableInfo.TriggerType type)
+        {
+            if (type == TableInfo.TriggerType.INSERT)
+                return insert;
+            if (type == TableInfo.TriggerType.UPDATE)
+                return update;
+            return null;
+        }
+    }
+
     /**
      * Returns the set of column names this trigger will read or write during row processing.
      * <p>
-     * For each row where a declared column is absent from the input, the data iterator initializes
-     * that column to {@link #COLUMN_SENTINEL} before the trigger fires. The trigger must then
-     * explicitly set each such column to {@code null} or a real value; failure to do so produces
+     * For each row where a declared column is absent from the input, the trigger must
+     * explicitly set each such column to null or a real value; failure to do so produces
      * a validation error naming this trigger and the unhandled column.
      * <p>
      * Columns that do not exist in the target table's schema (virtual/passthrough columns) may be
      * declared here and will work correctly — the database writer ignores them.
      */
-    default @Nullable Set<String> getManagedColumns()
+    default @Nullable ManagedColumns getManagedColumns()
     {
         return null;
     }
 
-    /**
-     * Convenience method for trigger implementations: replaces any {@link #COLUMN_SENTINEL} values
-     * in managed columns with {@code null}. Call this in early-return paths where the trigger will
-     * not produce a value for one or more of its declared columns.
-     */
-    default void clearManagedColumns(@Nullable Map<String, Object> row)
+    default void setInsertManagedColumns(@NotNull Map<String, Object> newRow)
     {
-        if (row == null)
+        setManagedColumns(newRow, null, TableInfo.TriggerType.INSERT);
+    }
+
+    default void setUpdateManagedColumns(@NotNull Map<String, Object> newRow, @NotNull Map<String, Object> oldRow)
+    {
+        if (oldRow == null)
+            throw new IllegalArgumentException("oldRow must be non-null for UPDATE triggers");
+
+        setManagedColumns(newRow, oldRow, TableInfo.TriggerType.UPDATE);
+    }
+
+    private void setManagedColumns(Map<String, Object> newRow, Map<String, Object> oldRow, TableInfo.TriggerType type)
+    {
+        var managedCols = getManagedColumns();
+        if (managedCols == null)
             return;
 
-        var managedColumns = getManagedColumns();
-        if (managedColumns == null || managedColumns.isEmpty())
+        var cols = managedCols.getColumns(type);
+        if (cols == null)
             return;
 
-        for (String col : managedColumns)
-        {
-            if (row.get(col) == COLUMN_SENTINEL)
-                row.remove(col);
-        }
+        for (var col : cols)
+            newRow.putIfAbsent(col, oldRow == null ? null : oldRow.get(col));
     }
 
     /**

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -112,6 +112,11 @@ public interface Trigger
             return new ManagedColumns(Collections.emptySet(), Collections.emptySet(), null);
         }
 
+        public static ManagedColumns ignored(@NotNull String... ignored)
+        {
+            return new ManagedColumns(Collections.emptySet(), Collections.emptySet(), Sets.newCaseInsensitiveHashSet(ignored));
+        }
+
         public @Nullable Set<String> getColumns(TableInfo.TriggerType type)
         {
             if (type == TableInfo.TriggerType.INSERT)

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -22,6 +22,7 @@ import org.labkey.api.collections.Sets;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
@@ -162,16 +163,16 @@ public interface Trigger
         @Nullable QueryUpdateService.InsertOption insertOption
     )
     {
-        // A null insertOption indicates a non-data iterator operation
-        if (insertOption == null)
+        // Trigger managed columns are disabled, do not modify the row
+        if (!QueryService.get().isTriggerManagedColumnsEnabled())
             return;
 
         // If this is a merge operation and the existingRecord is not supplied,
         // then throw an error to avoid overwriting managed values to null.
         // existingRow == null indicated the existing row was not queried, so throw an error
         // existingRecord.isEmpty() indicates a new record, so do not throw an error
-        if (insertOption.mergeRows && existingRecord == null)
-            throw new IllegalArgumentException("existingRecord must be non-null for MERGE triggers");
+        if (insertOption != null && insertOption.mergeRows && existingRecord == null)
+            throw new IllegalArgumentException("An existing record must be supplied for all MERGE triggers");
 
         setManagedColumns(newRow, null, TableInfo.TriggerType.INSERT);
     }
@@ -197,12 +198,12 @@ public interface Trigger
         @Nullable QueryUpdateService.InsertOption insertOption
     )
     {
-        // A null insertOption indicates a non-data iterator operation
-        if (insertOption == null)
+        // Trigger managed columns are disabled, do not modify the row
+        if (!QueryService.get().isTriggerManagedColumnsEnabled())
             return;
 
         if (oldRow == null)
-            throw new IllegalArgumentException("oldRow must be non-null for UPDATE triggers");
+            throw new IllegalArgumentException("An existing record must be supplied for all UPDATE triggers");
 
         setManagedColumns(newRow, oldRow, TableInfo.TriggerType.UPDATE);
     }

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -22,6 +22,7 @@ import org.labkey.api.collections.Sets;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.util.UnexpectedException;
@@ -135,8 +136,13 @@ public interface Trigger
         return null;
     }
 
-    default void setInsertManagedColumns(Map<String, Object> newRow)
+    default void setInsertManagedColumns(Map<String, Object> newRow, @Nullable Map<String, Object> existingRecord, @Nullable QueryUpdateService.InsertOption insertOption)
     {
+        // If this is a merge operation and the existingRecord is not supplied,
+        // then throw an error to avoid overwriting managed values to null.
+        if (insertOption != null && insertOption.mergeRows && (existingRecord == null || existingRecord.isEmpty()))
+            throw new IllegalArgumentException("existingRecord must be non-null for MERGE triggers");
+
         setManagedColumns(newRow, null, TableInfo.TriggerType.INSERT);
     }
 
@@ -189,7 +195,8 @@ public interface Trigger
     {
     }
 
-    default void rowTrigger(TableInfo table, Container c, User user, TableInfo.TriggerType event, boolean before, int rowNumber,
+    default void rowTrigger(TableInfo table, Container c, User user, TableInfo.TriggerType event,
+                            @Nullable QueryUpdateService.InsertOption insertOption, boolean before, int rowNumber,
                             @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow,
                             ValidationException errors, Map<String, Object> extraContext,
                             @Nullable Map<String, Object> existingRecord) throws ValidationException
@@ -199,7 +206,7 @@ public interface Trigger
             switch (event)
             {
                 case INSERT:
-                    beforeInsert(table, c, user, newRow, errors, extraContext, existingRecord);
+                    beforeInsert(table, c, user, insertOption, newRow, errors, extraContext, existingRecord);
                     break;
                 case UPDATE:
                     beforeUpdate(table, c, user, newRow, oldRow, errors, extraContext);
@@ -227,16 +234,16 @@ public interface Trigger
     }
 
     default void beforeInsert(TableInfo table, Container c,
-                              User user, @Nullable Map<String, Object> newRow,
+                              User user, @Nullable QueryUpdateService.InsertOption insertOption, @Nullable Map<String, Object> newRow,
                               ValidationException errors, Map<String, Object> extraContext) throws ValidationException
     {
     }
 
     default void beforeInsert(TableInfo table, Container c,
-                              User user, @Nullable Map<String, Object> newRow,
+                              User user, @Nullable QueryUpdateService.InsertOption insertOption, @Nullable Map<String, Object> newRow,
                               ValidationException errors, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord) throws ValidationException
     {
-        beforeInsert(table, c, user, newRow, errors, extraContext);
+        beforeInsert(table, c, user, insertOption, newRow, errors, extraContext);
     }
 
     default void beforeUpdate(TableInfo table, Container c,

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -138,6 +138,14 @@ public interface Trigger
     }
 
     /**
+     * Returns true if managed columns are enabled for this trigger.
+     */
+    default boolean isManagedColumnsEnabled()
+    {
+        return true;
+    }
+
+    /**
      * Ensures all columns declared by {@link #getManagedColumns()} are present in {@code newRow}
      * before INSERT trigger fires.
      * <p>

--- a/api/src/org/labkey/api/data/triggers/Trigger.java
+++ b/api/src/org/labkey/api/data/triggers/Trigger.java
@@ -172,7 +172,7 @@ public interface Trigger
     )
     {
         // Trigger managed columns are disabled, do not modify the row
-        if (!QueryService.get().isTriggerManagedColumnsEnabled())
+        if (!QueryService.get().isTriggerManagedColumnsEnabled() || !isManagedColumnsEnabled())
             return;
 
         // If this is a merge operation and the existingRecord is not supplied,
@@ -207,7 +207,7 @@ public interface Trigger
     )
     {
         // Trigger managed columns are disabled, do not modify the row
-        if (!QueryService.get().isTriggerManagedColumnsEnabled())
+        if (!QueryService.get().isTriggerManagedColumnsEnabled() || !isManagedColumnsEnabled())
             return;
 
         if (oldRow == null)

--- a/api/src/org/labkey/api/dataiterator/ListofMapsDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ListofMapsDataIterator.java
@@ -4,11 +4,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/** use MapDataIterator.of() */
+/**
+ * @deprecated Use {@link MapDataIterator#of(List)}
+ */
 @Deprecated
 public class ListofMapsDataIterator extends AbstractMapDataIterator.ListOfMapsDataIterator
 {
-    public ListofMapsDataIterator(Set<String> colNames, List<Map<String,Object>> rows)
+    public ListofMapsDataIterator(Set<String> colNames, List<Map<String, Object>> rows)
     {
         super(new DataIteratorContext(), colNames, rows);
     }
@@ -16,7 +18,7 @@ public class ListofMapsDataIterator extends AbstractMapDataIterator.ListOfMapsDa
     @Deprecated
     public static class Builder extends DataIteratorBuilder.Wrapper
     {
-        public Builder(Set<String> colNames, List<Map<String,Object>> rows)
+        public Builder(Set<String> colNames, List<Map<String, Object>> rows)
         {
             super(new ListofMapsDataIterator(colNames, rows));
         }

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -227,7 +227,7 @@ public class TriggerDataBuilderHelper
                 _currentRow = getInput().getMap();
                 try
                 {
-                    _target.fireRowTrigger(_c, _user, triggerType, _context.getInsertOption(), true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord(), true);
+                    _target.fireRowTrigger(_c, _user, triggerType, _context.getInsertOption(), true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord());
                     return true;
                 }
                 catch (ValidationException vex)
@@ -294,7 +294,7 @@ public class TriggerDataBuilderHelper
                     Map<String,Object> newRow = getInput().getMap();
                     try
                     {
-                        _target.fireRowTrigger(_c, _user, getTriggerType(), _context.getInsertOption(), false, rowNumber, newRow, getOldRow(), _extraContext, getExistingRecord(), false);
+                        _target.fireRowTrigger(_c, _user, getTriggerType(), _context.getInsertOption(), false, rowNumber, newRow, getOldRow(), _extraContext, getExistingRecord());
                     }
                     catch (ValidationException vex)
                     {

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -16,6 +16,7 @@
 package org.labkey.api.dataiterator;
 
 import org.labkey.api.data.AbstractTableInfo;
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.triggers.Trigger;
@@ -30,6 +31,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.labkey.api.admin.FolderImportContext.IS_NEW_FOLDER_IMPORT_KEY;
@@ -135,29 +137,7 @@ public class TriggerDataBuilderHelper
             di = LoggingDataIterator.wrap(di);
 
             // Incorporate columns managed by triggers that may not overlap with the requested column set
-            if (QueryService.get().isTriggerManagedColumnsEnabled())
-            {
-                var triggerColumns = _target.getTriggerManagedColumns(_c, context.getInsertOption());
-                if (triggerColumns != null && !triggerColumns.isEmpty())
-                {
-                    var columns = triggerColumns.stream().map(_target::getColumn).filter(Objects::nonNull).toList();
-                    if (!columns.isEmpty())
-                    {
-                        var translator = new SimpleTranslator(di, context);
-                        translator.setDebugName("TriggerDataBuilderHelper.Before.translator");
-                        translator.selectAll();
-
-                        var columnNameMap = translator.getColumnNameMap();
-
-                        for (var column : columns)
-                        {
-                            if (!columnNameMap.containsKey(column.getName()))
-                                translator.addColumn(column, (Supplier<Object>) () -> null);
-                        }
-                        di = translator.getDataIterator(context);
-                    }
-                }
-            }
+            di = getManagedColumnsDataIterator(di, context);
 
             Set<String> existingRecordKeyColumnNames = null;
             Set<String> sharedKeys = null;
@@ -189,6 +169,42 @@ public class TriggerDataBuilderHelper
 
             di = ExistingRecordDataIterator.createBuilder(di, _target, existingRecordKeyColumnNames, sharedKeys, true).getDataIterator(context);
             return LoggingDataIterator.wrap(new BeforeIterator(new CachingDataIterator(di), context));
+        }
+
+        private DataIterator getManagedColumnsDataIterator(DataIterator di, DataIteratorContext context)
+        {
+            if (QueryService.get().isTriggerManagedColumnsEnabled())
+            {
+                var triggerColumns = _target.getTriggerManagedColumns(_c, context.getInsertOption());
+                if (triggerColumns != null && !triggerColumns.isEmpty())
+                {
+                    Function<String, ColumnInfo> columnMapper;
+                    if (_target instanceof AbstractTableInfo target)
+                        columnMapper = colName -> target.getColumn(colName, false);
+                    else
+                        columnMapper = _target::getColumn;
+
+                    var columns = triggerColumns.stream().map(columnMapper).filter(Objects::nonNull).toList();
+                    if (!columns.isEmpty())
+                    {
+                        var translator = new SimpleTranslator(di, context);
+                        translator.setDebugName("TriggerDataBuilderHelper.Before.translator");
+                        translator.selectAll();
+
+                        var columnNameMap = translator.getColumnNameMap();
+
+                        for (var column : columns)
+                        {
+                            if (!columnNameMap.containsKey(column.getName()))
+                                translator.addColumn(column, (Supplier<Object>) () -> null);
+                        }
+
+                        di = translator.getDataIterator(context);
+                    }
+                }
+            }
+
+            return di;
         }
     }
 

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -225,6 +225,17 @@ public class TriggerDataBuilderHelper
             TableInfo.TriggerType triggerType = getTriggerType();
             if (_firstRow)
             {
+                // HACK?: Before initializing the triggers, reset the table triggers.
+                // This is late enough so that the data iteration context is configured properly.
+                // Note: This is not ideal. getTriggers(c) accepts a @Nullable container, however, the underlying
+                // scripts actually depend on this argument. For example, if the first caller passed in a container
+                // and the next calls with null, then the null argument will see the scripts defined in the container.
+                // But if they are called in the opposite order (null, then with a container), the container one will
+                // receive no scripts (or whatever null initialized with).
+                // Ideally, we could decouple loading the triggers and their associated container from the table/trigger
+                // lifecycle.
+                _target.resetTriggers(_c);
+
                 _target.fireBatchTrigger(_c, _user, triggerType, _context.getInsertOption(), true, getErrors(), _extraContext);
                 firedInit = true;
                 _firstRow = false;

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -21,6 +21,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.triggers.Trigger;
 import org.labkey.api.exp.query.ExpTable;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
@@ -192,10 +193,12 @@ public class TriggerDataBuilderHelper
     {
         boolean _firstRow = true;
         Map<String, Object> _currentRow = null;
+        private final boolean _manageColumns;
 
         BeforeIterator(DataIterator di, DataIteratorContext context)
         {
             super(di, context);
+            _manageColumns = QueryService.get().isTriggerManagedColumnsEnabled();
         }
 
         @Override
@@ -223,7 +226,7 @@ public class TriggerDataBuilderHelper
                 _currentRow = getInput().getMap();
                 try
                 {
-                    _target.fireRowTrigger(_c, _user, triggerType, _context.getInsertOption(), true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord(), true);
+                    _target.fireRowTrigger(_c, _user, triggerType, _context.getInsertOption(), true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord(), _manageColumns);
                     return true;
                 }
                 catch (ValidationException vex)
@@ -290,7 +293,7 @@ public class TriggerDataBuilderHelper
                     Map<String,Object> newRow = getInput().getMap();
                     try
                     {
-                        _target.fireRowTrigger(_c, _user, getTriggerType(), _context.getInsertOption(), false, rowNumber, newRow, getOldRow(), _extraContext, getExistingRecord(), true);
+                        _target.fireRowTrigger(_c, _user, getTriggerType(), _context.getInsertOption(), false, rowNumber, newRow, getOldRow(), _extraContext, getExistingRecord(), false);
                     }
                     catch (ValidationException vex)
                     {

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.dataiterator;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
@@ -25,6 +26,7 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -55,7 +57,6 @@ public class TriggerDataBuilderHelper
     {
         return new Before(in);
     }
-
 
     public DataIteratorBuilder after(DataIteratorBuilder in)
     {
@@ -162,11 +163,11 @@ public class TriggerDataBuilderHelper
         }
     }
 
-
     class BeforeIterator extends TriggerDataIterator
     {
         boolean _firstRow = true;
-        Map<String,Object> _currentRow = null;
+        Map<String, Object> _currentRow = null;
+        Set<String> _currentColumns = null;
 
         BeforeIterator(DataIterator di, DataIteratorContext context)
         {
@@ -179,7 +180,6 @@ public class TriggerDataBuilderHelper
             // DON'T FIRE TRIGGERS TWICE!
             return false;
         }
-
 
         @Override
         public boolean next() throws BatchValidationException
@@ -199,7 +199,25 @@ public class TriggerDataBuilderHelper
                 _currentRow = getInput().getMap();
                 try
                 {
+                    if (_currentRow != null && _currentColumns == null)
+                        _currentColumns = Set.copyOf(_currentRow.keySet());
+
                     _target.fireRowTrigger(_c, _user, triggerType, true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord());
+
+                    if (_currentRow != null && _currentColumns != null && !_currentColumns.equals(_currentRow.keySet()))
+                    {
+                        var added = CollectionUtils.subtract(_currentRow.keySet(), _currentColumns);
+                        var removed = CollectionUtils.subtract(_currentColumns, _currentRow.keySet());
+
+                        var diffs = new ArrayList<String>();
+                        if (!added.isEmpty())
+                            diffs.add("add: " + String.join(", ", added));
+                        if (!removed.isEmpty())
+                            diffs.add("remove: " + String.join(", ", removed));
+
+                        throw new ValidationException("Columns are not modifiable by triggers. Triggers attempted to " + String.join(", ", diffs));
+                    }
+
                     return true;
                 }
                 catch (ValidationException vex)
@@ -212,7 +230,6 @@ public class TriggerDataBuilderHelper
             return false;
         }
 
-
         @Override
         public Object get(int i)
         {
@@ -223,7 +240,6 @@ public class TriggerDataBuilderHelper
             return super.get(i);
         }
     }
-
 
     class After implements DataIteratorBuilder
     {
@@ -243,7 +259,6 @@ public class TriggerDataBuilderHelper
             return new AfterIterator(LoggingDataIterator.wrap(it), context);
         }
     }
-
 
     class AfterIterator extends TriggerDataIterator
     {

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -212,7 +212,7 @@ public class TriggerDataBuilderHelper
             TableInfo.TriggerType triggerType = getTriggerType();
             if (_firstRow)
             {
-                _target.fireBatchTrigger(_c, _user, triggerType, true, getErrors(), _extraContext);
+                _target.fireBatchTrigger(_c, _user, triggerType, _context.getInsertOption(), true, getErrors(), _extraContext);
                 firedInit = true;
                 _firstRow = false;
             }
@@ -223,7 +223,7 @@ public class TriggerDataBuilderHelper
                 _currentRow = getInput().getMap();
                 try
                 {
-                    _target.fireRowTrigger(_c, _user, triggerType, true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord(), true);
+                    _target.fireRowTrigger(_c, _user, triggerType, _context.getInsertOption(), true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord(), true);
                     return true;
                 }
                 catch (ValidationException vex)
@@ -290,7 +290,7 @@ public class TriggerDataBuilderHelper
                     Map<String,Object> newRow = getInput().getMap();
                     try
                     {
-                        _target.fireRowTrigger(_c, _user, getTriggerType(), false, rowNumber, newRow, getOldRow(), _extraContext, getExistingRecord(), true);
+                        _target.fireRowTrigger(_c, _user, getTriggerType(), _context.getInsertOption(), false, rowNumber, newRow, getOldRow(), _extraContext, getExistingRecord(), true);
                     }
                     catch (ValidationException vex)
                     {
@@ -302,7 +302,7 @@ public class TriggerDataBuilderHelper
             finally
             {
                 if (!hasNext && firedInit && !getErrors().hasErrors())
-                    _target.fireBatchTrigger(_c, _user, getTriggerType(), false, getErrors(), _extraContext);
+                    _target.fireBatchTrigger(_c, _user, getTriggerType(), _context.getInsertOption(), false, getErrors(), _extraContext);
             }
         }
     }

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.api.dataiterator;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
@@ -26,10 +25,11 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.labkey.api.admin.FolderImportContext.IS_NEW_FOLDER_IMPORT_KEY;
 import static org.labkey.api.util.IntegerUtils.asInteger;
@@ -115,20 +115,45 @@ public class TriggerDataBuilderHelper
 
     class Before implements DataIteratorBuilder
     {
-        final DataIteratorBuilder _pre;
+        final DataIteratorBuilder _in;
 
         Before(DataIteratorBuilder in)
         {
-            _pre = in;
+            _in = in;
         }
 
         @Override
         public DataIterator getDataIterator(DataIteratorContext context)
         {
-            DataIterator di = _pre.getDataIterator(context);
+            DataIterator di = _in.getDataIterator(context);
+            if (di == null)
+                return null; // can happen if context has errors
+
             if (!_target.hasTriggers(_c))
                 return di;
             di = LoggingDataIterator.wrap(di);
+
+            // Incorporate columns managed by triggers that may not overlap with the requested column set
+            var triggerColumns = _target.getTriggerManagedColumns(_c);
+            if (triggerColumns != null && !triggerColumns.isEmpty())
+            {
+                var columns = triggerColumns.stream().map(_target::getColumn).filter(Objects::nonNull).toList();
+                if (!columns.isEmpty())
+                {
+                    var translator = new SimpleTranslator(di, context);
+                    translator.setDebugName("TriggerDataBuilderHelper.Before.translator");
+                    translator.selectAll();
+
+                    var columnNameMap = translator.getColumnNameMap();
+
+                    for (var column : columns)
+                    {
+                        if (!columnNameMap.containsKey(column.getName()))
+                            translator.addColumn(column, (Supplier<Object>) () -> null);
+                    }
+                    di = translator.getDataIterator(context);
+                }
+            }
 
             Set<String> existingRecordKeyColumnNames = null;
             Set<String> sharedKeys = null;
@@ -167,7 +192,6 @@ public class TriggerDataBuilderHelper
     {
         boolean _firstRow = true;
         Map<String, Object> _currentRow = null;
-        Set<String> _currentColumns = null;
 
         BeforeIterator(DataIterator di, DataIteratorContext context)
         {
@@ -199,25 +223,7 @@ public class TriggerDataBuilderHelper
                 _currentRow = getInput().getMap();
                 try
                 {
-                    if (_currentRow != null && _currentColumns == null)
-                        _currentColumns = Set.copyOf(_currentRow.keySet());
-
                     _target.fireRowTrigger(_c, _user, triggerType, true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord());
-
-                    if (_currentRow != null && _currentColumns != null && !_currentColumns.equals(_currentRow.keySet()))
-                    {
-                        var added = CollectionUtils.subtract(_currentRow.keySet(), _currentColumns);
-                        var removed = CollectionUtils.subtract(_currentColumns, _currentRow.keySet());
-
-                        var diffs = new ArrayList<String>();
-                        if (!added.isEmpty())
-                            diffs.add("add: " + String.join(", ", added));
-                        if (!removed.isEmpty())
-                            diffs.add("remove: " + String.join(", ", removed));
-
-                        throw new ValidationException("Columns are not modifiable by triggers. Triggers attempted to " + String.join(", ", diffs));
-                    }
-
                     return true;
                 }
                 catch (ValidationException vex)
@@ -243,20 +249,24 @@ public class TriggerDataBuilderHelper
 
     class After implements DataIteratorBuilder
     {
-        final DataIteratorBuilder _post;
+        final DataIteratorBuilder _in;
 
         After(DataIteratorBuilder in)
         {
-            _post = in;
+            _in = in;
         }
 
         @Override
         public DataIterator getDataIterator(DataIteratorContext context)
         {
-            DataIterator it = _post.getDataIterator(context);
+            DataIterator di = _in.getDataIterator(context);
+            if (di == null)
+                return null; // can happen if context has errors
+
             if (!_target.hasTriggers(_c))
-                return it;
-            return new AfterIterator(LoggingDataIterator.wrap(it), context);
+                return di;
+
+            return new AfterIterator(LoggingDataIterator.wrap(di), context);
         }
     }
 

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -134,7 +134,7 @@ public class TriggerDataBuilderHelper
             di = LoggingDataIterator.wrap(di);
 
             // Incorporate columns managed by triggers that may not overlap with the requested column set
-            var triggerColumns = _target.getTriggerManagedColumns(_c);
+            var triggerColumns = _target.getTriggerManagedColumns(_c, context.getInsertOption());
             if (triggerColumns != null && !triggerColumns.isEmpty())
             {
                 var columns = triggerColumns.stream().map(_target::getColumn).filter(Objects::nonNull).toList();
@@ -223,7 +223,7 @@ public class TriggerDataBuilderHelper
                 _currentRow = getInput().getMap();
                 try
                 {
-                    _target.fireRowTrigger(_c, _user, triggerType, true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord());
+                    _target.fireRowTrigger(_c, _user, triggerType, true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord(), true);
                     return true;
                 }
                 catch (ValidationException vex)
@@ -290,7 +290,7 @@ public class TriggerDataBuilderHelper
                     Map<String,Object> newRow = getInput().getMap();
                     try
                     {
-                        _target.fireRowTrigger(_c, _user, getTriggerType(), false, rowNumber, newRow, getOldRow(), _extraContext, getExistingRecord());
+                        _target.fireRowTrigger(_c, _user, getTriggerType(), false, rowNumber, newRow, getOldRow(), _extraContext, getExistingRecord(), true);
                     }
                     catch (ValidationException vex)
                     {

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static org.labkey.api.admin.FolderImportContext.IS_NEW_FOLDER_IMPORT_KEY;
 import static org.labkey.api.util.IntegerUtils.asInteger;
 
 public class TriggerDataBuilderHelper
@@ -150,17 +149,11 @@ public class TriggerDataBuilderHelper
                 sharedKeys = expTable.getExistingRecordSharedKeyColumnNames();
             }
 
-            boolean isNewFolderImport = false;
-            if (_extraContext != null && _extraContext.get(IS_NEW_FOLDER_IMPORT_KEY) != null)
-            {
-                isNewFolderImport = (boolean) _extraContext.get(IS_NEW_FOLDER_IMPORT_KEY);
-            }
-
             di = LoggingDataIterator.wrap(new CoerceDataIterator(di, context, _target, !context.getInsertOption().updateOnly));
             context.setWithLookupRemapping(false);
 
             // Skip existing records
-            if (!context.getInsertOption().allowUpdate || existingRecordKeyColumnNames == null || isNewFolderImport)
+            if (!context.getInsertOption().allowUpdate || existingRecordKeyColumnNames == null)
                 return LoggingDataIterator.wrap(new BeforeIterator(new CachingDataIterator(di), context));
 
             // Merge request but merge is not supported

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -135,24 +135,27 @@ public class TriggerDataBuilderHelper
             di = LoggingDataIterator.wrap(di);
 
             // Incorporate columns managed by triggers that may not overlap with the requested column set
-            var triggerColumns = _target.getTriggerManagedColumns(_c, context.getInsertOption());
-            if (triggerColumns != null && !triggerColumns.isEmpty())
+            if (QueryService.get().isTriggerManagedColumnsEnabled())
             {
-                var columns = triggerColumns.stream().map(_target::getColumn).filter(Objects::nonNull).toList();
-                if (!columns.isEmpty())
+                var triggerColumns = _target.getTriggerManagedColumns(_c, context.getInsertOption());
+                if (triggerColumns != null && !triggerColumns.isEmpty())
                 {
-                    var translator = new SimpleTranslator(di, context);
-                    translator.setDebugName("TriggerDataBuilderHelper.Before.translator");
-                    translator.selectAll();
-
-                    var columnNameMap = translator.getColumnNameMap();
-
-                    for (var column : columns)
+                    var columns = triggerColumns.stream().map(_target::getColumn).filter(Objects::nonNull).toList();
+                    if (!columns.isEmpty())
                     {
-                        if (!columnNameMap.containsKey(column.getName()))
-                            translator.addColumn(column, (Supplier<Object>) () -> null);
+                        var translator = new SimpleTranslator(di, context);
+                        translator.setDebugName("TriggerDataBuilderHelper.Before.translator");
+                        translator.selectAll();
+
+                        var columnNameMap = translator.getColumnNameMap();
+
+                        for (var column : columns)
+                        {
+                            if (!columnNameMap.containsKey(column.getName()))
+                                translator.addColumn(column, (Supplier<Object>) () -> null);
+                        }
+                        di = translator.getDataIterator(context);
                     }
-                    di = translator.getDataIterator(context);
                 }
             }
 
@@ -193,12 +196,10 @@ public class TriggerDataBuilderHelper
     {
         boolean _firstRow = true;
         Map<String, Object> _currentRow = null;
-        private final boolean _manageColumns;
 
         BeforeIterator(DataIterator di, DataIteratorContext context)
         {
             super(di, context);
-            _manageColumns = QueryService.get().isTriggerManagedColumnsEnabled();
         }
 
         @Override
@@ -226,7 +227,7 @@ public class TriggerDataBuilderHelper
                 _currentRow = getInput().getMap();
                 try
                 {
-                    _target.fireRowTrigger(_c, _user, triggerType, _context.getInsertOption(), true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord(), _manageColumns);
+                    _target.fireRowTrigger(_c, _user, triggerType, _context.getInsertOption(), true, rowNumber, _currentRow, getOldRow(), _extraContext, getExistingRecord(), true);
                     return true;
                 }
                 catch (ValidationException vex)

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -77,7 +77,6 @@ import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.ontology.OntologyService;
-import org.labkey.api.ontology.Quantity;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.reader.TabLoader;
@@ -605,7 +604,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
 
         errors.setExtraContext(extraScriptContext);
         if (hasTableScript)
-            getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.INSERT, true, errors, extraScriptContext);
+            getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.INSERT, null, true, errors, extraScriptContext);
 
         List<Map<String, Object>> result = new ArrayList<>(rows.size());
         List<Map<String, Object>> providedValues = new ArrayList<>(rows.size());
@@ -659,7 +658,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         }
 
         if (hasTableScript)
-            getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.INSERT, false, errors, extraScriptContext);
+            getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.INSERT, null, false, errors, extraScriptContext);
 
         addAuditEvent(user, container, QueryService.AuditAction.INSERT, null, result, null, providedValues);
 
@@ -837,7 +836,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         assert(getQueryTable().supportsInsertOption(InsertOption.UPDATE));
 
         errors.setExtraContext(extraScriptContext);
-        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.UPDATE, true, errors, extraScriptContext);
+        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.UPDATE, null, true, errors, extraScriptContext);
 
         List<Map<String, Object>> result = new ArrayList<>(rows.size());
         List<Map<String, Object>> oldRows = new ArrayList<>(rows.size());
@@ -889,7 +888,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         }
 
         // Fire triggers, if any, and also throw if there are any errors
-        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.UPDATE, false, errors, extraScriptContext);
+        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.UPDATE, null, false, errors, extraScriptContext);
         afterInsertUpdate(null==result?0:result.size(), errors, true);
 
         if (errors.hasErrors())
@@ -961,7 +960,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
 
         BatchValidationException errors = new BatchValidationException();
         errors.setExtraContext(extraScriptContext);
-        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.DELETE, true, errors, extraScriptContext);
+        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.DELETE, null, true, errors, extraScriptContext);
 
         // TODO: Support update/delete without selecting the existing row -- unfortunately, we currently get the existing row to check its container matches the incoming container
         boolean streaming = false; //_queryTable.canStreamTriggers(container) && _queryTable.getAuditBehavior() != AuditBehaviorType.NONE;
@@ -1006,7 +1005,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         }
 
         // Fire triggers, if any, and also throw if there are any errors
-        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.DELETE, false, errors, extraScriptContext);
+        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.DELETE, null, false, errors, extraScriptContext);
 
         addAuditEvent(user, container,  QueryService.AuditAction.DELETE, configParameters, result, null, null);
 
@@ -1028,11 +1027,11 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
 
         BatchValidationException errors = new BatchValidationException();
         errors.setExtraContext(extraScriptContext);
-        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.TRUNCATE, true, errors, extraScriptContext);
+        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.TRUNCATE, null, true, errors, extraScriptContext);
 
         int result = truncateRows(user, container);
 
-        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.TRUNCATE, false, errors, extraScriptContext);
+        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.TRUNCATE, null, false, errors, extraScriptContext);
         addAuditEvent(user, container,  QueryService.AuditAction.TRUNCATE, configParameters, null, null, null);
 
         return result;

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -73,6 +73,7 @@ import java.util.Set;
 public interface QueryService
 {
     String EXPERIMENTAL_LAST_MODIFIED = "queryMetadataLastModified";
+    String EXPERIMENTAL_DISABLE_MANAGED_TRIGGER_COLUMNS = "queryDisableManagedTriggerColumns";
     String EXPERIMENTAL_PRODUCT_ALL_FOLDER_LOOKUPS = "queryProductAllFolderLookups";
     String EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED = "queryProductProjectDataListingScoped";
     String MAX_QUERY_SELECTION = "maxQuerySelection";
@@ -723,4 +724,9 @@ public interface QueryService
      * Returns true if the "Product projects display project-specific data" experimental feature is enabled.
      */
     boolean isProductFoldersDataListingScopedToProject();
+
+    /**
+     * Returns false if the "Disable managed columns in query triggers" experimental feature is enabled.
+     */
+    boolean isTriggerManagedColumnsEnabled();
 }

--- a/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
@@ -21,6 +21,7 @@ import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.qc.DataState;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.util.UnexpectedException;
@@ -163,6 +164,7 @@ public class AssayPlateTriggerFactory implements TriggerFactory
             TableInfo table,
             Container c,
             User user,
+            @Nullable QueryUpdateService.InsertOption insertOption,
             @Nullable Map<String, Object> newRow,
             @Nullable Map<String, Object> oldRow,
             ValidationException errors,

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -212,11 +212,11 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     private final AtomicBoolean _pausePlateIndex = new AtomicBoolean(false);
     private static final Object PLATE_INDEX_LOCK = new Object();
 
-    // This flag is applied to the extraScriptContext of query mutating calls (e.g. insertRows, updateRows, etc.)
+    // This flag is applied to the extraScriptContext of query mutating calls (e.g., insertRows, updateRows, etc.)
     // when those calls are being made for a plate copy operation.
     public static final String PLATE_COPY_FLAG = ".plateCopy";
 
-    // This flag is applied to the extraScriptContext of query mutating calls (e.g. insertRows, updateRows, etc.)
+    // This flag is applied to the extraScriptContext of query mutating calls (e.g., insertRows, updateRows, etc.)
     // when those calls are being made for a plate save operation.
     public static final String PLATE_SAVE_FLAG = ".plateSave";
 

--- a/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
@@ -17,6 +17,7 @@ import org.labkey.api.data.triggers.Trigger;
 import org.labkey.api.data.triggers.TriggerFactory;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
@@ -148,13 +149,15 @@ public final class WellTriggerFactory implements TriggerFactory
             TableInfo table,
             Container c,
             User user,
+            @Nullable QueryUpdateService.InsertOption insertOption,
             @Nullable Map<String, Object> newRow,
             ValidationException errors,
-            Map<String, Object> extraContext
+            Map<String, Object> extraContext,
+            @Nullable Map<String, Object> existingRecord
         )
         {
             addTypeSample(c, user, newRow, null, extraContext);
-            setInsertManagedColumns(newRow);
+            setInsertManagedColumns(newRow, existingRecord, insertOption);
         }
 
         @Override

--- a/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
@@ -173,7 +173,7 @@ public final class WellTriggerFactory implements TriggerFactory
         )
         {
             addTypeSample(c, user, newRow, oldRow, extraContext);
-            setUpdateManagedColumns(newRow, oldRow);
+            setUpdateManagedColumns(newRow, oldRow, insertOption);
         }
     }
 

--- a/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
@@ -54,13 +54,13 @@ public final class WellTriggerFactory implements TriggerFactory
 
         @Override
         public void beforeUpdate(
-            TableInfo table,
-            Container c,
-            User user,
-            @Nullable Map<String, Object> newRow,
-            @Nullable Map<String, Object> oldRow,
-            ValidationException errors,
-            Map<String, Object> extraContext
+                TableInfo table,
+                Container c,
+                User user,
+                @Nullable QueryUpdateService.InsertOption insertOption, @Nullable Map<String, Object> newRow,
+                @Nullable Map<String, Object> oldRow,
+                ValidationException errors,
+                Map<String, Object> extraContext
         ) throws ValidationException
         {
             if (oldRow == null || errors.hasErrors() || !oldRow.containsKey(WellTable.Column.PlateId.name()))
@@ -165,6 +165,7 @@ public final class WellTriggerFactory implements TriggerFactory
             TableInfo table,
             Container c,
             User user,
+            @Nullable QueryUpdateService.InsertOption insertOption,
             @Nullable Map<String, Object> newRow,
             @Nullable Map<String, Object> oldRow,
             ValidationException errors,

--- a/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
@@ -54,13 +54,14 @@ public final class WellTriggerFactory implements TriggerFactory
 
         @Override
         public void beforeUpdate(
-                TableInfo table,
-                Container c,
-                User user,
-                @Nullable QueryUpdateService.InsertOption insertOption, @Nullable Map<String, Object> newRow,
-                @Nullable Map<String, Object> oldRow,
-                ValidationException errors,
-                Map<String, Object> extraContext
+            TableInfo table,
+            Container c,
+            User user,
+            @Nullable QueryUpdateService.InsertOption insertOption,
+            @Nullable Map<String, Object> newRow,
+            @Nullable Map<String, Object> oldRow,
+            ValidationException errors,
+            Map<String, Object> extraContext
         ) throws ValidationException
         {
             if (oldRow == null || errors.hasErrors() || !oldRow.containsKey(WellTable.Column.PlateId.name()))
@@ -92,7 +93,8 @@ public final class WellTriggerFactory implements TriggerFactory
         @Override
         public @Nullable ManagedColumns getManagedColumns()
         {
-            return ManagedColumns.all(WellTable.Column.Type.name());
+            // "Type" is a calculated column, so we do not include it as a managed column
+            return ManagedColumns.ignored(WellTable.Column.Type.name());
         }
 
         private void addTypeSample(
@@ -121,8 +123,8 @@ public final class WellTriggerFactory implements TriggerFactory
             newRow.put(WellTable.Column.Type.name(), WellGroup.Type.SAMPLE.name());
         }
 
-        // Since "Type" is a calculated column (i.e. not in the database) its value is not included in
-        // the original row, thus, we need to query for it dynamically.
+        // Since "Type" is a calculated column (i.e., not in the database), its value is not included in
+        // the original row; thus, we need to query for it dynamically.
         private boolean hasWellType(Container c, User user, @Nullable Map<String, Object> oldRow)
         {
             if (oldRow == null)
@@ -157,7 +159,6 @@ public final class WellTriggerFactory implements TriggerFactory
         )
         {
             addTypeSample(c, user, newRow, null, extraContext);
-            setInsertManagedColumns(newRow, existingRecord, insertOption);
         }
 
         @Override
@@ -173,7 +174,6 @@ public final class WellTriggerFactory implements TriggerFactory
         )
         {
             addTypeSample(c, user, newRow, oldRow, extraContext);
-            setUpdateManagedColumns(newRow, oldRow, insertOption);
         }
     }
 

--- a/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
@@ -88,6 +88,12 @@ public final class WellTriggerFactory implements TriggerFactory
     {
         private final Map<Long, String> wellTypeMap = new LRUMap<>(PlateSet.MAX_PLATE_SET_WELLS);
 
+        @Override
+        public @Nullable ManagedColumns getManagedColumns()
+        {
+            return ManagedColumns.all(WellTable.Column.Type.name());
+        }
+
         private void addTypeSample(
             Container c,
             User user,
@@ -148,6 +154,7 @@ public final class WellTriggerFactory implements TriggerFactory
         )
         {
             addTypeSample(c, user, newRow, null, extraContext);
+            setInsertManagedColumns(newRow);
         }
 
         @Override
@@ -162,6 +169,7 @@ public final class WellTriggerFactory implements TriggerFactory
         )
         {
             addTypeSample(c, user, newRow, oldRow, extraContext);
+            setUpdateManagedColumns(newRow, oldRow);
         }
     }
 

--- a/core/src/org/labkey/core/query/UsersTable.java
+++ b/core/src/org/labkey/core/query/UsersTable.java
@@ -453,9 +453,9 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
     }
 
     @Override
-    public void fireRowTrigger(Container c, User user, TriggerType type, boolean before, int rowNumber, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord) throws ValidationException
+    public void fireRowTrigger(Container c, User user, TriggerType type, boolean before, int rowNumber, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord, boolean manageColumns) throws ValidationException
     {
-        super.fireRowTrigger(c, user, type, before, rowNumber, newRow, oldRow, extraContext, existingRecord);
+        super.fireRowTrigger(c, user, type, before, rowNumber, newRow, oldRow, extraContext, existingRecord, manageColumns);
         Integer userId = null!=oldRow ? asInteger(oldRow.get("UserId")) : null!=newRow ? asInteger(newRow.get("UserId")) : null;
         if (null != userId && !before)
             UserManager.fireUserPropertiesChanged(userId);

--- a/core/src/org/labkey/core/query/UsersTable.java
+++ b/core/src/org/labkey/core/query/UsersTable.java
@@ -453,9 +453,9 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
     }
 
     @Override
-    public void fireRowTrigger(Container c, User user, TriggerType type, @Nullable QueryUpdateService.InsertOption insertOption, boolean before, int rowNumber, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord, boolean manageColumns) throws ValidationException
+    public void fireRowTrigger(Container c, User user, TriggerType type, @Nullable QueryUpdateService.InsertOption insertOption, boolean before, int rowNumber, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord) throws ValidationException
     {
-        super.fireRowTrigger(c, user, type, insertOption, before, rowNumber, newRow, oldRow, extraContext, existingRecord, manageColumns);
+        super.fireRowTrigger(c, user, type, insertOption, before, rowNumber, newRow, oldRow, extraContext, existingRecord);
         Integer userId = null!=oldRow ? asInteger(oldRow.get("UserId")) : null!=newRow ? asInteger(newRow.get("UserId")) : null;
         if (null != userId && !before)
             UserManager.fireUserPropertiesChanged(userId);

--- a/core/src/org/labkey/core/query/UsersTable.java
+++ b/core/src/org/labkey/core/query/UsersTable.java
@@ -453,9 +453,9 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
     }
 
     @Override
-    public void fireRowTrigger(Container c, User user, TriggerType type, boolean before, int rowNumber, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord, boolean manageColumns) throws ValidationException
+    public void fireRowTrigger(Container c, User user, TriggerType type, @Nullable QueryUpdateService.InsertOption insertOption, boolean before, int rowNumber, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, Map<String, Object> extraContext, @Nullable Map<String, Object> existingRecord, boolean manageColumns) throws ValidationException
     {
-        super.fireRowTrigger(c, user, type, before, rowNumber, newRow, oldRow, extraContext, existingRecord, manageColumns);
+        super.fireRowTrigger(c, user, type, insertOption, before, rowNumber, newRow, oldRow, extraContext, existingRecord, manageColumns);
         Integer userId = null!=oldRow ? asInteger(oldRow.get("UserId")) : null!=newRow ? asInteger(newRow.get("UserId")) : null;
         if (null != userId && !before)
             UserManager.fireUserPropertiesChanged(userId);

--- a/core/src/org/labkey/core/script/RhinoService.java
+++ b/core/src/org/labkey/core/script/RhinoService.java
@@ -807,7 +807,7 @@ class RhinoEngine extends RhinoScriptEngine
                 }
 
                 // Other JS scripts can call require('serverContext') to load this.
-                extraModules = Map.of(ScriptTrigger.SERVER_CONTEXT_SCRIPTNAME, scriptContextScript);
+                extraModules = Map.of(ScriptTrigger.SERVER_CONTEXT_SCRIPT_NAME, scriptContextScript);
             }
 
             Require require = new Require(cx, getTopLevel(), new WrappingModuleScriptProvider(_moduleScriptProvider, extraModules), null, null, true);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -9685,7 +9685,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 // Since those tables already wire up trigger scripts, we'll use that mechanism here as well for the move event.
                 BatchValidationException errors = new BatchValidationException();
                 Map<String, Object> extraContext = Map.of("targetContainer", targetContainer, "classObjects", classObjects, "dataIds", dataIds);
-                dataClassTable.fireBatchTrigger(sourceContainer, user, TableInfo.TriggerType.MOVE, false, errors, extraContext);
+                dataClassTable.fireBatchTrigger(sourceContainer, user, TableInfo.TriggerType.MOVE, null, false, errors, extraContext);
                 if (errors.hasErrors())
                     throw errors;
 

--- a/experiment/src/org/labkey/experiment/samples/AbstractExpFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/AbstractExpFolderImporter.java
@@ -61,7 +61,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import static org.labkey.api.admin.FolderImportContext.IS_NEW_FOLDER_IMPORT_KEY;
 import static org.labkey.api.dataiterator.SimpleTranslator.getContainerFileRootPath;
 import static org.labkey.api.dataiterator.SimpleTranslator.getFileRootSubstitutedFilePath;
 import static org.labkey.api.exp.XarContext.XAR_JOB_ID_NAME;
@@ -313,15 +312,8 @@ public abstract class AbstractExpFolderImporter implements FolderImporter
                                     options.put(ExperimentService.QueryOptions.DeferRequiredLineageValidation, true);
                                     context.setConfigParameters(options);
 
-                                    Map<String, Object> extraContext = null;
-                                    if (ctx.isNewFolderImport())
-                                    {
-                                        extraContext = new HashMap<>();
-                                        extraContext.put(IS_NEW_FOLDER_IMPORT_KEY, true);
-                                    }
-
                                     DataIterator data = new ResolveLsidAndFileLinkDataIterator(loader.getDataIterator(context), xarContext, expObject instanceof ExpDataClass ? "DataClass" : ExpMaterial.DEFAULT_CPAS_TYPE, tinfo);
-                                    int count = qus.loadRows(ctx.getUser(), ctx.getContainer(), data, context, extraContext);
+                                    int count = qus.loadRows(ctx.getUser(), ctx.getContainer(), data, context, null);
                                     log.info("Imported a total of " + count + " rows into : " + tableName);
 
                                     if (context.getErrors().hasErrors())

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -551,7 +551,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
 
                     // Before trigger per batch
                     Map<String, Object> extraContext = Map.of("targetContainer", targetContainer, "keys", rowPks);
-                    listTable.fireBatchTrigger(sourceContainer, user, TableInfo.TriggerType.MOVE, true, errors, extraContext);
+                    listTable.fireBatchTrigger(sourceContainer, user, TableInfo.TriggerType.MOVE, null, true, errors, extraContext);
                     if (errors.hasErrors())
                         throw errors;
 
@@ -574,7 +574,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
                         listAuditEventsCreatedCount += addDetailedMoveAuditEvents(user, sourceContainer, targetContainer, batch);
 
                     // After trigger per batch
-                    listTable.fireBatchTrigger(sourceContainer, user, TableInfo.TriggerType.MOVE, false, errors, extraContext);
+                    listTable.fireBatchTrigger(sourceContainer, user, TableInfo.TriggerType.MOVE, null, false, errors, extraContext);
                     if (errors.hasErrors())
                         throw errors;
                 }

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -247,6 +247,8 @@ public class QueryModule extends DefaultModule
             "Allow for lookup fields in product folders to query across all folders within the top-level folder.", false);
         OptionalFeatureService.get().addExperimentalFeatureFlag(QueryServiceImpl.EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED, "Product folders display folder-specific data",
             "Only list folder-specific data within product folders.", false);
+        OptionalFeatureService.get().addExperimentalFeatureFlag(QueryService.EXPERIMENTAL_DISABLE_MANAGED_TRIGGER_COLUMNS, "Disable managed columns in query triggers",
+                "By default LabKey enforces managed columns for triggers and errors when the data does not align. Enabling this feature will result in them only logging warnings.", false);
 
         McpService.get().register(new QueryMcp());
     }

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -33,7 +33,6 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.audit.AbstractAuditHandler;
 import org.labkey.api.audit.AuditHandler;
@@ -3609,6 +3608,11 @@ public class QueryServiceImpl implements QueryService
     public boolean isProductFoldersDataListingScopedToProject()
     {
         return AppProps.getInstance().isOptionalFeatureEnabled(EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED);
+    }
+
+    public boolean isTriggerManagedColumnsEnabled()
+    {
+        return !AppProps.getInstance().isOptionalFeatureEnabled(EXPERIMENTAL_DISABLE_MANAGED_TRIGGER_COLUMNS);
     }
 
     public static class TestCase extends Assert

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3610,6 +3610,7 @@ public class QueryServiceImpl implements QueryService
         return AppProps.getInstance().isOptionalFeatureEnabled(EXPERIMENTAL_PRODUCT_PROJECT_DATA_LISTING_SCOPED);
     }
 
+    @Override
     public boolean isTriggerManagedColumnsEnabled()
     {
         return !AppProps.getInstance().isOptionalFeatureEnabled(EXPERIMENTAL_DISABLE_MANAGED_TRIGGER_COLUMNS);

--- a/specimen/src/org/labkey/specimen/query/SpecimenUpdateService.java
+++ b/specimen/src/org/labkey/specimen/query/SpecimenUpdateService.java
@@ -70,7 +70,6 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
         super(queryTable);
     }
 
-
     @Override
     public int importRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors, Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext)
     {
@@ -94,7 +93,7 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
 
         BatchValidationException errors = new BatchValidationException();
         errors.setExtraContext(extraScriptContext);
-        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.DELETE, true, errors, extraScriptContext);
+        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.DELETE, null, true, errors, extraScriptContext);
 
         Set<Long> rowIds = new HashSet<>(keys.size());
         for (Map<String, Object> key : keys)
@@ -139,7 +138,7 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
             throw new IllegalStateException(e.getMessage());
         }
 
-        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.DELETE, false, errors, extraScriptContext);
+        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.DELETE, null, false, errors, extraScriptContext);
 
         addAuditEvent(user, container, QueryService.AuditAction.DELETE, configParameters, null, null, null);
 
@@ -203,7 +202,7 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
         try
         {
             if (hasTableScript)
-                getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.INSERT, true, errors, extraScriptContext);
+                getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.INSERT, null, true, errors, extraScriptContext);
         }
         catch (BatchValidationException e)
         {
@@ -263,7 +262,7 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
         try
         {
             if (hasTableScript)
-                getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.INSERT, false, errors, extraScriptContext);
+                getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.INSERT, null, false, errors, extraScriptContext);
         }
         catch (BatchValidationException e)
         {
@@ -332,7 +331,7 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
             throw new IllegalArgumentException("rows and oldKeys are required to be the same length, but were " + rows.size() + " and " + oldKeys + " in length, respectively");
 
         errors.setExtraContext(extraScriptContext);
-        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.UPDATE, true, errors, extraScriptContext);
+        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.UPDATE, null, true, errors, extraScriptContext);
 
         Set<Long> rowIds = new HashSet<>(rows.size());
         Map<Long, Map<String, Object>> uniqueRows = new LongHashMap<>(rows.size());
@@ -406,7 +405,7 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
             throw new IllegalStateException(e.getMessage());
         }
 
-        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.UPDATE, false, errors, extraScriptContext);
+        getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.UPDATE, null, false, errors, extraScriptContext);
 
         addAuditEvent(user, container, QueryService.AuditAction.UPDATE, configParameters, rows, null, null);
 


### PR DESCRIPTION
#### Rationale
When query triggers are called within data iterators they are allowed to manipulate the data of the row that is being procured. However, if a trigger modifies the columns (i.e., the keys of the row map) it can result in data being mismanaged due to the columns in the row not aligning with what the data iterator specified.

This introduces the notion of "managed" columns to triggers. Triggers can, at the outset, declare which columns they are going to manage. Any managed columns are then picked up by the data iterator during initialization to ensure they are persisted correctly. To enforce this management more strictly, and to avoid mismanagement of null values, triggers are required to fulfill all managed column values by either clearing the value or setting the value. After the trigger has fired the resulting row will be validated and checked. The result is consistent enforcement and acknowledgement of triggers that manipulate the shape of the data.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2087
- https://github.com/LabKey/premiumModules/pull/501
- https://github.com/LabKey/testAutomation/pull/2938
- https://github.com/LabKey/targetedms/pull/1191
- https://github.com/LabKey/ehrModules/pull/1114
- https://github.com/LabKey/nircEHRModules/pull/682
- https://github.com/LabKey/wnprc-modules/pull/940
- https://github.com/LabKey/DiscvrLabKeyModules/pull/422
- https://github.com/LabKey/johnsHopkinsEHRModules/pull/627
- https://github.com/LabKey/LabDevKitModules/pull/282
- https://github.com/LabKey/BimberLabKeyModules/pull/290

#### User Education Handoff
@labkey-steveh 
For developer teams that have implemented trigger scripts that are using beforeInsert() or beforeUpdate(), and are modifying the shape of the data by adding or removing columns (i.e., altering the keys of the row map), they will need to implement managed Columns:
https://www.labkey.org/Documentation/wiki-page.view?name=serverSideValidation#managedColumns

If they have a lot of these, they can turn on the experimental feature flag:  Disable managed columns in query triggers 


#### Changes
- Declare `TableInfo.getTriggerManagedColumns()` to allow for data iterator to gather all managed columns
- Add difference checks for non-managed columns added or removed by triggers
- Support managed columns in server-side JS trigger scripts
- Add utilities to ensure managed column values are set (`setInsertManagedColumns()` and `setUpdateManagedColumns()`)
- Add experimental feature flag which when enabled will disable the managed trigger columns feature

#### Tasks
- [x] Initial review @labkey-matthewb 
- [x] Hook up server-side JS triggers
- [x] Only throw errors in development for non-data iterator triggers
- [x] Add experimental feature flag to disable
- [x] Optimize row checks
- [x] Needs automation
- [x] Code review @mbellew 
- [x] Manual testing @XingY 
- [ ] Verify fix

#### Manual Testing notes (in progress)
- [ ] DataIterator is not able to recognize column labels, but managedColumns does? (Not quite fixed... ScriptTrigger.getManagedColumns still accepts label. ) @labkey-nicka 
  1. Repro: create a string key list, add another property "With Space" (with a space in the color name)
  2. Use the following trigger script:
  ```js
  function beforeUpdate(row, errors) {
      row['WithSpace'] = 'true';
  }
  
  function managedColumns() {
      return {
          update: ['WithSpace']
      }
  }
  ```
  3. Use query api to update a single row, update is successful and correctly sets "With Space" to 'true'.
  4. Use bulk update, update is successful, but "With Space" is not set to 'true'. 
- [x] Study dataset: the presence of a trigger script result in existing QCState erased using "Import with Update" (Not merge, which is a different known issue).
  - Unrelated to this branch: reproduces on develop
- [x] Study dataset: the presence of the following trigger script setup result in inability to update a dataset row from detail edit (non data iterator). The update page refreshes on submit, without error or success feedback, the data is not actually updated 
  - Unrelated to this branch: reproduces on develop
```js
function beforeUpdate(row, errors) {
    row['QC State'] = 'clean';
}

function managedColumns() {
    return {
        update: ['QC State']
    }
}
```
- [x] Lists (but maybe other data type as well): if the trigger script provides an invalid value for the managed column, for example, a string value for an int field. The import fails with a "false" error msg.
  - Unrelated to this branch: reproduces on develop
- [x] Not sure if related to this branch (data integrity): trigger script only works for column name, not column label. However, if the trigger script uses label (such as 'Status' for 'SampleState'), then that results in existing SampleState being set to blank.
  - Unrelated to this branch: reproduces on develop
  - Seems like this is the same as [this issue](https://github.com/LabKey/internal-issues/issues/1048) (current critical issue)
- [x] Trigger script doesn't work for parent input columns for sources and samples
  - Unrelated to this branch: reproduces on develop

