### PR TITLE
Issue 1051: Preserve audit comments for cross-type imports involving storage updates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,6 @@
 <!-- list of standard tasks (remove this comment to enable)
 #### Tasks 📍
 - [ ] Manual Testing
-- [ ] Needs Automation
+- [ ] Test Automation
 - [ ] Verify Fix
 -->

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -3167,6 +3167,8 @@ public class ExpDataIterators
             validFields.add("Storage Unit Label");
             // For consistency with other storage fields that are imported without spaces in the names
             validFields.add("EnteredStorage");
+            validFields.add("StorageComment"); // GH Issue 1051
+            validFields.add("Storage Comment");
             List<Integer> fieldIndexes = new IntArrayList();
             Map<Integer, String> dependencyIndexes = new IntHashMap<>();
             List<String> header = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
Issue [1051](https://github.com/LabKey/internal-issues/issues/1051): Because we support the use of a special column (`StorageComment`) for adding audit comments about storage actions on a per-line basis during file import, we update the audit comment in the data iterator context to override any comment provided at the file level. This works just fine when doing a single-type or single-container import but when doing a cross-type or cross-container import, the file-level comment is lost after the first file of samples is processed.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2112

#### Changes
- Write the `StorageComment` field to the split files for a cross-type or cross-container import
- update language in pull request template