### PR TITLE
Prevent memory leak after `ListManager.TestCase`

### DIFF
--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -1383,11 +1383,12 @@ public class ListManager implements SearchService.DocumentProvider
         @AfterClass
         public static void cleanup()
         {
-            deleteTestContainer();
-
+            list = null;
             dp = null;
             c = null;
             u = null;
+
+            deleteTestContainer();
         }
 
         private static void deleteTestContainer()


### PR DESCRIPTION
#### Rationale
This test leaks a `ListDefinition` instance. It should null out the static variable that holds it.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7563

#### Changes
- Prevent memory leak after `ListManager.TestCase`
- `null` out static variables before deleting test container so that container deletion errors can't cause other leaks