### PR TITLE
GitHub Issue 954: Add error for duplicate values for parent inputs

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -76,6 +76,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.labkey.api.exp.api.ExpMaterial.ALIQUOTED_FROM_INPUT;
@@ -787,7 +788,7 @@ public class NameGenerator
         {
             List<String> valueList = values.toList();
             Set<String> valueSet = new HashSet<>();
-            List<String> duplicates = valueList.stream().filter(s -> !valueSet.add(s)).toList();
+            Set<String> duplicates = valueList.stream().filter(s -> !valueSet.add(s)).collect(Collectors.toSet());
             if (!duplicates.isEmpty())
             {
                 if (errors != null)

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -785,8 +785,9 @@ public class NameGenerator
 
         if (values != null)
         {
+            List<String> valueList = values.toList();
             Set<String> valueSet = new HashSet<>();
-            List<String> duplicates = values.filter(s -> !valueSet.add(s)).toList();
+            List<String> duplicates = valueList.stream().filter(s -> !valueSet.add(s)).toList();
             if (!duplicates.isEmpty())
             {
                 if (errors != null)
@@ -794,6 +795,7 @@ public class NameGenerator
                 else
                     throw new IllegalStateException("Duplicate parent names found: " + StringUtils.join(duplicates, ", "));
             }
+            return valueList.stream();
         }
 
         return values;

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -729,7 +729,7 @@ public class NameGenerator
                 .filter(s -> !s.isEmpty());
     }
 
-    public static Stream<String> parentNames(Object value, String parentColName, TSVWriter tsvWriter, @Nullable BatchValidationException errors)
+    public static @Nullable Stream<String> parentNames(Object value, String parentColName, TSVWriter tsvWriter, @Nullable BatchValidationException errors)
     {
         if (value == null)
             return Stream.empty();
@@ -781,6 +781,19 @@ public class NameGenerator
                 errors.addRowError(new ValidationException("Expected comma separated list or a JSONArray of parent names: " + value, parentColName));
             else
                 throw new IllegalStateException("For parent values in naming pattern, expected string or collection for '" + parentColName + "': " + value);
+        }
+
+        if (values != null)
+        {
+            Set<String> valueSet = new HashSet<>();
+            List<String> duplicates = values.filter(s -> !valueSet.add(s)).toList();
+            if (!duplicates.isEmpty())
+            {
+                if (errors != null)
+                    errors.addRowError(new ValidationException("Duplicate parent names found: " + StringUtils.join(duplicates, ", "), parentColName));
+                else
+                    throw new IllegalStateException("Duplicate parent names found: " + StringUtils.join(duplicates, ", "));
+            }
         }
 
         return values;


### PR DESCRIPTION
#### Rationale
GitHub Issue [954](https://github.com/LabKey/internal-issues/issues/954): Add error for duplicate values for parent inputs

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1977
- https://github.com/LabKey/platform/pull/7559
- https://github.com/LabKey/limsModules/pull/2100

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->