### PR TITLE
Issue 975: Don't include sample types from other folders when exporting

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/SampleTypeFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeFolderWriter.java
@@ -78,7 +78,7 @@ public abstract class SampleTypeFolderWriter extends AbstractExpFolderWriter
 
         Lsid sampleTypeLsid = new Lsid(ExperimentService.get().generateLSID(c, ExpSampleType.class, "export"));
         Set<String> sampleTypeLsids = new HashSet<>();
-        for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(c, true))
+        for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(c, false))
         {
             // ignore the magic sample type that is used for the specimen repository, it is managed by the specimen importer
             StudyService ss = StudyService.get();


### PR DESCRIPTION
#### Rationale
Issue [975](https://github.com/LabKey/internal-issues/issues/975)

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2933

#### Changes
- Don't include sample types from other folders when exporting
