### PR TITLE
GitHub Issue #1061: Error loading assay import page when Participant/Visit resolver field is set to 'fixed value' default

### DIFF
--- a/api/src/org/labkey/api/study/actions/ParticipantVisitResolverChooser.java
+++ b/api/src/org/labkey/api/study/actions/ParticipantVisitResolverChooser.java
@@ -168,7 +168,7 @@ public class ParticipantVisitResolverChooser extends SimpleDisplayColumn
                                             return ret2;
                                         }
                                     ),
-                                    disabledInput ? InputBuilder.hidden().name(_typeInputName).value(finalSelected.getName()).appendTo(out) : null
+                                    disabledInput ? InputBuilder.hidden().name(_typeInputName).value(finalSelected.getName()).getHtmlString() : null
                                 )
                             ).appendTo(out);
                         }


### PR DESCRIPTION
#### Rationale
[#1061](https://github.com/LabKey/internal-issues/issues/1061) Error loading import page when NAb assay participant/resolver field is set to 'fixed value' default

This PR fixes a page load error on the assay import page when a Participant/Visit resolver field is set to a 'fixed value' default (i.e., when disabledInput is true). The fix changes how the hidden <input> element is    
  generated in the disabled state: instead of calling .appendTo(out) which writes HTML immediately and returns the HtmlWriter as a value, it calls .getHtmlString() which returns a proper HtmlString DOM node.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7592
- https://github.com/LabKey/testAutomation/pull/2953

#### Changes
- ParticipantVisitResolverChooser disabled state fix to use getHtmlString() isntead of appendTo()