### PR TITLE
GitHub Issue 1082: Server exception "Badly formatted list of strings" on assay run import with invalid MVTC field value

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -866,8 +866,17 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                     Object o = map.get(pd.getName());
                     if (PropertyType.MULTI_CHOICE == pd.getPropertyType())
                     {
-                        o = MultiChoice.Converter.getInstance().convert(MultiChoice.Array.class, o);
-                        map.put(pd.getName(), o);
+                        try
+                        {
+                            // GitHub Issue 1082: Server exception "Badly formatted list of strings" on assay run import with invalid MVTC field value
+                            o = MultiChoice.Converter.getInstance().convert(MultiChoice.Array.class, o);
+                            map.put(pd.getName(), o);
+                        }
+                        catch (ConversionException e)
+                        {
+                            errors.add(new PropertyValidationError(e.getMessage(), pd.getName()));
+                        }
+
                     }
                     else if (o instanceof String)
                     {

--- a/experiment/src/client/test/integration/AssayImportRunAction.ispec.ts
+++ b/experiment/src/client/test/integration/AssayImportRunAction.ispec.ts
@@ -718,7 +718,7 @@ describe('assay-importRun.api', () => {
         });
 
         // GitHub Issue 1082: Server exception "Badly formatted list of strings" on assay run import with invalid MVTC field value
-        it('blocks deleting in-use multi-choice value used as part of an array value', async () => {
+        it('illegal tsv string', async () => {
             if (!supportMultiChoice) {
                 return;
             }

--- a/experiment/src/client/test/integration/AssayImportRunAction.ispec.ts
+++ b/experiment/src/client/test/integration/AssayImportRunAction.ispec.ts
@@ -717,6 +717,23 @@ describe('assay-importRun.api', () => {
             expect(response.text).toContain('One or more values cannot be removed from the multi-choice list');
         });
 
+        // GitHub Issue 1082: Server exception "Badly formatted list of strings" on assay run import with invalid MVTC field value
+        it('blocks deleting in-use multi-choice value used as part of an array value', async () => {
+            if (!supportMultiChoice) {
+                return;
+            }
+
+            const { topFolderOptions } = context;
+
+            // Import a run with ['Abnormal', 'cDNA'] as multi-choice values
+            const importPayload: ImportRunOptions = {
+                assayId: ASSAY_A_ID,
+                dataRows: [{ [RESULT_MVTC_FIELD_NAME]: ['""x,y""'] }],
+            };
+            const importResponse = await importRunToServer(server, importPayload, topFolderOptions);
+            expect(importResponse.body.exception).toContain('for field \'' + RESULT_MVTC_FIELD_NAME + '\' is invalid.');
+        });
+
         // GitHub Issue 925: Not providing a MVTC value in an assay result throws error
         it('errors when required MVTC column not provided in assay import', async () => {
             if (!supportMultiChoice) {


### PR DESCRIPTION
#### Rationale
Handle ConversionException for AssayTsvDataHandler.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->
