### PR TITLE
Close InputStream when validating assay transform scripts during save

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -124,6 +124,7 @@ import org.springframework.web.servlet.mvc.Controller;
 import javax.script.ScriptEngine;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.sql.ResultSet;
@@ -1274,9 +1275,9 @@ public abstract class AbstractAssayProvider implements AssayProvider
                     if (!(engine instanceof ExternalScriptEngine && ((ExternalScriptEngine) engine).isBinary(scriptFile)))
                     {
                         String scriptText;
-                        try
+                        try (InputStream is = scriptFile.openInputStream())
                         {
-                            scriptText = IOUtils.toString(scriptFile.openInputStream(), StringUtilsLabKey.DEFAULT_CHARSET);
+                            scriptText = IOUtils.toString(is, StringUtilsLabKey.DEFAULT_CHARSET);
                         }
                         catch (IOException e)
                         {


### PR DESCRIPTION
#### Rationale
We read transform scripts during assay design save. We open but don't close the file. This is impolite, and Windows automated tests have been noticing.

https://teamcity.labkey.org/buildConfiguration/LabKey_263Release_Premium_CommunitySqlserver_DailyCSqlserver/3929893?buildTab=tests&status=failed&expandedTest=build%3A%28id%3A3929893%29%2Cid%3A2000000048

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2946

#### Changes
- try-with-resources is the polite way to handle InputStreams

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->