### PR TITLE
GitHub Issue 1039: Remove DefaultModule.setVcsTag()

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -817,12 +817,6 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         _vcsBranch = vcsBranch;
     }
 
-    @SuppressWarnings({"UnusedDeclaration"})
-    public void setVcsTag(String vcsTag)
-    {
-        // Ignored - present in module.xml but not used
-    }
-
     public final String getBuildUser()
     {
         return _buildUser;


### PR DESCRIPTION
#### Rationale
This code is dead and can be removed in the upcoming monthly release.

#### Changes
- Remove unused method