### PR TITLE
Improve nullability treatment for PageFlowUtil.urlProvider()

### DIFF
--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -266,7 +266,7 @@ public abstract class SpringActionController implements Controller, HasViewConte
     // Convenience method
     protected static <P extends UrlProvider> P urlProvider(Class<P> inter)
     {
-        return Objects.requireNonNull(PageFlowUtil.urlProvider(inter));
+        return PageFlowUtil.urlProvider(inter);
     }
 
     protected void requiresLogin()

--- a/api/src/org/labkey/api/action/UrlProviderService.java
+++ b/api/src/org/labkey/api/action/UrlProviderService.java
@@ -18,7 +18,9 @@ package org.labkey.api.action;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.module.Module;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.UnexpectedException;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -27,7 +29,7 @@ import java.util.Map;
 public class UrlProviderService
 {
     private static final UrlProviderService instance = new UrlProviderService();
-    private static final Map<Class, Class<? extends UrlProvider>> _urlProviderToImpl = new HashMap<>();
+    private static final Map<Class<?>, Class<? extends UrlProvider>> _urlProviderToImpl = new HashMap<>();
     private static final Map<Class<? extends UrlProvider>, List<Pair<Module, UrlProvider>>> _urlProviderToOverrideImpls = new HashMap<>();
 
     public static UrlProviderService getInstance()
@@ -35,15 +37,9 @@ public class UrlProviderService
         return instance;
     }
 
-    public <P extends UrlProvider> void registerUrlProvider(Class<P> inter, Class innerClass)
+    public <P extends UrlProvider> void registerUrlProvider(Class<P> inter, Class<? extends UrlProvider> innerClass)
     {
         _urlProviderToImpl.put(inter, innerClass);
-    }
-
-    /** @return true if the UrlProvider exists. */
-    public <P extends UrlProvider> boolean hasUrlProvider(Class<P> inter)
-    {
-        return _urlProviderToImpl.get(inter) != null;
     }
 
     @Nullable
@@ -56,16 +52,11 @@ public class UrlProviderService
 
         try
         {
-            P impl = (P) clazz.newInstance();
-            return impl;
+            return (P) clazz.getDeclaredConstructor().newInstance();
         }
-        catch (InstantiationException e)
+        catch (InstantiationException | InvocationTargetException | IllegalAccessException | NoSuchMethodException e)
         {
-            throw new RuntimeException("Failed to instantiate provider class " + clazz.getName() + " for " + inter.getName(), e);
-        }
-        catch (IllegalAccessException e)
-        {
-            throw new RuntimeException("Illegal access of provider class " + clazz.getName() + " for " + inter.getName(), e);
+            throw UnexpectedException.wrap(e, "Failed to instantiate provider class " + clazz.getName() + " for " + inter.getName());
         }
     }
 

