### PR TITLE
Update activemq version to 5.19.6

### DIFF
--- a/pipeline/gradle.properties
+++ b/pipeline/gradle.properties
@@ -1,4 +1,4 @@
-activemqVersion=5.19.5
+activemqVersion=5.19.6
 
 geronimoJ2eeConnector15SpecVersion=1.0.1
 


### PR DESCRIPTION
#### Rationale
Resolve several CVEs
 - https://nvd.nist.gov/vuln/detail/CVE-2026-40466
 - https://nvd.nist.gov/vuln/detail/CVE-2026-41043
 - https://nvd.nist.gov/vuln/detail/CVE-2026-41044

#### Related Pull Requests
- N/A

#### Changes
- Update activemq version to 5.19.6