### PR TITLE
GitHub Issue #1087: App Admins cannot view the Schema Browser link from the apps

### DIFF
--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -42,6 +42,7 @@ import org.labkey.api.security.permissions.PlatformDeveloperPermission;
 import org.labkey.api.security.permissions.SampleWorkflowJobPermission;
 import org.labkey.api.security.permissions.SeeGroupDetailsPermission;
 import org.labkey.api.security.permissions.SiteAdminPermission;
+import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.security.permissions.TrustedPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.AbstractRootContainerRole;
@@ -310,6 +311,11 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
     public boolean isTrustedBrowserDev()
     {
         return hasRootPermissions(TRUSTED_BROWSER_DEV);
+    }
+
+    public boolean isTroubleShooter()
+    {
+        return hasRootPermission(TroubleshooterPermission.class);
     }
 
     public boolean isBrowserDev()

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -313,7 +313,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
         return hasRootPermissions(TRUSTED_BROWSER_DEV);
     }
 
-    public boolean isTroubleShooter()
+    public boolean isTroubleshooter()
     {
         return hasRootPermission(TroubleshooterPermission.class);
     }

--- a/api/src/org/labkey/api/view/PopupAdminView.java
+++ b/api/src/org/labkey/api/view/PopupAdminView.java
@@ -101,7 +101,7 @@ public class PopupAdminView
             }
         }
 
-        if (user.isAnalyst() || user.isTroubleShooter())
+        if (user.isAnalyst() || user.isTroubleshooter())
         {
             NavTree devMenu = new NavTree("Developer Links");
             devMenu.addChildren(DeveloperMenu.getNavTree(context));

--- a/api/src/org/labkey/api/view/PopupAdminView.java
+++ b/api/src/org/labkey/api/view/PopupAdminView.java
@@ -101,7 +101,7 @@ public class PopupAdminView
             }
         }
 
-        if (user.isAnalyst() || user.hasRootPermission(TroubleshooterPermission.class))
+        if (user.isAnalyst() || user.isTroubleShooter())
         {
             NavTree devMenu = new NavTree("Developer Links");
             devMenu.addChildren(DeveloperMenu.getNavTree(context));


### PR DESCRIPTION
#### Rationale
[#1087](https://github.com/LabKey/internal-issues/issues/1087) App Admins cannot view the Schema Browser link from the apps

  This is a companion to limsModules#2143. It adds a isTroubleShooter() convenience method to User.java following the same pattern as isAnalyst(), isBrowserDev(), etc., and then refactors PopupAdminView.java to use it.    
  This makes user.isTroubleShooter() available as a first-class helper so both the platform code and the limsModules menu providers can use consistent, readable permission checks.  

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2143
- https://github.com/LabKey/platform/pull/7620

#### Changes
- Add User helper for isTroubleShooter() for root permission check