--- a/api/src/org/labkey/api/assay/AssayRunType.java
+++ b/api/src/org/labkey/api/assay/AssayRunType.java
@@ -73,7 +73,7 @@ public class AssayRunType extends ExperimentRunType
             Domain domain = provider.getResultsDomain(_protocol);
             if (domain != null && domain.getTypeId() > 0)
             {
-                StudyUrls urls = PageFlowUtil.urlProvider(StudyUrls.class);
+                StudyUrls urls = PageFlowUtil.urlProviderOptional(StudyUrls.class);
 
                 if (null != urls)
                 {

--- a/api/src/org/labkey/api/assay/query/ResultsQueryView.java
+++ b/api/src/org/labkey/api/assay/query/ResultsQueryView.java
@@ -145,7 +145,7 @@ public class ResultsQueryView extends AssayBaseQueryView
         if (null == StudyPublishService.get() || StudyPublishService.get().getValidPublishTargets(getUser(), InsertPermission.class).isEmpty())
             return null;
 
-        StudyUrls urls = PageFlowUtil.urlProvider(StudyUrls.class);
+        StudyUrls urls = PageFlowUtil.urlProviderOptional(StudyUrls.class);
         if (urls == null)
             return null;
 

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -1450,7 +1450,7 @@ public class DataRegion extends DisplayElement
             ignoreViewFilter = getSettings().getIgnoreViewFilter();
         dataRegionJSON.put("ignoreViewFilter", ignoreViewFilter);
 
-        VisualizationUrls visUrlProvider = PageFlowUtil.urlProvider(VisualizationUrls.class);
+        VisualizationUrls visUrlProvider = PageFlowUtil.urlProviderOptional(VisualizationUrls.class);
         if (visUrlProvider != null)
             dataRegionJSON.put("chartWizardURL", visUrlProvider.getGenericChartDesignerURL(ctx.getContainer(), user, getSettings(), null));
 

--- a/api/src/org/labkey/api/exp/LsidManager.java
+++ b/api/src/org/labkey/api/exp/LsidManager.java
@@ -216,7 +216,7 @@ public class LsidManager
         @Override
         public @Nullable ActionURL detailsURL()
         {
-            var urls = PageFlowUtil.urlProvider(AssayUrls.class);
+            var urls = PageFlowUtil.urlProviderOptional(AssayUrls.class);
             if (urls == null)
                 return null;
 

--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -422,12 +422,6 @@ public abstract class JspBase extends JspContext implements HasViewContext
         return new ActionURL(actionClass, getContainer());
     }
 
-    /** @return true if the UrlProvider exists. */
-    public <P extends UrlProvider> boolean hasUrlProvider(Class<P> inter)
-    {
-        return PageFlowUtil.hasUrlProvider(inter);
-    }
-
     /**
      * Convenience function for getting a specified <code>UrlProvider</code> interface
      * implementation, for use in writing URLs implemented in other modules.
@@ -435,7 +429,7 @@ public abstract class JspBase extends JspContext implements HasViewContext
      * @param inter interface extending UrlProvider
      * @return an implementation of the interface
      */
-    @Nullable
+    @NotNull
     public <P extends UrlProvider> P urlProvider(Class<P> inter)
     {
         return PageFlowUtil.urlProvider(inter);

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -2217,7 +2217,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
                         {
                             Class<?>[] supr = inter.getInterfaces();
                             if (supr.length == 1 && UrlProvider.class.equals(supr[0]))
-                                UrlProviderService.getInstance().registerUrlProvider((Class<UrlProvider>) inter, innerClass);
+                                UrlProviderService.getInstance().registerUrlProvider((Class<UrlProvider>) inter, (Class<? extends UrlProvider>) innerClass);
                         }
                     }
                 }
@@ -2323,7 +2323,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
             return;
 
         ResourceFinder finder = new ResourceFinder(name, sourcePath, buildPath);
-        Collection<ResourceFinder> col = _resourceFinders.computeIfAbsent(prefix, k -> new ArrayList<>());
+        Collection<ResourceFinder> col = _resourceFinders.computeIfAbsent(prefix, _ -> new ArrayList<>());
 
         synchronized (col)
         {
@@ -2334,8 +2334,8 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
     public @NotNull Collection<ResourceFinder> getResourceFindersForPath(String path)
     {
         //NOTE: jasper encodes underscores and dashes in JSPs, so decode them here
-        path = path.replaceAll("_005f", "_");
-        path = path.replaceAll("_002d", "-");
+        path = path.replace("_005f", "_");
+        path = path.replace("_002d", "-");
 
         Collection<ResourceFinder> finders = new LinkedList<>();
 

--- a/api/src/org/labkey/api/security/Encryption.java
+++ b/api/src/org/labkey/api/security/Encryption.java
@@ -127,7 +127,7 @@ public class Encryption
                         if (context != null && context.getUser().hasSiteAdminPermission())
                         {
                             who = "you";
-                            link = LinkBuilder.simpleLink("this link", Objects.requireNonNull(PageFlowUtil.urlProvider(AdminUrls.class)).getDeleteEncryptedContentURL());
+                            link = LinkBuilder.simpleLink("this link", PageFlowUtil.urlProvider(AdminUrls.class).getDeleteEncryptedContentURL());
                         }
                         else
                         {

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -3198,10 +3198,23 @@ public class PageFlowUtil
         }
     }
 
-    /** @return true if the UrlProvider exists. */
-    static public <P extends UrlProvider> boolean hasUrlProvider(Class<P> inter)
+    /**
+     * Returns a specified <code>UrlProvider</code> interface implementation, for use
+     * in writing URLs implemented in other modules.
+     *
+     * @param inter interface extending UrlProvider
+     * @return an implementation of the interface
+     * @throws IllegalArgumentException if the provider is not available. Use urlProviderOptional() if you're OK with it not being present
+     */
+    @NotNull
+    static public <P extends UrlProvider> P urlProvider(Class<P> inter)
     {
-        return UrlProviderService.getInstance().hasUrlProvider(inter);
+        P result = urlProviderOptional(inter);
+        if (result == null)
+        {
+            throw new IllegalArgumentException("No provider registered for " + inter.getName());
+        }
+        return result;
     }
 
     /**
@@ -3212,7 +3225,7 @@ public class PageFlowUtil
      * @return an implementation of the interface.
      */
     @Nullable
-    static public <P extends UrlProvider> P urlProvider(Class<P> inter)
+    static public <P extends UrlProvider> P urlProviderOptional(Class<P> inter)
     {
         return UrlProviderService.getInstance().getUrlProvider(inter);
     }
@@ -3228,7 +3241,7 @@ public class PageFlowUtil
      * @param checkForOverrides true to check for module overrides to this interface
      * @return an implementation of the interface.
      */
-    @Nullable
+    @NotNull
     static public <P extends UrlProvider> P urlProvider(Class<P> inter, boolean checkForOverrides)
     {
         if (checkForOverrides)

--- a/api/src/org/labkey/api/view/PopupMenu.java
+++ b/api/src/org/labkey/api/view/PopupMenu.java
@@ -199,7 +199,7 @@ public class PopupMenu extends DisplayElement
 
                 UL(
                     cl("dropdown-menu dropdown-menu-left"),
-                    (DOM.Renderable) ret2 -> PopupMenuView.renderTree(_navTree, out)
+                    (DOM.Renderable) _ -> PopupMenuView.renderTree(_navTree, out)
                 ).appendTo(out);
 
                 return ret;
@@ -245,7 +245,7 @@ public class PopupMenu extends DisplayElement
         LEFT("tl-bl?"),
         RIGHT("tr-br?");
 
-        String extPosition;
+        final String extPosition;
         Align(String position)
         {
             extPosition = position;

--- a/api/src/org/labkey/api/view/Portal.java
+++ b/api/src/org/labkey/api/view/Portal.java
@@ -199,7 +199,7 @@ public class Portal implements ModuleChangeListener
 
     @NotNull static ProjectUrls urlProvider()
     {
-        return Objects.requireNonNull(PageFlowUtil.urlProvider(ProjectUrls.class));
+        return PageFlowUtil.urlProvider(ProjectUrls.class);
     }
 
     /** Issue 51727 - metrics to track web part usage */

--- a/core/src/org/labkey/core/admin/DisplayFormatAnalyzer.java
+++ b/core/src/org/labkey/core/admin/DisplayFormatAnalyzer.java
@@ -215,10 +215,6 @@ public class DisplayFormatAnalyzer
 
     private <P extends UrlProvider> @NotNull P urlProvider(Class<P> inter)
     {
-        P provider = PageFlowUtil.urlProvider(inter);
-        if (provider == null)
-            throw new IllegalStateException("No urlProvider found for " + inter.getName());
-
-        return provider;
+        return PageFlowUtil.urlProvider(inter);
     }
 }

--- a/core/src/org/labkey/core/admin/editMenuBar.jsp
+++ b/core/src/org/labkey/core/admin/editMenuBar.jsp
@@ -23,7 +23,7 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    HttpView me = HttpView.currentView();
+    HttpView<?> me = HttpView.currentView();
     ActionURL refreshURL = urlProvider(AdminUrls.class).getProjectSettingsMenuURL(getContainer());
     boolean isAdminMode = PageFlowUtil.isPageAdminMode(getViewContext());
     String toggleUrl = urlProvider(ProjectUrls.class).getTogglePageAdminModeURL(getContainer(), getViewContext().getActionURL()).toString();

--- a/core/src/org/labkey/core/view/template/bootstrap/WarningServiceImpl.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/WarningServiceImpl.java
@@ -176,13 +176,10 @@ public class WarningServiceImpl implements WarningService
         appendMessageContent(warnings, html);
         html.unsafeAppend("</div>\n");
         CoreUrls coreUrls = urlProvider(CoreUrls.class);
-        if (coreUrls != null)
-        {
-            String dismissURL = coreUrls.getDismissWarningsActionURL(context).toString();
-            html.unsafeAppend("<script type=\"text/javascript\" nonce=\"" + HttpView.currentPageConfig().getScriptNonce() + "\">\n");
-            html.unsafeAppend(String.format(DISMISSAL_SCRIPT_FORMAT, PageFlowUtil.jsString(dismissURL)));
-            html.unsafeAppend("</script>\n");
-        }
+        String dismissURL = coreUrls.getDismissWarningsActionURL(context).toString();
+        html.unsafeAppend("<script type=\"text/javascript\" nonce=\"" + HttpView.currentPageConfig().getScriptNonce() + "\">\n");
+        html.unsafeAppend(String.format(DISMISSAL_SCRIPT_FORMAT, PageFlowUtil.jsString(dismissURL)));
+        html.unsafeAppend("</script>\n");
         html.unsafeAppend("</div>");
 
         return html.getHtmlString();

--- a/core/src/org/labkey/core/view/template/bootstrap/header.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/header.jsp
@@ -83,7 +83,7 @@
     LookAndFeelProperties laf = LookAndFeelProperties.getInstance(c);
     ModuleLoader moduleLoader = ModuleLoader.getInstance();
     boolean isStartupComplete = moduleLoader.isStartupComplete();
-    boolean showSearch = isStartupComplete && hasUrlProvider(SearchUrls.class);
+    boolean showSearch = isStartupComplete && PageFlowUtil.urlProviderOptional(SearchUrls.class) != null;
 
     HtmlView headerHtml = new HeaderProperties(getContainer()).getView();
     String siteShortName = (laf.getShortName() != null && !laf.getShortName().isEmpty()) ? laf.getShortName() : null;
@@ -182,9 +182,7 @@
 <%
     CoreUrls coreUrls = urlProvider(CoreUrls.class);
 
-    if (coreUrls != null)
-    {
-        String displayUrl = coreUrls.getDisplayWarningsActionURL(getViewContext()).toString();
+    String displayUrl = coreUrls.getDisplayWarningsActionURL(getViewContext()).toString();
 %>
             <script type="text/javascript" nonce="<%=getScriptNonce()%>">
                 +function($){
@@ -203,8 +201,6 @@
                 }(jQuery)
             </script>
 <%
-    }
-
     if (showProductMenu)
     {
 %>

--- a/experiment/src/org/labkey/experiment/ProtocolSteps.jsp
+++ b/experiment/src/org/labkey/experiment/ProtocolSteps.jsp
@@ -45,7 +45,6 @@
     ppURL.addParameter("ParentLSID", protocol.getLSID());
 
     ExperimentUrls urls = urlProvider(ExperimentUrls.class);
-    assert urls != null;
 
     List<ExpProtocolActionImpl> steps = protocol.getSteps();
     boolean debug = getViewContext().getRequest().getParameter("_debug") != null;

--- a/experiment/src/org/labkey/experiment/RunGroupWebPart.java
+++ b/experiment/src/org/labkey/experiment/RunGroupWebPart.java
@@ -122,7 +122,7 @@ public class RunGroupWebPart extends QueryView
         super.populateButtonBar(view, bb);
         if (!_narrow)
         {
-            AssayUrls urls = PageFlowUtil.urlProvider(AssayUrls.class);
+            AssayUrls urls = PageFlowUtil.urlProviderOptional(AssayUrls.class);
             if (null != urls)
             {
                 ActionButton addXarFile = new ActionButton(urls.getImportAssayDesignURL(getViewContext().getContainer()), "Upload XAR");

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
@@ -396,13 +396,8 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
             return null;
 
         ExperimentUrls urlProvider = PageFlowUtil.urlProvider(ExperimentUrls.class);
-        ActionURL url = null;
-
-        if (urlProvider != null)
-        {
-            url = urlProvider.getShowDataClassURL(container, getRowId());
-            url.setExtraPath(container.getId());
-        }
+        ActionURL url = urlProvider.getShowDataClassURL(container, getRowId());
+        url.setExtraPath(container.getId());
 
         Map<String, Object> props = new HashMap<>();
         Set<String> identifiersHi = new HashSet<>();

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -1000,13 +1000,8 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
             return null;
 
         ExperimentUrls urlProvider = PageFlowUtil.urlProvider(ExperimentUrls.class);
-        ActionURL url = null;
-
-        if (urlProvider != null)
-        {
-            url = urlProvider.getShowSampleTypeURL(this);
-            url.setExtraPath(container.getId());
-        }
+        ActionURL url = urlProvider.getShowSampleTypeURL(this);
+        url.setExtraPath(container.getId());
 
         Map<String, Object> props = new HashMap<>();
         Set<String> identifiersHi = new HashSet<>();

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -1479,12 +1479,9 @@ public class StorageProvisionerImpl implements StorageProvisioner
             if (!domainReport.getErrors().isEmpty())
             {
                 ExperimentUrls urls = PageFlowUtil.urlProvider(ExperimentUrls.class);
-                if (null != urls)
-                {
-                    ActionURL fix = urls.getRepairTypeURL(domain.getContainer());
-                    fix.addParameter("domainUri", domain.getTypeURI());
-                    domainReport.addError("See this page for more info: " + fix.getURIString());
-                }
+                ActionURL fix = urls.getRepairTypeURL(domain.getContainer());
+                fix.addParameter("domainUri", domain.getTypeURI());
+                domainReport.addError("See this page for more info: " + fix.getURIString());
             }
         }
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
@@ -92,7 +92,7 @@ public class SampleTypeContentsView extends QueryView
         if (null == StudyPublishService.get() || StudyPublishService.get().getValidPublishTargets(getUser(), InsertPermission.class).isEmpty())
             return null;
 
-        StudyUrls urls = PageFlowUtil.urlProvider(StudyUrls.class);
+        StudyUrls urls = PageFlowUtil.urlProviderOptional(StudyUrls.class);
         if (urls == null)
             return null;
 

--- a/pipeline/src/org/labkey/pipeline/status/deleteStatus.jsp
+++ b/pipeline/src/org/labkey/pipeline/status/deleteStatus.jsp
@@ -53,7 +53,7 @@
 
         Container c = file.lookupContainer();
         PipelineStatusUrls provider = urlProvider(PipelineStatusUrls.class);
-        ActionURL detailsURL = null != provider ? provider.urlDetails(c, file.getRowId()) : null;
+        ActionURL detailsURL = provider.urlDetails(c, file.getRowId());
         sb.append("<span>job: <a href='").append(h(detailsURL)).append("'>").append(h(file.getDescription())).append("</a></span>");
 
         // Directory that will be deleted if they aren't any usages

--- a/pipeline/src/org/labkey/pipeline/validators/PipelineSetupValidatorFactory.java
+++ b/pipeline/src/org/labkey/pipeline/validators/PipelineSetupValidatorFactory.java
@@ -71,15 +71,8 @@ public class PipelineSetupValidatorFactory implements SiteValidationProviderFact
                         SiteValidationResultList results = new SiteValidationResultList();
                         for (String error : errors)
                         {
-                            if (null != pipelineUrls)
-                            {
-                                SiteValidationResult result = results.addError(error, pipelineUrls.urlSetup(c));
-                                result.append(" Click link to go to pipeline setup for this folder.");
-                            }
-                            else
-                            {
-                                results.addError(error);
-                            }
+                            SiteValidationResult result = results.addError(error, pipelineUrls.urlSetup(c));
+                            result.append(" Click link to go to pipeline setup for this folder.");
                         }
                         return results;
                     }

--- a/query/src/org/labkey/query/DataViewsWebPartFactory.java
+++ b/query/src/org/labkey/query/DataViewsWebPartFactory.java
@@ -124,7 +124,7 @@ public class DataViewsWebPartFactory extends BaseWebPartFactory
             if (isAdmin)
             {
                 StudyService svc = StudyService.get();
-                StudyUrls urls = PageFlowUtil.urlProvider(StudyUrls.class);
+                StudyUrls urls = PageFlowUtil.urlProviderOptional(StudyUrls.class);
                 if (svc != null && svc.getStudy(c) != null && urls != null)
                     menu.addChild("Manage Datasets", urls.getManageDatasetsURL(c));
                 menu.addChild("Manage Queries", PageFlowUtil.urlProvider(QueryUrls.class).urlSchemaBrowser(c));

--- a/query/src/org/labkey/query/reports/ReportViewProvider.java
+++ b/query/src/org/labkey/query/reports/ReportViewProvider.java
@@ -221,7 +221,7 @@ public class ReportViewProvider implements DataViewProvider
                 ActionURL reportPermUrl = null;
                 if (c.hasPermission(user, AdminPermission.class))
                 {
-                    StudyUrls urls = PageFlowUtil.urlProvider(StudyUrls.class);
+                    StudyUrls urls = PageFlowUtil.urlProviderOptional(StudyUrls.class);
                     if (urls != null)
                     {
                         reportPermUrl = urls.getManageReportPermissions(c)

--- a/study/src/org/labkey/study/assay/AssayPublishStartAction.java
+++ b/study/src/org/labkey/study/assay/AssayPublishStartAction.java
@@ -143,8 +143,7 @@ public class AssayPublishStartAction extends AbstractPublishStartAction<AssayPub
 
             // Copy url parameters to hidden inputs
             ActionURL url = urlProvider(StudyUrls.class).getLinkToStudyConfirmURL(getContainer(), _protocol);
-            for (Pair<String, String> parameter : url.getParameters())
-                inputs.add(parameter);
+            inputs.addAll(url.getParameters());
 
             url.deleteParameters();
             getPageConfig().setTemplate(PageConfig.Template.None);

--- a/study/src/org/labkey/study/view/StudyToolsWebPartFactory.java
+++ b/study/src/org/labkey/study/view/StudyToolsWebPartFactory.java
@@ -34,7 +34,7 @@ public class StudyToolsWebPartFactory extends ToolsWebPartFactory
         String iconBase = portalCtx.getContextPath() + "/study/tools/";
         List<StudyToolsWebPart.Item> items = new ArrayList<>();
 
-        VisualizationUrls visUrlProvider = PageFlowUtil.urlProvider(VisualizationUrls.class);
+        VisualizationUrls visUrlProvider = PageFlowUtil.urlProviderOptional(VisualizationUrls.class);
         if (visUrlProvider != null)
         {
             URLHelper timeChartURL = visUrlProvider.getTimeChartDesignerURL(portalCtx.getContainer());


### PR DESCRIPTION
#### Rationale
The vast majority of callers of PageFlowUtil.urlProvider() are in the module that supplies the provider, or in a module that has a hard dependency on the supplying module. We can eliminate thousands of warnings in the code about null return values by differentiating between nullable and non-nullable use cases.

#### Changes
- Split `PageFlowUtil.urlProvider()` (throws a clear exception instead of returning null) and `PageFlowUtil.urlProviderOptional()` (may return null)
- Update select callers to eliminate their own null special-casing
- Minor code cleanup

#### Tasks 📍
- ~Manual Testing~
- ~Test Automation~
- ~Verify Fix~