### PR TITLE
GitHub Issue #688: Sample's Created By and Modified By fields do not resolve correctly when added to assay results grid if sample lookup is set to a specific sample type 

### DIFF
--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -264,7 +264,15 @@ public class SamplesSchema extends AbstractExpSchema implements UserSchema.HasCo
                 if (domainProperty != null && domainProperty.getPropertyType().getJdbcType().isText())
                     _columnName = "Name";
 
-                return getTable(tableName, getLookupContainerFilter());
+                // GitHub Issue #688
+                if (st != null)
+                    return getTable(tableName, getLookupContainerFilter());
+
+                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(SamplesSchema.this, getLookupContainerFilter(), st);
+                ret.populate();
+                ret.overlayMetadata(ret.getPublicName(), SamplesSchema.this, new ArrayList<>());
+                ret.setLocked(true);
+                return ret;
             }
 
             @Override

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -255,21 +255,7 @@ public class SamplesSchema extends AbstractExpSchema implements UserSchema.HasCo
             {
                 ContainerFilter cf = getLookupContainerFilter();
                 String cacheKey = SamplesSchema.class.getName() + "/" + schemaName + "/" + tableName + "/" + (null==st ? "" : st.getMaterialLSIDPrefix()) + "/" + (null==domainProperty ? "" : domainProperty.getPropertyURI()) + cf.getCacheKey();
-                return SamplesSchema.this.getCachedLookupTableInfo(cacheKey, this::createLookupTableInfo);
-            }
-
-            private TableInfo createLookupTableInfo()
-            {
-                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(SamplesSchema.this, getLookupContainerFilter(), st);
-                ret.populate();
-                ret.overlayMetadata(ret.getPublicName(), SamplesSchema.this, new ArrayList<>());
-                if (domainProperty != null && domainProperty.getPropertyType().getJdbcType().isText())
-                {
-                    // Hack to support lookup via RowId or Name
-                    _columnName = "Name";
-                }
-                ret.setLocked(true);
-                return ret;
+                return SamplesSchema.this.getCachedLookupTableInfo(cacheKey, () -> getTable(tableName, cf));
             }
 
             @Override

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -255,7 +255,16 @@ public class SamplesSchema extends AbstractExpSchema implements UserSchema.HasCo
             {
                 ContainerFilter cf = getLookupContainerFilter();
                 String cacheKey = SamplesSchema.class.getName() + "/" + schemaName + "/" + tableName + "/" + (null==st ? "" : st.getMaterialLSIDPrefix()) + "/" + (null==domainProperty ? "" : domainProperty.getPropertyURI()) + cf.getCacheKey();
-                return SamplesSchema.this.getCachedLookupTableInfo(cacheKey, () -> getTable(tableName, cf));
+                return SamplesSchema.this.getCachedLookupTableInfo(cacheKey, this::createLookupTableInfo);
+            }
+
+            private TableInfo createLookupTableInfo()
+            {
+                // Hack to support lookup via RowId or Name
+                if (domainProperty != null && domainProperty.getPropertyType().getJdbcType().isText())
+                    _columnName = "Name";
+
+                return getTable(tableName, getLookupContainerFilter());
             }
 
             @Override

--- a/study/test/src/org/labkey/test/tests/study/AssayTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AssayTest.java
@@ -279,7 +279,6 @@ public class AssayTest extends AbstractAssayTest
         clickAndWait(Locator.linkWithText("view results"));
         assertElementPresent("Sample lookup failed for: OS_1", new Locator.LinkLocator("OS_1"), 1);
 
-
         log("Edit assay design and change Sample field to point to created Sample Type");
         goToManageAssays();
         clickAndWait(Locator.LinkLocator.linkWithText(SAMPLE_FIELD_TEST_ASSAY));
@@ -294,9 +293,20 @@ public class AssayTest extends AbstractAssayTest
         importAssayData(SAMPLE_FIELD_TEST_ASSAY, TEST_RUN2, "SampleField\nS_1");
         goToManageAssays().clickAndWait(Locator.linkWithText(SAMPLE_FIELD_TEST_ASSAY));
         clickAndWait(Locator.linkWithText("view results"));
-//        assertElementPresent("Sample lookup failed for: OS_1", new Locator.LinkLocator("OS_1"), 1); //TODO this becomes the RowId "<123>" after change. Issue #40047
-
+        DataRegionTable table = new DataRegionTable("Data", getDriver());
+        List<String> sampleFieldValues = table.getColumnDataAsText("SampleField");
+        assertTrue("First sample should not resolve to sample type", sampleFieldValues.get(0).startsWith("<"));
+        assertEquals("Second sample should resolve to sample type", "S_1", sampleFieldValues.get(1));
         assertElementPresent("Sample lookup failed for: S_1", new Locator.LinkLocator("S_1"), 1);
+
+        log("GitHub Issue #688: verify sample lookup to createdBy");
+        _customizeViewsHelper.openCustomizeViewPanel();
+        _customizeViewsHelper.addColumn("SampleField/CreatedBy");
+        _customizeViewsHelper.applyCustomView();
+        table = new DataRegionTable("Data", getDriver());
+        List<String> createdByValues = table.getColumnDataAsText("SampleField/CreatedBy");
+        assertEquals("First sample should not have a createdBy since it doesn't resolve", " ", createdByValues.get(0));
+        assertEquals("Second sample should have a createdBy since it resolves to a sample type", getCurrentUserName(), createdByValues.get(1));
 
         log("Edit assay design and change Sample field to point back to 'All Samples'");
         goToManageAssays();
@@ -319,6 +329,10 @@ public class AssayTest extends AbstractAssayTest
         assertElementPresent("Sample lookup failed for: S_2", new Locator.LinkLocator("S_2"), 1);
         assertElementPresent("Sample lookup failed for: OS_2", new Locator.LinkLocator("OS_2"), 1);
 
+        log("GitHub Issue #688: verify sample lookup to createdBy");
+        table = new DataRegionTable("Data", getDriver());
+        for (int i = 0; i < table.getDataRowCount(); i++)
+            assertEquals("Row " + i + " should have current user as createdBy since they all resolve to samples", getCurrentUserName(), table.getDataAsText(i, "SampleField/CreatedBy"));
     }
 
     private void importAssayData(String assayName, String runName, String runDataStr)


### PR DESCRIPTION
#### Rationale
[#688](https://github.com/LabKey/internal-issues/issues/688) Sample's Created By and Modified By fields do not resolve correctly when added to assay results grid if sample lookup is set to a specific sample type

This PR fixes GitHub issue [#688](https://github.com/LabKey/internal-issues/issues/688) where CreatedBy and ModifiedBy fields fail to resolve when navigating through a sample lookup field (in an assay results grid) that targets a specific sample type. The fix replaces a
  custom createLookupTableInfo() implementation — which manually called createMaterialTable() + populate() + overlayMetadata() — with a simpler delegation to getTable(tableName, cf), which goes through the schema's full   
  table construction pipeline and correctly sets up all FK columns including CreatedBy/ModifiedBy.

#### Changes
- use schema getTable() for materialIdForeignKey instead of custom createLookupTableInfo()
- add test case to AssayTest