### PR TITLE
Use correct method to write error message in JSP

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentRunGraph.java
+++ b/experiment/src/org/labkey/experiment/ExperimentRunGraph.java
@@ -49,6 +49,10 @@ public class ExperimentRunGraph
     private static String getSvg(String dot) throws ExecuteException
     {
         Graphviz graph = DotParser.parse(dot);
+
+        if (graph.isEmpty())
+            return ""; // Graphviz.toSvgStr() throws an exception if the graph is empty.
+
         String svg = graph.toSvgStr();
 
         // Scale down to 50% of default size. This is arbitrary but seems reasonable. Diagrams are larger than

--- a/experiment/src/org/labkey/experiment/ExperimentRunGraph.java
+++ b/experiment/src/org/labkey/experiment/ExperimentRunGraph.java
@@ -53,11 +53,19 @@ public class ExperimentRunGraph
         if (graph.isEmpty())
             return ""; // Graphviz.toSvgStr() throws an exception if the graph is empty.
 
-        String svg = graph.toSvgStr();
+        try
+        {
+            String svg = graph.toSvgStr();
 
-        // Scale down to 50% of default size. This is arbitrary but seems reasonable. Diagrams are larger than
-        // the old image-based ones, but monitors are much higher resolution than when those were scaled.
-        return SvgUtil.scaleSize(svg, 0.5f);
+            // Scale down to 50% of default size. This is arbitrary but seems reasonable. Diagrams are larger than
+            // the old image-based ones, but monitors are much higher resolution than when those were scaled.
+            return SvgUtil.scaleSize(svg, 0.5f);
+        }
+        catch (ExecuteException ex)
+        {
+            LOG.warn("Error generating graph", ex);
+            throw ex;
+        }
     }
 
     private static String getDotGraph(Container c, ExpRunImpl run, boolean detail, String focus, String focusType)

--- a/experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp
+++ b/experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp
@@ -69,7 +69,7 @@
     }
     catch (ExecuteException e)
     {
-        out.print("<p>Error rendering graph</p>");
+        out.write("<p class=\"labkey-error\">Error rendering graph</p>");
     }
 
     if (isSummaryView)


### PR DESCRIPTION
#### Rationale
`LabKeyJspWriter` complains if you call `out.print`.
```
java.lang.IllegalStateException: A JSP is attempting to render a string! '<p>Error rendering graph</p>' For help rectifying this problem, review this page https://www.labkey.org/Documentation/26.3/wiki-page.view?name=premServerEncoding&referrer=inPage or contact your LabKey Account Manager.
	at org.labkey.api.jsp.LabKeyJspWriter.throwException(LabKeyJspWriter.java:77)
	at org.labkey.api.jsp.LabKeyJspWriter.print(LabKeyJspWriter.java:54)
	at org.labkey.jsp.compiled.org.labkey.experiment.controllers.exp.experimentRunGraphView_jsp._jspService(experimentRunGraphView_jsp.java:219)
```
`out.write` does what we want.

Additionally. While the above error was useful for flagging this JSP issue, an empty graph shouldn't be throwing an exception.

#### Related Pull Requests
- #7557 

#### Changes
- Use correct method to write error message in JSP
- Don't throw an exception if the graph is empty
- Log errors thrown when converting graph to SVG