### PR TITLE
Issue 1051: Fix up audit comments for cross-type imports and updates that update storage data

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,6 @@
 <!-- list of standard tasks (remove this comment to enable)
 #### Tasks 📍
 - [ ] Manual Testing
-- [ ] Needs Automation
+- [ ] Test Automation
 - [ ] Verify Fix
 -->

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -3167,8 +3167,6 @@ public class ExpDataIterators
             validFields.add("EnteredStorage");
             validFields.add("StorageComment"); // GH Issue 1051
             validFields.add("Storage Comment");
-            validFields.add("StorageLocation");
-            validFields.add("Storage Location");
             List<Integer> fieldIndexes = new IntArrayList();
             Map<Integer, String> dependencyIndexes = new IntHashMap<>();
             List<String> header = new ArrayList<>();

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -3165,6 +3165,10 @@ public class ExpDataIterators
             validFields.add("Storage Unit Label");
             // For consistency with other storage fields that are imported without spaces in the names
             validFields.add("EnteredStorage");
+            validFields.add("StorageComment"); // GH Issue 1051
+            validFields.add("Storage Comment");
+            validFields.add("StorageLocation");
+            validFields.add("Storage Location");
             List<Integer> fieldIndexes = new IntArrayList();
             Map<Integer, String> dependencyIndexes = new IntHashMap<>();
             List<String> header = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
Issue [1051](https://github.com/LabKey/internal-issues/issues/1051): Because we support the use of a special column (`StorageComment`) for adding audit comments about storage actions on a per-line basis during file import, we update the audit comment in the data iterator context to override any comment provided at the file level. This works just fine when doing a single-type or single-container import but when doing a cross-type or cross-container import, the file-level comment is lost after the first file of samples is processed.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2110

#### Changes
- Write the `StorageComment` field to the split files for a cross-type or cross-container import
