### PR TITLE
Add the currently enabled productKey to the LABKEY object

### DIFF
--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -105,6 +105,7 @@ import org.labkey.api.notification.EmailService;
 import org.labkey.api.notification.NotificationMenuView;
 import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.premium.AntiVirusProviderRegistry;
+import org.labkey.api.products.Product;
 import org.labkey.api.products.ProductRegistry;
 import org.labkey.api.qc.DataStateManager;
 import org.labkey.api.query.DefaultSchema;
@@ -1404,6 +1405,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         JSONObject json = new JSONObject(getDefaultPageContextJson(context.getContainer()));
         json.put("productFeatures", ProductRegistry.getProductFeatureSet());
         json.put("primaryApplicationId", ProductRegistry.get().getPrimaryApplicationId(context.getContainer()));
+        json.put("productKey", ProductRegistry.getProducts().stream().filter(Product::isEnabled).toList().getFirst().getKey());
         return json;
     }
 

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1405,7 +1405,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         JSONObject json = new JSONObject(getDefaultPageContextJson(context.getContainer()));
         json.put("productFeatures", ProductRegistry.getProductFeatureSet());
         json.put("primaryApplicationId", ProductRegistry.get().getPrimaryApplicationId(context.getContainer()));
-        json.put("productKey", ProductRegistry.getProducts().stream().filter(Product::isEnabled).toList().getFirst().getKey());
+        json.put("productKey", new ProductConfiguration().getCurrentProductKey());
         return json;
     }
 


### PR DESCRIPTION
#### Rationale
When reasoning about why features show up or don't, it is often useful to know what the configured product key is. Users with the proper permission can see this on the product configuration page in the admin console, but not everyone who needs to do troubleshooting of this sort has such permissions. 

#### Changes
- add `productKey` to the `LABKEY` object

#### Tasks 📍
- [x] Manual Testing @cnathe 
- [ ] ~Needs Automation~
- [ ] ~Verify Fix~