### PR TITLE
Use ReleaseVersion instead of no-longer-populated vcsTag

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -817,12 +817,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         _vcsBranch = vcsBranch;
     }
 
-    @SuppressWarnings({"UnusedDeclaration"})
-    public void setVcsTag(String vcsTag)
-    {
-        // Ignored - present in module.xml but not used
-    }
-
     public final String getBuildUser()
     {
         return _buildUser;

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -817,6 +817,12 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         _vcsBranch = vcsBranch;
     }
 
+    @SuppressWarnings({"UnusedDeclaration"})
+    public void setVcsTag(String vcsTag)
+    {
+        // Ignored - present in module.xml but not used
+    }
+
     public final String getBuildUser()
     {
         return _buildUser;

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -137,7 +137,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     private String _vcsRevision = null;
     private String _vcsUrl = null;
     private String _vcsBranch = "Unknown";
-    private String _vcsTag = "Unknown";
     private String _buildUser = null;
     private String _buildTime = null;
     private String _buildOS = null;
@@ -818,19 +817,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         _vcsBranch = vcsBranch;
     }
 
-    @Nullable
-    @Override
-    public String getVcsTag()
-    {
-        return _vcsTag;
-    }
-
-    @SuppressWarnings({"UnusedDeclaration"})
-    public void setVcsTag(String vcsTag)
-    {
-        _vcsTag = vcsTag;
-    }
-
     public final String getBuildUser()
     {
         return _buildUser;
@@ -974,7 +960,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         props.put("VCS URL", getVcsUrl());
         props.put("VCS Revision", getVcsRevision());
         props.put("VCS Branch", getVcsBranch());
-        props.put("VCS Tag", getVcsTag());
         props.put("Build OS", getBuildOS());
 
         props.put("Build Time", getBuildTime());
@@ -1605,7 +1590,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         this.setUrl(from.getUrl());
         this.setVcsBranch(from.getVcsBranch());
         this.setVcsRevision(from.getVcsRevision());
-        this.setVcsTag(from.getVcsTag());
         this.setVcsUrl(from.getVcsUrl());
         this.setZippedPath(from.getZippedPath());
     }

--- a/api/src/org/labkey/api/module/MockModule.java
+++ b/api/src/org/labkey/api/module/MockModule.java
@@ -332,12 +332,6 @@ public class MockModule implements Module
     }
 
     @Override
-    public String getVcsTag()
-    {
-        return null;
-    }
-
-    @Override
     public boolean shouldManageVersion()
     {
         return false;

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -311,7 +311,6 @@ public interface Module
     String getVcsRevision();
     String getVcsUrl();
     String getVcsBranch();
-    String getVcsTag();
     String getBuildNumber();
 
     default String getBuildTime()

--- a/api/src/org/labkey/api/util/UsageReportingLevel.java
+++ b/api/src/org/labkey/api/util/UsageReportingLevel.java
@@ -327,9 +327,11 @@ public enum UsageReportingLevel implements SafeToRenderEnum
             moduleBuildInfo.put("vcsUrl", module.getVcsUrl());
             moduleBuildInfo.put("vcsBranch", module.getVcsBranch());
             moduleBuildInfo.put("vcsRevision", module.getVcsRevision());
-            moduleBuildInfo.put("vcsTag", module.getVcsTag());
+            // We stopped capturing the Git tag in module metadata. The release version property serves
+            // the same purpose. Continue reporting as vcsTag for backwards compatibility with mothership reporting.
+            moduleBuildInfo.put("vcsTag", module.getReleaseVersion());
             moduleBuildInfo.put("moduleClass", module.getClass().getName());
-            moduleBuildInfo.put("version", module.getFormattedSchemaVersion()); // TODO: call this "schemaVersion"? Also send "releaseVersion"?
+            moduleBuildInfo.put("version", module.getFormattedSchemaVersion()); // TODO: call this "schemaVersion"?
 
             // Add to the module's info to be included in the submission
             moduleStats.put("buildInfo", moduleBuildInfo);


### PR DESCRIPTION
#### Rationale
`vcsTag` is no longer populated. Use `ReleaseVersion` instead for mothership reporting to track maintenance release versions.

#### Related PRs
- https://github.com/LabKey/server/pull/1324

#### Changes
- Swap the source of the `vcsTag` module metadata submitted to mothership
- Remove defunct `vcsTag` from `Module` interface

#### Tasks 📍
- [x] Manual Testing
