### PR TITLE
More usages of user.isTroubleshooter()

### DIFF
--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -46,7 +46,6 @@ import org.labkey.api.security.ActionNames;
 import org.labkey.api.security.LoginUrls;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
-import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.ExceptionUtil;
@@ -656,7 +655,7 @@ public abstract class SpringActionController implements Controller, HasViewConte
                     // ignore
                 }
 
-                if (!user.hasRootPermission(TroubleshooterPermission.class))
+                if (!user.isTroubleshooter())
                 {
                     if (HttpUtil.isApiLike(request, action))
                     {

--- a/api/src/org/labkey/api/miniprofiler/MiniProfiler.java
+++ b/api/src/org/labkey/api/miniprofiler/MiniProfiler.java
@@ -26,7 +26,6 @@ import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.PropertyManager.WritablePropertyMap;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.User;
-import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.util.JavaScriptFragment;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.SafeToRender;
@@ -101,7 +100,7 @@ public class MiniProfiler
             return false;
 
         // CONSIDER: Add CanSeeProfilingPermission?
-        if (user != null && (user.isPlatformDeveloper() || user.hasRootPermission(TroubleshooterPermission.class)))
+        if (user != null && (user.isPlatformDeveloper() || user.isTroubleshooter()))
         {
             Settings settings = getSettings(user);
             if (settings != null)

--- a/api/src/org/labkey/api/security/Encryption.java
+++ b/api/src/org/labkey/api/security/Encryption.java
@@ -40,7 +40,6 @@ import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.PropertyManager.WritablePropertyMap;
 import org.labkey.api.data.PropertyStore;
 import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.HasHtmlString;
@@ -113,7 +112,7 @@ public class Encryption
             @Override
             public void addDynamicWarnings(@NotNull Warnings warnings, @Nullable ViewContext context, boolean showAllWarnings)
             {
-                if (context == null || context.getUser().hasRootPermission(TroubleshooterPermission.class))
+                if (context == null || context.getUser().isTroubleshooter())
                 {
                     if (!isEncryptionPassPhraseSpecified() || showAllWarnings)
                         warnings.add(HtmlStringBuilder.of("The encryption key property is not set in " + AppProps.getInstance().getWebappConfigurationFilename() +

--- a/api/src/org/labkey/api/view/PopupAdminView.java
+++ b/api/src/org/labkey/api/view/PopupAdminView.java
@@ -24,7 +24,6 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
-import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.menu.FolderAdminMenu;
 import org.labkey.api.view.menu.ProjectAdminMenu;
@@ -79,7 +78,7 @@ public class PopupAdminView
         User user = context.getUser();
         NavTree navTree = new NavTree("Admin");
 
-        if (user.hasRootPermission(TroubleshooterPermission.class))
+        if (user.isTroubleshooter())
         {
             NavTree siteAdmin = new NavTree("Site");
             siteAdmin.addChildren(SiteAdminMenu.getNavTree(context));

--- a/api/src/org/labkey/api/view/menu/SiteAdminMenu.java
+++ b/api/src/org/labkey/api/view/menu/SiteAdminMenu.java
@@ -23,7 +23,6 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.SecurityUrls;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserUrls;
-import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.security.permissions.UserManagementPermission;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
@@ -48,7 +47,7 @@ public class SiteAdminMenu extends NavTreeMenu
         SecurityUrls securityUrls = PageFlowUtil.urlProvider(SecurityUrls.class);
         List<NavTree> items = new ArrayList<>();
 
-        if (user.hasRootPermission(TroubleshooterPermission.class))
+        if (user.isTroubleshooter())
             items.add(getAdminConsole(context));
 
         URLHelper returnUrl = context.getActionURL().getReturnUrl() == null ? context.getActionURL() : context.getActionURL().getReturnUrl();
@@ -70,7 +69,7 @@ public class SiteAdminMenu extends NavTreeMenu
     @Override
     public boolean isVisible()
     {
-        return getViewContext().getUser().hasRootPermission(TroubleshooterPermission.class);
+        return getViewContext().getUser().isTroubleshooter();
     }
 
     private static @NotNull NavTree getAdminConsole(ViewContext context)

--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -63,7 +63,6 @@ import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.util.GUID;
@@ -1286,7 +1285,7 @@ public class ProjectController extends SpringActionController
 
         private boolean isTroubleshooterRetrievingFolderNav()
         {
-            return getContainer().isRoot() && getUser().hasRootPermission(TroubleshooterPermission.class) && "FolderNav".equals(getViewContext().get("webpart.name"));
+            return getContainer().isRoot() && getUser().isTroubleshooter() && "FolderNav".equals(getViewContext().get("webpart.name"));
         }
 
         @Override

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -142,7 +142,7 @@ public class CoreQuerySchema extends UserSchema
             CONTAINERS_TABLE_NAME, WORKBOOKS_TABLE_NAME, QCSTATE_TABLE_NAME, DATA_STATES_TABLE_NAME,
             VIEW_CATEGORY_TABLE_NAME, MISSING_VALUE_INDICATOR_TABLE_NAME);
 
-        if (getUser().hasRootPermission(TroubleshooterPermission.class))
+        if (getUser().isTroubleshooter())
             names.add(DOCUMENTS_TABLE_NAME);
 
         if (getUser().hasRootPermission(UserManagementPermission.class))
@@ -203,7 +203,7 @@ public class CoreQuerySchema extends UserSchema
             return getMVIndicatorTable(cf);
         if (SHORT_URL_TABLE_NAME.equalsIgnoreCase(name) && ShortUrlTableInfo.canDisplayTable(getUser(), getContainer()))
             return new ShortUrlTableInfo(this);
-        if (DOCUMENTS_TABLE_NAME.equalsIgnoreCase(name) && getUser().hasRootPermission(TroubleshooterPermission.class))
+        if (DOCUMENTS_TABLE_NAME.equalsIgnoreCase(name) && getUser().isTroubleshooter())
             return new DocumentsTable(this, cf);
 
         return null;

--- a/core/src/org/labkey/core/query/PostgresUserSchema.java
+++ b/core/src/org/labkey/core/query/PostgresUserSchema.java
@@ -8,7 +8,6 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.dialect.BasePostgreSqlDialect;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
-import org.labkey.api.security.permissions.TroubleshooterPermission;
 
 import java.util.Set;
 
@@ -23,7 +22,7 @@ import java.util.Set;
     @Override
     public boolean canReadSchema()
     {
-        return super.canReadSchema() || getUser().hasRootPermission(TroubleshooterPermission.class);
+        return super.canReadSchema() || getUser().isTroubleshooter();
     }
 
     @Override

--- a/core/src/org/labkey/core/user/LimitActiveUsersSettings.java
+++ b/core/src/org/labkey/core/user/LimitActiveUsersSettings.java
@@ -9,7 +9,6 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.AddUserPermission;
-import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.settings.AbstractWriteableSettingsGroup;
 import org.labkey.api.settings.StandardStartupPropertyHandler;
 import org.labkey.api.settings.StartupProperty;
@@ -185,7 +184,7 @@ public class LimitActiveUsersSettings extends AbstractWriteableSettingsGroup
 
     public static @Nullable HtmlString getWarningMessage(Container c, User user, boolean showAllWarnings)
     {
-        if (c.hasPermission(user, AddUserPermission.class) || user.hasRootPermission(TroubleshooterPermission.class))
+        if (c.hasPermission(user, AddUserPermission.class) || user.isTroubleshooter())
         {
             LimitActiveUsersSettings settings = new LimitActiveUsersSettings();
             int activeUsers = getActiveUserCount();

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -33,7 +33,6 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.DbLoginService;
 import org.labkey.api.security.impersonation.AbstractImpersonationContextFactory;
 import org.labkey.api.security.permissions.SiteAdminPermission;
-import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.OptionalFeatureFlag;
 import org.labkey.api.settings.OptionalFeatureService;
@@ -130,7 +129,7 @@ public class CoreWarningProvider implements WarningProvider
                 warnings.add(UsageReportingLevel.getMarketingUpdate());
         }
 
-        if (context == null || context.getUser().hasRootPermission(TroubleshooterPermission.class))
+        if (context == null || context.getUser().isTroubleshooter())
         {
             addUserRequestedAdminOnlyModeWarnings(warnings, showAllWarnings, context == null || context.getUser().hasSiteAdminPermission());
 

--- a/core/src/org/labkey/core/view/template/bootstrap/WarningServiceImpl.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/WarningServiceImpl.java
@@ -18,7 +18,6 @@ package org.labkey.core.view.template.bootstrap;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.admin.CoreUrls;
 import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.util.HtmlString;
@@ -160,7 +159,7 @@ public class WarningServiceImpl implements WarningService
         // Collect warnings
         List<HtmlString> warningMessages = new LinkedList<>();
 
-        if (context == null || context.getUser().hasRootPermission(TroubleshooterPermission.class))
+        if (context == null || context.getUser().isTroubleshooter())
             warningMessages.addAll(getStaticAdminWarnings());
 
         Warnings warnings = Warnings.of(warningMessages);

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -55,7 +55,6 @@ import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.util.FileUtil;
@@ -136,7 +135,7 @@ public class StatusController extends SpringActionController
         Container c = getContainer();
         if (c == null || c.isRoot())
         {
-            if (!getUser().hasRootPermission(TroubleshooterPermission.class))
+            if (!getUser().isTroubleshooter())
             {
                 throw new UnauthorizedException();
             }


### PR DESCRIPTION
#### Rationale
Follow-up from recent PR that added a user.isTroubleshooter() helper. This PR replaces some usages in the platform module.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7620

#### Changes
- replaces all remaining usages of `user.hasRootPermission(TroubleshooterPermission.class)` in platform
