### PR TITLE
GitHub Issue 1076: Clearing a MVTC value in the SDMS UI is confusing

### DIFF
--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -773,6 +773,19 @@ public class DataColumn extends DisplayColumn
 
         out.write(select.addOptions(options));
 
+        /*
+         * GitHub Issue 1076: Clearing a MVTC value in the SDMS UI is confusing
+         * Multi-selects are weird. If no options are selected they don't post at all, so it's impossible to tell
+         * the difference between values that weren't on the html form at all and ones that were cleared by the user.
+         *
+         * To fix this, each multiple-select posts a hidden field with the same name and an empty value,
+         * ensuring the field is always present in the POST body.
+         */
+        if (isMultiple && !_boundColumn.isRequired())
+            out.write(InputBuilder.hidden()
+                .name(formFieldName)
+                .value(""));
+
         // disabled inputs are not posted with the form, so we output a hidden form element:
         if (disabledInput)
             renderHiddenFormInput(out, formFieldName, value);


### PR DESCRIPTION
#### Rationale
To clear an existing MVTC value in LKS UI, user have to explicitly select the blank option. Removing existing options by unselect them doesn't work. 

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- add a hidden empty input for multi select so multi value fields are included in post params when no options are selected

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->
