### PR TITLE
Manually parse viewName parameter.

### DIFF
--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -563,7 +563,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
                 else if (value instanceof String str)
                     _viewName = new String[] { str };
                 else
-                    LOG.error("Unexpected viewName parameter type: " + String.valueOf(value));
+                    LOG.error("Unexpected viewName parameter type: " + value);
             }
             return BaseViewAction.springBindParameters(this, "form", params);
         }

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -562,6 +562,8 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
                     _viewName = strs;
                 else if (value instanceof String str)
                     _viewName = new String[] { str };
+                else
+                    LOG.error("Unexpected viewName parameter type: " + String.valueOf(value));
             }
             return BaseViewAction.springBindParameters(this, "form", params);
         }

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -18,12 +18,15 @@ package org.labkey.query.controllers;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.action.Action;
 import org.labkey.api.action.ActionType;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
+import org.labkey.api.action.BaseViewAction;
+import org.labkey.api.action.HasBindParameters;
 import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -63,6 +66,7 @@ import org.labkey.api.view.NotFoundException;
 import org.labkey.query.CustomViewUtil;
 import org.labkey.query.QueryDefinitionImpl;
 import org.labkey.query.persist.QueryDef;
+import org.springframework.beans.PropertyValues;
 import org.springframework.validation.BindException;
 
 import java.util.ArrayList;
@@ -460,7 +464,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         return colProps;
     }
 
-    public static class Form
+    public static class Form implements HasBindParameters
     {
         private String _queryName;
         private String _schemaName;
@@ -494,11 +498,6 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         public String[] getViewName()
         {
             return _viewName;
-        }
-
-        public void setViewName(String[] viewName)
-        {
-            _viewName = viewName;
         }
 
         public String getFk()
@@ -549,6 +548,22 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         public void setIncludeTriggers(boolean includeTriggers)
         {
             _includeTriggers = includeTriggers;
+        }
+
+        @Override
+        public @NotNull BindException bindParameters(PropertyValues params)
+        {
+            // GitHub Issue #936 : manually bind the viewName parameter
+            var viewName = params.getPropertyValue("viewName");
+            if (viewName != null)
+            {
+                var value = viewName.getValue();
+                if (value instanceof String[] strs)
+                    _viewName = strs;
+                else if (value instanceof String str)
+                    _viewName = new String[] { str };
+            }
+            return BaseViewAction.springBindParameters(this, "form", params);
         }
     }
 }


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/936

Avoid automatic conversion to `String[]` when the view name contains commas. 