### PR TITLE
GitHub Issue 1028: Can't delete a sample when any sample in the sample type has been linked to study

### DIFF
--- a/api/src/org/labkey/api/study/publish/StudyPublishService.java
+++ b/api/src/org/labkey/api/study/publish/StudyPublishService.java
@@ -156,7 +156,7 @@ public interface StudyPublishService
 
     String checkForLockedLinks(Dataset def, @Nullable List<Long> rowIds);
 
-    void addRecallAuditEvent(Container sourceContainer, User user, Dataset def, int rowCount, @Nullable Collection<Pair<String,Long>> datasetRowLsidAndSourceRowIds);
+    void addRecallAuditEvent(Container sourceContainer, User user, Dataset def, int rowCount, @Nullable Collection<Long> rowIds);
 
     /**
      * Adds columns to an assay data table, providing a link to any datasets that have

--- a/study/src/org/labkey/study/assay/ExperimentListenerImpl.java
+++ b/study/src/org/labkey/study/assay/ExperimentListenerImpl.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.study.assay;
 
+import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
@@ -30,8 +31,10 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.ElevatedUser;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
+import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.view.UnauthorizedException;
@@ -72,41 +75,55 @@ public class ExperimentListenerImpl implements ExperimentListener
 
         // It's likely that we'll have multiple materials from the same sample type, so group them for efficient processing
 
-        Map<ExpSampleType, List<ExpMaterial>> typeToMaterials = new HashMap<>();
+        Map<ExpSampleType, Map<Container, List<ExpMaterial>>> typeToMaterials = new HashMap<>();
 
         for (ExpMaterial material: materials)
         {
             ExpSampleType sampleType = material.getSampleType();
             if (sampleType != null)
             {
-                typeToMaterials.computeIfAbsent(sampleType, x -> new ArrayList<>()).add(material);
+                Container materialContainer = material.getContainer();
+                typeToMaterials.
+                        computeIfAbsent(sampleType, k -> new HashMap<>()).
+                        computeIfAbsent(materialContainer, k -> new ArrayList<>()).
+                        add(material);
             }
         }
 
-        for (Map.Entry<ExpSampleType, List<ExpMaterial>> entry : typeToMaterials.entrySet())
+        for (Map.Entry<ExpSampleType, Map<Container, List<ExpMaterial>>> entry : typeToMaterials.entrySet())
         {
             for (Dataset dataset: StudyPublishService.get().getDatasetsForPublishSource(entry.getKey().getRowId(), Dataset.PublishSource.SampleType))
             {
-                TableInfo t = dataset.getTableInfo(user);
-                if (null == t || !t.hasPermission(user, DeletePermission.class))
+                Map<Container, List<ExpMaterial>> containerSamples = entry.getValue();
+
+                for (Map.Entry<Container, List<ExpMaterial>> containerEntry : containerSamples.entrySet())
                 {
-                    throw new UnauthorizedException("Cannot delete rows from dataset " + dataset);
-                }
+                    Container sampleContainer = containerEntry.getKey();
+                    List<ExpMaterial> samples = containerEntry.getValue();
 
-                UserSchema schema = QueryService.get().getUserSchema(user, dataset.getContainer(), "study");
-                TableInfo tableInfo = schema.getTable(dataset.getName());
+                    // Need Read permission to check for linked samples
+                    User userWithReadPerm = ElevatedUser.getElevatedUser(user, ReaderRole.class);
 
-                // Future optimization - query for all the materials at once
-                for (ExpMaterial material : entry.getValue())
-                {
-                    SimpleFilter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.RowId.toString()), material.getRowId());
-                    String lsid = new TableSelector(tableInfo, singleton("LSID"), filter, null).getObject(String.class);
+                    UserSchema schemaWithReadPerm = QueryService.get().getUserSchema(userWithReadPerm, dataset.getContainer(), "study");
+                    TableInfo tableInfoForRead = schemaWithReadPerm.getTable(dataset.getName());
 
-                    if (lsid != null)
+                    // GitHub Issue 1028: Can't delete a sample when any sample in the sample type has been linked to study
+                    // check if samples are linked to the dataset, if not, skip the permission check for DeletePermission since we won't be deleting any rows
+                    SimpleFilter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.RowId.toString()), samples.stream().map(ExpMaterial::getRowId).toList(), CompareType.IN);
+                    List<String> linkedLsids = new TableSelector(tableInfoForRead, singleton("LSID"), filter, null).getArrayList(String.class);
+
+                    if (linkedLsids.isEmpty())
+                        continue;
+
+                    TableInfo tableInfo = dataset.getTableInfo(user);
+                    if (null == tableInfo || !tableInfo.hasPermission(user, DeletePermission.class))
                     {
-                        StudyPublishService.get().addRecallAuditEvent(material.getContainer(), user, dataset, 1, null);
-                        dataset.deleteDatasetRows(user, Arrays.asList(lsid));
+                        throw new UnauthorizedException("Cannot delete rows from dataset " + dataset);
                     }
+
+                    List<Long> linkedIds = samples.stream().filter(s -> linkedLsids.contains(s.getLSID())).map(ExpMaterial::getRowId).toList();
+                    StudyPublishService.get().addRecallAuditEvent(sampleContainer, user, dataset, linkedLsids.size(), linkedIds);
+                    dataset.deleteDatasetRows(user, linkedLsids);
                 }
             }
         }

--- a/study/src/org/labkey/study/assay/ExperimentListenerImpl.java
+++ b/study/src/org/labkey/study/assay/ExperimentListenerImpl.java
@@ -96,16 +96,18 @@ public class ExperimentListenerImpl implements ExperimentListener
             {
                 Map<Container, List<ExpMaterial>> containerSamples = entry.getValue();
 
+                // Need Read permission to check for linked samples
+                User userWithReadPerm = ElevatedUser.getElevatedUser(user, ReaderRole.class);
+
+                UserSchema schemaWithReadPerm = QueryService.get().getUserSchema(userWithReadPerm, dataset.getContainer(), "study");
+                TableInfo tableInfoForRead = schemaWithReadPerm.getTable(dataset.getName());
+                if (null == tableInfoForRead)
+                    throw new UnauthorizedException("Cannot delete rows from dataset " + dataset);
+
                 for (Map.Entry<Container, List<ExpMaterial>> containerEntry : containerSamples.entrySet())
                 {
                     Container sampleContainer = containerEntry.getKey();
                     List<ExpMaterial> samples = containerEntry.getValue();
-
-                    // Need Read permission to check for linked samples
-                    User userWithReadPerm = ElevatedUser.getElevatedUser(user, ReaderRole.class);
-
-                    UserSchema schemaWithReadPerm = QueryService.get().getUserSchema(userWithReadPerm, dataset.getContainer(), "study");
-                    TableInfo tableInfoForRead = schemaWithReadPerm.getTable(dataset.getName());
 
                     // GitHub Issue 1028: Can't delete a sample when any sample in the sample type has been linked to study
                     // check if samples are linked to the dataset, if not, skip the permission check for DeletePermission since we won't be deleting any rows

--- a/study/src/org/labkey/study/assay/ExperimentListenerImpl.java
+++ b/study/src/org/labkey/study/assay/ExperimentListenerImpl.java
@@ -44,6 +44,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.Collections.singleton;
 
@@ -112,8 +113,10 @@ public class ExperimentListenerImpl implements ExperimentListener
                     // GitHub Issue 1028: Can't delete a sample when any sample in the sample type has been linked to study
                     // check if samples are linked to the dataset, if not, skip the permission check for DeletePermission since we won't be deleting any rows
                     SimpleFilter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.RowId.toString()), samples.stream().map(ExpMaterial::getRowId).toList(), CompareType.IN);
-                    List<String> linkedLsids = new TableSelector(tableInfoForRead, singleton("LSID"), filter, null).getArrayList(String.class);
+                    Map<String, Object>[] linkedLsidRowIds = new TableSelector(tableInfoForRead, Set.of("LSID", "RowId"), filter, null).getMapArray();
 
+                    Set<String> linkedLsids = Arrays.stream(linkedLsidRowIds).map(m -> (String)m.get("LSID")).collect(java.util.stream.Collectors.toSet());
+                    Set<Long> linkedRowIds = Arrays.stream(linkedLsidRowIds).map(m -> ((Integer)m.get("RowId")).longValue()).collect(java.util.stream.Collectors.toSet());
                     if (linkedLsids.isEmpty())
                         continue;
 
@@ -123,8 +126,7 @@ public class ExperimentListenerImpl implements ExperimentListener
                         throw new UnauthorizedException("Cannot delete rows from dataset " + dataset);
                     }
 
-                    List<Long> linkedIds = samples.stream().filter(s -> linkedLsids.contains(s.getLSID())).map(ExpMaterial::getRowId).toList();
-                    StudyPublishService.get().addRecallAuditEvent(sampleContainer, user, dataset, linkedLsids.size(), linkedIds);
+                    StudyPublishService.get().addRecallAuditEvent(sampleContainer, user, dataset, linkedLsids.size(), linkedRowIds);
                     dataset.deleteDatasetRows(user, linkedLsids);
                 }
             }

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -1520,7 +1520,7 @@ public class StudyPublishManager implements StudyPublishService
     }
 
     @Override
-    public void addRecallAuditEvent(Container sourceContainer, User user, Dataset def, int rowCount, @Nullable Collection<Pair<String,Long>> pairs)
+    public void addRecallAuditEvent(Container sourceContainer, User user, Dataset def, int rowCount, @Nullable Collection<Long> rowIds)
     {
         Dataset.PublishSource sourceType = def.getPublishSource();
         if (sourceType != null)
@@ -1541,15 +1541,14 @@ public class StudyPublishManager implements StudyPublishService
             AuditLogService.get().addEvent(user, event);
 
             // Create sample timeline event for each of the samples
-            if (sourceType == Dataset.PublishSource.SampleType && pairs != null)
+            if (sourceType == Dataset.PublishSource.SampleType && rowIds != null && rowIds.isEmpty())
             {
                 var timelineEventType = SampleTimelineAuditEvent.SampleTimelineEventType.RECALL;
                 Map<String, Object> eventMetadata = new HashMap<>();
                 eventMetadata.put(SAMPLE_TIMELINE_EVENT_TYPE, timelineEventType.name());
                 String metadata = AbstractAuditTypeProvider.encodeForDataMap(eventMetadata);
 
-                List<Long> sampleIds = pairs.stream().map(Pair::getValue).collect(toList());
-                List<? extends ExpMaterial> samples = ExperimentService.get().getExpMaterials(sampleIds);
+                List<? extends ExpMaterial> samples = ExperimentService.get().getExpMaterials(rowIds);
                 List<AuditTypeEvent> events = new ArrayList<>(samples.size());
                 for (ExpMaterial sample : samples)
                 {

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -1541,7 +1541,7 @@ public class StudyPublishManager implements StudyPublishService
             AuditLogService.get().addEvent(user, event);
 
             // Create sample timeline event for each of the samples
-            if (sourceType == Dataset.PublishSource.SampleType && rowIds != null && rowIds.isEmpty())
+            if (sourceType == Dataset.PublishSource.SampleType && rowIds != null && !rowIds.isEmpty())
             {
                 var timelineEventType = SampleTimelineAuditEvent.SampleTimelineEventType.RECALL;
                 Map<String, Object> eventMetadata = new HashMap<>();

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -313,6 +313,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.labkey.api.util.IntegerUtils.asInteger;
 import static org.labkey.study.model.QCStateSet.PUBLIC_STATES_LABEL;
@@ -3106,9 +3107,10 @@ public class StudyController extends BaseStudyController
                 {
                     String sourceLsid = entry.getKey();
                     Collection<Pair<String, Long>> pairs = entry.getValue();
+                    Collection<Long> rowIds = pairs.stream().map(Pair::getValue).collect(Collectors.toList());
                     Container sourceContainer = publishSource.resolveSourceLsidContainer(sourceLsid, _sourceRowId);
                     if (sourceContainer != null)
-                        StudyPublishService.get().addRecallAuditEvent(sourceContainer, getUser(), _def, pairs.size(), pairs);
+                        StudyPublishService.get().addRecallAuditEvent(sourceContainer, getUser(), _def, pairs.size(), rowIds);
                 }
             }
 


### PR DESCRIPTION
#### Rationale
Issue [link](https://github.com/LabKey/internal-issues/issues/1028)
Users shouldn't need permission on the linked study container to delete samples that are not linked.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7572
- https://github.com/LabKey/limsModules/pull/2107

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->