### PR TITLE
fix usage of out.print()

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp
+++ b/experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp
@@ -69,7 +69,7 @@
     }
     catch (ExecuteException e)
     {
-        out.print("<p>Error rendering graph</p>");
+        %><p class="labkey-error">Error rendering graph</p><%
     }
 
     if (isSummaryView)


### PR DESCRIPTION
#### Rationale
don't use out.print().  I think we're hitting this because of some other error that may also fail the test, but this code needs to be updated.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->
