### PR TITLE
Escape backslashes in DotGraph values

### DIFF
--- a/experiment/src/org/labkey/experiment/DotGraph.java
+++ b/experiment/src/org/labkey/experiment/DotGraph.java
@@ -490,7 +490,7 @@ public class DotGraph
         {
             return null;
         }
-        return s.replace("\"", "\\\"").replace("\n", " ").replace("\r", " ");
+        return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", " ").replace("\r", " ");
     }
 
     private class MNode extends DotNode

--- a/experiment/src/org/labkey/experiment/ExperimentRunGraph.java
+++ b/experiment/src/org/labkey/experiment/ExperimentRunGraph.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.Logger;
 import org.graphper.api.Graphviz;
 import org.graphper.draw.ExecuteException;
 import org.graphper.parser.DotParser;
+import org.graphper.parser.ParseException;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpData;
@@ -48,22 +49,22 @@ public class ExperimentRunGraph
 
     private static String getSvg(String dot) throws ExecuteException
     {
-        Graphviz graph = DotParser.parse(dot);
-
-        if (graph.isEmpty())
-            return ""; // Graphviz.toSvgStr() throws an exception if the graph is empty.
-
         try
         {
+            Graphviz graph = DotParser.parse(dot);
+
+            if (graph.isEmpty())
+                return ""; // Graphviz.toSvgStr() throws an exception if the graph is empty.
+
             String svg = graph.toSvgStr();
 
             // Scale down to 50% of default size. This is arbitrary but seems reasonable. Diagrams are larger than
             // the old image-based ones, but monitors are much higher resolution than when those were scaled.
             return SvgUtil.scaleSize(svg, 0.5f);
         }
-        catch (ExecuteException ex)
+        catch (ExecuteException | ParseException ex)
         {
-            LOG.warn("Error generating graph", ex);
+            LOG.error("Error generating graph", ex);
             throw ex;
         }
     }

--- a/experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp
+++ b/experiment/src/org/labkey/experiment/controllers/exp/experimentRunGraphView.jsp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.graphper.draw.ExecuteException" %>
 <%@ page import="org.labkey.api.util.UniqueID" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
@@ -67,7 +66,7 @@
             model.getFocusType()
         );
     }
-    catch (ExecuteException e)
+    catch (Exception e)
     {
         out.write("<p class=\"labkey-error\">Error rendering graph</p>");
     }


### PR DESCRIPTION
#### Rationale
We aren't escaping backslashes in our generated `DotGraph`. This can end up generating invalid DOT syntax.

The actual label in the following DOT snippet is intended to be `,\"^:}}"#)B-d@x.Db&-`. We correctly escape the quote but not the backslash:
```
M27231[label=",\\"^:}}\"#)B-d@x.Db&-", tooltip="Material: ,\\"^:}}\"#)B-d@x.Db&-", etc.]
```
The parser then decodes the double-backslash and leaves the following quote unescaped:
```
org.graphper.parser.ParseException: line 4:18 token recognition error at: '^'
	at org.graphper.parser.DotSyntaxErrorListener.syntaxError(DotSyntaxErrorListener.java:40)
	[...]
	at org.labkey.experiment.ExperimentRunGraph.getSvg(ExperimentRunGraph.java:53)
	at org.labkey.experiment.ExperimentRunGraph.renderSvg(ExperimentRunGraph.java:46)
```

This is a pre-existing defect (reproduced in 25.7) but didn't cause any test failures because we didn't log errors returned by `dot` execution.

#### Related Pull Requests
- #7557 

#### Changes
- Escape backslashes in DotGraph values