### PR TITLE
Log orphaned attachments action for tests

### DIFF
--- a/api/src/org/labkey/api/attachments/AttachmentService.java
+++ b/api/src/org/labkey/api/attachments/AttachmentService.java
@@ -140,7 +140,10 @@ public interface AttachmentService
 
     HttpView<?> getFindAttachmentParentsView();
 
-    void logOrphanedAttachments();
+    /**
+     * Logs the first 20 orphaned attachments it detects. Returns the total number of orphaned attachments detected.
+     */
+    int logOrphanedAttachments();
 
     void deleteOrphanedAttachments();
 

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1944,7 +1944,9 @@ public class ContainerManager
                 setContainerTabDeleted(c.getParent(), c.getName(), c.getParent().getFolderType().getName());
             }
 
-            AttachmentService.get().logOrphanedAttachments();
+            // Log orphaned attachments in this server, but only in dev mode, since this is for our testing
+            if (AppProps.getInstance().isDevMode())
+                AttachmentService.get().logOrphanedAttachments();
 
             fireDeleteContainer(c, user);
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -3710,6 +3710,20 @@ public class AdminController extends SpringActionController
         }
     }
 
+    @AdminConsoleAction
+    public static class LogOrphanedAttachmentsAction extends ReadOnlyApiAction<Object>
+    {
+        @Override
+        public Object execute(Object o, BindException errors) throws Exception
+        {
+            int count = 0;
+            AttachmentService svc = AttachmentService.get();
+            if (svc != null)
+                count = svc.logOrphanedAttachments();
+            return Map.of("count", count);
+        }
+    }
+
     public static ActionURL getMemTrackerURL(boolean clearCaches, boolean gc)
     {
         ActionURL url = new ActionURL(MemTrackerAction.class, ContainerManager.getRoot());

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -1101,10 +1101,10 @@ public class AttachmentServiceImpl implements AttachmentService
     private record Orphan(String documentName, String parentType){}
 
     @Override
-    public void logOrphanedAttachments()
+    public int logOrphanedAttachments()
     {
-        // Log orphaned attachments in this server, but in dev mode only, since this is for our testing. Also, we
-        // don't yet offer a way to delete orphaned attachments via the UI, so it's not helpful to inform admins.
+        int ret = 0;
+
         if (AppProps.getInstance().isDevMode())
         {
             User user = ElevatedUser.getElevatedUser(User.getSearchUser(), TroubleshooterRole.class);
@@ -1118,7 +1118,8 @@ public class AttachmentServiceImpl implements AttachmentService
                     List<Orphan> orphans = new TableSelector(documents, new CsvSet("DocumentName, ParentType"), filter, null).getArrayList(Orphan.class);
                     if (!orphans.isEmpty())
                     {
-                        LOG.error("Found {}, which likely indicates a problem with a delete method or a container listener.", StringUtilsLabKey.pluralize(orphans.size(), "orphaned attachment"));
+                        ret = orphans.size();
+                        LOG.error("Found {}, which likely indicates a problem with a delete method or a container listener.", StringUtilsLabKey.pluralize(ret, "orphaned attachment"));
 
                         final String message;
                         if (orphans.size() > MAX_ORPHANS_TO_LOG)
@@ -1136,6 +1137,8 @@ public class AttachmentServiceImpl implements AttachmentService
                 }
             }
         }
+
+        return ret;
     }
 
     record OrphanedAttachment(String container, String parent, String parentType, String documentName)

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -1104,36 +1104,33 @@ public class AttachmentServiceImpl implements AttachmentService
     public int logOrphanedAttachments()
     {
         int ret = 0;
+        User user = ElevatedUser.getElevatedUser(User.getSearchUser(), TroubleshooterRole.class);
+        UserSchema core = DefaultSchema.get(user, ContainerManager.getRoot()).getUserSchema(CoreQuerySchema.NAME);
 
-        if (AppProps.getInstance().isDevMode())
+        if (core != null)
         {
-            User user = ElevatedUser.getElevatedUser(User.getSearchUser(), TroubleshooterRole.class);
-            UserSchema core = DefaultSchema.get(user, ContainerManager.getRoot()).getUserSchema(CoreQuerySchema.NAME);
-            if (core != null)
+            TableInfo documents = core.getTable(CoreQuerySchema.DOCUMENTS_TABLE_NAME, new AllFolders(user));
+            if (null != documents)
             {
-                TableInfo documents = core.getTable(CoreQuerySchema.DOCUMENTS_TABLE_NAME, new AllFolders(user));
-                if (null != documents)
+                SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("Orphaned"), true);
+                List<Orphan> orphans = new TableSelector(documents, new CsvSet("DocumentName, ParentType"), filter, null).getArrayList(Orphan.class);
+                if (!orphans.isEmpty())
                 {
-                    SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("Orphaned"), true);
-                    List<Orphan> orphans = new TableSelector(documents, new CsvSet("DocumentName, ParentType"), filter, null).getArrayList(Orphan.class);
-                    if (!orphans.isEmpty())
+                    ret = orphans.size();
+                    LOG.error("Found {}, which likely indicates a problem with a delete method or a container listener.", StringUtilsLabKey.pluralize(ret, "orphaned attachment"));
+
+                    final String message;
+                    if (orphans.size() > MAX_ORPHANS_TO_LOG)
                     {
-                        ret = orphans.size();
-                        LOG.error("Found {}, which likely indicates a problem with a delete method or a container listener.", StringUtilsLabKey.pluralize(ret, "orphaned attachment"));
-
-                        final String message;
-                        if (orphans.size() > MAX_ORPHANS_TO_LOG)
-                        {
-                            orphans = orphans.subList(0, MAX_ORPHANS_TO_LOG);
-                            message = "The first " + MAX_ORPHANS_TO_LOG;
-                        }
-                        else
-                        {
-                            message = "All";
-                        }
-
-                        LOG.error("{} detected orphans are listed below:\n{}", message, orphans.stream().map(Record::toString).collect(Collectors.joining("\n")));
+                        orphans = orphans.subList(0, MAX_ORPHANS_TO_LOG);
+                        message = "The first " + MAX_ORPHANS_TO_LOG;
                     }
+                    else
+                    {
+                        message = "All";
+                    }
+
+                    LOG.error("{} detected orphans are listed below:\n{}", message, orphans.stream().map(Record::toString).collect(Collectors.joining("\n")));
                 }
             }
         }


### PR DESCRIPTION
#### Rationale
`LogOrphanedAttachmentsAction` gives our tests a way to proactively check for orphaned attachments

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2940