### PR TITLE
Issue 1035: Add terminal storage location name column to sample grids

### DIFF
--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -52,6 +52,7 @@ public interface InventoryService
         StorageColSort,
         StorageComment,
         StorageLocation,
+        StorageTerminalLocation,
         StorageRow,
         StorageRowSort,
         StoragePositionNumber,

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -875,7 +875,10 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         addColumn(RawAliquotUnit).getRenderer().addQueryFieldKeys(new HashSet<>(Set.of(AliquotUnit.fieldKey())));
 
         if (InventoryService.get() != null && (st == null || !st.isMedia()))
-            defaultCols.addAll(InventoryService.get().addInventoryStatusColumns(st == null ? null : st.getMetricUnit(), this, getContainer(), _userSchema.getUser()));
+        {
+            List<FieldKey> inventoryCols = InventoryService.get().addInventoryStatusColumns(st == null ? null : st.getMetricUnit(), this, getContainer(), _userSchema.getUser());
+            defaultCols.addAll(inventoryCols.stream().filter(fk -> !fk.equals(InventoryService.InventoryStatusColumn.StorageTerminalLocation.fieldKey())).toList());
+        }
 
         SQLFragment sql;
         UserSchema plateUserSchema;

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -877,6 +877,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         if (InventoryService.get() != null && (st == null || !st.isMedia()))
         {
             List<FieldKey> inventoryCols = InventoryService.get().addInventoryStatusColumns(st == null ? null : st.getMetricUnit(), this, getContainer(), _userSchema.getUser());
+            // GH Issue 1035: Don't include StorageTerminalLocation in the default view
             defaultCols.addAll(inventoryCols.stream().filter(fk -> !fk.equals(InventoryService.InventoryStatusColumn.StorageTerminalLocation.fieldKey())).toList());
         }
 


### PR DESCRIPTION
#### Rationale
Issue [1035](https://github.com/LabKey/internal-issues/issues/1035): Some users don't want to see the full storage location path, just the name of the terminal storage location.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2131

#### Changes
- Add new `InventoryStatusColumn` and make it not shown in the default view for samples grids

