### PR TITLE
Add DOCUMENT_BUILDER_FACTORY_ALLOWING_DOCTYPE to XmlBeansUtil

### DIFF
--- a/api/src/org/labkey/api/util/XmlBeansUtil.java
+++ b/api/src/org/labkey/api/util/XmlBeansUtil.java
@@ -132,6 +132,7 @@ public class XmlBeansUtil
     public static final SAXParserFactory SAX_PARSER_FACTORY_ALLOWING_DOCTYPE;
     public static final XMLInputFactory XML_INPUT_FACTORY;
     public static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY;
+    public static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY_ALLOWING_DOCTYPE;
 
     static
     {
@@ -145,16 +146,8 @@ public class XmlBeansUtil
             SAX_PARSER_FACTORY = saxParserFactory(false);
             SAX_PARSER_FACTORY_ALLOWING_DOCTYPE = saxParserFactory(true);
 
-            //noinspection XMLInputFactory
-            DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
-            DOCUMENT_BUILDER_FACTORY.setNamespaceAware(true);
-            DOCUMENT_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            DOCUMENT_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            DOCUMENT_BUILDER_FACTORY.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            DOCUMENT_BUILDER_FACTORY.setXIncludeAware(false);
-            DOCUMENT_BUILDER_FACTORY.setExpandEntityReferences(false);
+            DOCUMENT_BUILDER_FACTORY = documentBuilderFactory(false);
+            DOCUMENT_BUILDER_FACTORY_ALLOWING_DOCTYPE = documentBuilderFactory(true);
         }
         catch (ParserConfigurationException | SAXException e)
         {
@@ -179,6 +172,32 @@ public class XmlBeansUtil
         result.setFeature("http://xml.org/sax/features/external-general-entities", false);
         result.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         result.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        return result;
+    }
+
+    private static DocumentBuilderFactory documentBuilderFactory(boolean allowDocType) throws ParserConfigurationException
+    {
+        //noinspection XMLInputFactory
+        DocumentBuilderFactory result = DocumentBuilderFactory.newInstance();
+        result.setNamespaceAware(true);
+
+        // Disable features that could lead to XXE or other vulnerabilities.
+        // When allowDocType is true the DOCTYPE declaration is permitted, but external entity
+        // and external DTD resolution remain disabled, so XXE protection stays in effect —
+        // only the strict disallow-doctype-decl flag is relaxed. Use the ALLOWING_DOCTYPE
+        // variant when parsing XML from a source that legitimately emits a <!DOCTYPE>
+        // declaration (e.g. NCBI's eSummary responses, which reference an external DTD that
+        // we don't actually fetch).
+        if (!allowDocType)
+        {
+            result.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        }
+        result.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        result.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        result.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        result.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        result.setXIncludeAware(false);
+        result.setExpandEntityReferences(false);
         return result;
     }
 }

--- a/api/src/org/labkey/api/util/XmlBeansUtil.java
+++ b/api/src/org/labkey/api/util/XmlBeansUtil.java
@@ -147,6 +147,7 @@ public class XmlBeansUtil
             SAX_PARSER_FACTORY_ALLOWING_DOCTYPE = saxParserFactory(true);
 
             DOCUMENT_BUILDER_FACTORY = documentBuilderFactory(false);
+            // Use the ALLOWING_DOCTYPE variant when parsing XML that contains a <!DOCTYPE> declaration (e.g. NCBI's eSummary responses)
             DOCUMENT_BUILDER_FACTORY_ALLOWING_DOCTYPE = documentBuilderFactory(true);
         }
         catch (ParserConfigurationException | SAXException e)
@@ -182,12 +183,8 @@ public class XmlBeansUtil
         result.setNamespaceAware(true);
 
         // Disable features that could lead to XXE or other vulnerabilities.
-        // When allowDocType is true the DOCTYPE declaration is permitted, but external entity
-        // and external DTD resolution remain disabled, so XXE protection stays in effect —
-        // only the strict disallow-doctype-decl flag is relaxed. Use the ALLOWING_DOCTYPE
-        // variant when parsing XML from a source that legitimately emits a <!DOCTYPE>
-        // declaration (e.g. NCBI's eSummary responses, which reference an external DTD that
-        // we don't actually fetch).
+        // When allowDocType is true the DOCTYPE declaration is permitted. External entity
+        // resolution remains disabled, so XXE protection is still in effect.
         if (!allowDocType)
         {
             result.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);


### PR DESCRIPTION
#### Rationale
`XmlBeansUtil.DOCUMENT_BUILDER_FACTORY` sets `disallow-doctype-decl=true` for XXE protection, which causes parsers to fail on any XML with a `<!DOCTYPE>` declaration. This is a problem for the Panorama Public code that parses NCBI's `esummary.fcgi` response that begins with `<!DOCTYPE eSummaryResult PUBLIC ... esummary-v1.dtd>`

#### Related Pull Requests
- https://github.com/LabKey/MacCossLabModules/pull/605
- https://github.com/LabKey/MacCossLabModules/pull/623

#### Changes
- Added `DOCUMENT_BUILDER_FACTORY_ALLOWING_DOCTYPE` to `XmlBeansUtil`, mirroring the existing `SAX_PARSER_FACTORY_ALLOWING_DOCTYPE`. The DOCTYPE declaration is permitted, but every other XXE mitigation stays in place. 
- Extracted  a private `documentBuilderFactory(boolean allowDocType)` helper, mirroring the existing `saxParserFactory(boolean)`  helper.