### PR TITLE
Remove error on failed link

### DIFF
--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -1246,8 +1246,6 @@ public class StudyPublishManager implements StudyPublishService
                                             StudyPublishService.SOURCE_LSID_PROPERTY_NAME, sampleType.getLSID()
                                     ));
                                 }
-                                else
-                                    LOG.error("Failed to auto link samples to study for folder {}. Timepoint and subject ID were both not resolved.", container.getPath());
                             }
                         }
 


### PR DESCRIPTION
#### Rationale
The error is a bit overaggressive. It would be normal to not include subject/timepoint information in sample imports that have autolink configured. 

Reverting back to ignoring the row.