### PR TITLE
TableInfo: ensure ExprColumn dependent columns are referenced

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -43,6 +43,7 @@ import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.query.AggregateRowConfig;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DetailsURL;
+import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.MetadataParseWarning;
 import org.labkey.api.query.QueryException;
@@ -181,10 +182,10 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     private final Map<String, CounterDefinition> _counterDefinitionMap = new CaseInsensitiveHashMap<>();    // Really only 1 for now, but could be more in future
 
     /* If a subclass generates a non-trivial FROM clause in getFromSQL(), it may need to track dependencies
-     * for calculated columns.  This is where we do that.  This is setup in loadAllButCustomizerFromXML(), and
+     * for calculated columns.  This is where we do that.  This is set up in loadAllButCustomizerFromXML(), and
      * and used in getFromSQL(String alias, Set<FieldKey> cols)
      */
-    protected final HashMap<FieldKey, HashSet<FieldKey>> _referencedColumns = new HashMap<>();
+    protected final Map<FieldKey, Set<FieldKey>> _referencedColumns = new HashMap<>();
 
     private boolean _initialColumnsAreAdded = false;
 
@@ -325,7 +326,6 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         }
     }
 
-
     protected Map<String, ColumnInfo> constructColumnMap()
     {
         if (isCaseSensitive())
@@ -399,15 +399,17 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     {
         if (null == columns || columns.isEmpty() || _referencedColumns.isEmpty())
             return columns;
-        // We're not recursively expanding. However, if expressions can reference each other we'll have to.
+
+        // We're not recursively expanding. However, if expressions can reference each other, we'll have to.
         HashSet<FieldKey> expanded = new HashSet<>();
         for (var fk : columns)
         {
             expanded.add(fk);
-            HashSet<FieldKey> refs = _referencedColumns.get(fk);
+            Set<FieldKey> refs = _referencedColumns.get(fk);
             if (null != refs)
                 expanded.addAll(refs);
         }
+
         return expanded;
     }
 
@@ -439,8 +441,8 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             List<ColumnInfo> pkColumns = getPkColumns();
             if (pkColumns.size() != 1)
                 return new NamedObjectList();
-            else
-                return getSelectList(pkColumns.get(0), Collections.emptyList(), maxRows, titleColumnInfo);
+
+            return getSelectList(pkColumns.getFirst(), Collections.emptyList(), maxRows, titleColumnInfo);
         }
 
         ColumnInfo column = getColumn(columnName);
@@ -460,12 +462,12 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         final int titleIndex;
         if (!(firstColumn.equals(titleColumn)))
         {
-            cols = Arrays.asList(firstColumn, titleColumn);
+            cols = List.of(firstColumn, titleColumn);
             titleIndex = 2;
         }
         else
         {
-            cols = Arrays.asList(firstColumn);
+            cols = List.of(firstColumn);
             titleIndex = 1;
         }
 
@@ -563,7 +565,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                 }
             }
             if (null == _titleColumn && !getColumns().isEmpty())
-                _titleColumn = getColumns().get(0).getName();
+                _titleColumn = getColumns().getFirst().getName();
         }
 
         return _titleColumn;
@@ -769,21 +771,39 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         _description = description;
     }
 
+    // GitHub Issue #1118
+    // ExprColumn may have dependent columns that need to be referenced so that getFromSQL() can include them
+    private void updateReferencedColumns(ColumnInfo column)
+    {
+        if (column instanceof ExprColumn exprColumn)
+        {
+            var fieldKey = exprColumn.getFieldKey();
+            var dependentColumns = exprColumn.getDependentColumns();
+            if (!dependentColumns.isEmpty())
+                _referencedColumns.put(fieldKey, dependentColumns.stream().map(ColumnInfo::getFieldKey).collect(Collectors.toSet()));
+        }
+    }
+
     public boolean removeColumn(ColumnInfo column)
     {
         checkLocked();
         ensureInitialColumnsAreAdded();
-        // Clear the cached resolved columns so we regenerate it if the shape of the table changes
-        _resolvedColumns.clear();
-        return _columnMap.remove(column.getName()) != null;
+
+        boolean removed = _columnMap.remove(column.getName()) != null;
+        if (removed)
+        {
+            // Clear the cached resolved columns so we regenerate it if the shape of the table changes
+            _resolvedColumns.clear();
+            _referencedColumns.remove(column.getFieldKey());
+        }
+
+        return removed;
     }
 
     public MutableColumnInfo addColumn(MutableColumnInfo column)
     {
         checkLocked();
         ensureInitialColumnsAreAdded();
-        // Not true if this is a VirtualTableInfo
-        // assert column.getParentTable() == this;
         if (_columnMap.containsKey(column.getName()))
         {
             String message = "Column " + column.getName() + " already exists for table " + getName() + ". Full set of existing columns: " + _columnMap.keySet();
@@ -794,7 +814,9 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         _columnMap.put(column.getName(), column);
         // Clear the cached resolved columns so we regenerate it if the shape of the table changes
         _resolvedColumns.clear();
+        updateReferencedColumns(column);
         assert !(column instanceof BaseColumnInfo) || ((BaseColumnInfo)column).lockName();
+
         return column;
     }
 
@@ -803,8 +825,6 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
      * This is usually only done in TableInfo.afterConstruct() to modify the behavior of a column.
      * Because the ColumnInfo implementation can change in afterConstruct(), TableInfo implementations
      * should hold onto columnInfo references by FieldKey, and not by reference.
-
-     * during construction.
      */
     public ColumnInfo replaceColumn(ColumnInfo updated, ColumnInfo existing)
     {
@@ -821,9 +841,12 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         _columnMap.put(updated.getName(), updated);
         // Clear the cached resolved columns so we regenerate it if the shape of the table changes
         _resolvedColumns.clear();
+
+        _referencedColumns.remove(existing.getFieldKey());
+        updateReferencedColumns(updated);
+
         return updated;
     }
-
 
     protected ColumnInfo transformColumn(MutableColumnInfo existing, @Nullable ColumnInfoTransformer t)
     {
@@ -831,10 +854,10 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         existing.checkLocked();
         if (null == t)
             return existing;
+
         MutableColumnInfo updated = t.apply(existing);
         return replaceColumn(updated, existing);
     }
-
 
     public void addCounterDefinition(@NotNull CounterDefinition counterDef)
     {
@@ -1380,7 +1403,6 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         if (xmlTable.isSetTableUrl())
             _detailsURL = DetailsURL.fromXML(xmlTable.getTableUrl(), errors);
 
-
         if (xmlTable.isSetCacheSize())
             _cacheSize = xmlTable.getCacheSize();
 
@@ -1467,7 +1489,8 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                     var wrappedColumn = QueryService.get().createQueryExpressionColumn(this, FieldKey.fromParts(xmlColumn.getColumnName()), sql, xmlColumn);
                     HashSet<FieldKey> referencedColumns = new HashSet<>();
                     QueryService.get().bindQueryExpressionColumn(wrappedColumn, existingColumns, true, referencedColumns);
-                    _referencedColumns.put(wrappedColumn.getFieldKey(), referencedColumns);
+                    if (!referencedColumns.isEmpty())
+                        _referencedColumns.put(wrappedColumn.getFieldKey(), referencedColumns);
                     calculatedFieldKeys.add(wrappedColumn.getFieldKey());
                     addColumn(wrappedColumn);
                 }
@@ -1503,7 +1526,6 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             {
                 warnings.add(new QueryParseWarning("Invalid AuditLogging: " + auditBehavior,null,0,0));
             }
-
         }
 
         _warnings.addAll(warnings);
@@ -2140,7 +2162,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         {
             List<String> pks = getPkColumnNames();
             if (pks.size() == 1)
-                _auditRowPk = FieldKey.fromParts(pks.get(0));
+                _auditRowPk = FieldKey.fromParts(pks.getFirst());
             else if (getColumn(FieldKey.fromParts("EntityId")) != null)
                 _auditRowPk = FieldKey.fromParts("EntityId");
             else if (getColumn(FieldKey.fromParts("RowId")) != null)

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -43,7 +43,6 @@ import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.query.AggregateRowConfig;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DetailsURL;
-import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.MetadataParseWarning;
 import org.labkey.api.query.QueryException;
@@ -182,10 +181,10 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     private final Map<String, CounterDefinition> _counterDefinitionMap = new CaseInsensitiveHashMap<>();    // Really only 1 for now, but could be more in future
 
     /* If a subclass generates a non-trivial FROM clause in getFromSQL(), it may need to track dependencies
-     * for calculated columns.  This is where we do that.  This is set up in loadAllButCustomizerFromXML(), and
-     * and used in getFromSQL(String alias, Set<FieldKey> cols)
+     * for calculated columns. Lazily built from each column's getReferencedFieldKeys() and used in
+     * getFromSQL(String alias, Set<FieldKey> cols). Cleared whenever the column shape changes.
      */
-    protected final Map<FieldKey, Set<FieldKey>> _referencedColumns = new HashMap<>();
+    private volatile Map<FieldKey, Set<FieldKey>> _referencedColumns;
 
     private boolean _initialColumnsAreAdded = false;
 
@@ -392,12 +391,23 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             return new SQLFragment().append("(").append(getFromSQL()).append(") ").appendIdentifier(alias);
     }
 
+    // Clear the cached resolved/referenced columns so we regenerate them when the shape of the table changes
+    private void clearColumnReferences()
+    {
+        _resolvedColumns.clear();
+        _referencedColumns = null;
+    }
+
     /** When a table a) overrides (String alias, Set<FieldKey> cols) b) has CalculatedColumns we need to make sure that
      * we include the dependent columns in the Set<>.
      */
     protected Set<FieldKey> expandColumns(Set<FieldKey> columns)
     {
-        if (null == columns || columns.isEmpty() || _referencedColumns.isEmpty())
+        if (null == columns || columns.isEmpty())
+            return columns;
+
+        var referenced = getReferencedColumns();
+        if (referenced.isEmpty())
             return columns;
 
         // We're not recursively expanding. However, if expressions can reference each other, we'll have to.
@@ -405,12 +415,30 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         for (var fk : columns)
         {
             expanded.add(fk);
-            Set<FieldKey> refs = _referencedColumns.get(fk);
+            Set<FieldKey> refs = referenced.get(fk);
             if (null != refs)
                 expanded.addAll(refs);
         }
 
         return expanded;
+    }
+
+    private Map<FieldKey, Set<FieldKey>> getReferencedColumns()
+    {
+        if (_referencedColumns == null)
+        {
+            var built = new HashMap<FieldKey, Set<FieldKey>>();
+            for (var col : getColumns())
+            {
+                var deps = col.getReferencedFieldKeys();
+                if (!deps.isEmpty())
+                    built.put(col.getFieldKey(), deps);
+            }
+
+            _referencedColumns = built.isEmpty() ? Map.of() : Collections.unmodifiableMap(built);
+        }
+
+        return _referencedColumns;
     }
 
     @Override
@@ -771,19 +799,6 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         _description = description;
     }
 
-    // GitHub Issue #1118
-    // ExprColumn may have dependent columns that need to be referenced so that getFromSQL() can include them
-    private void updateReferencedColumns(ColumnInfo column)
-    {
-        if (column instanceof ExprColumn exprColumn)
-        {
-            var fieldKey = exprColumn.getFieldKey();
-            var dependentColumns = exprColumn.getDependentColumns();
-            if (!dependentColumns.isEmpty())
-                _referencedColumns.put(fieldKey, dependentColumns.stream().map(ColumnInfo::getFieldKey).collect(Collectors.toSet()));
-        }
-    }
-
     public boolean removeColumn(ColumnInfo column)
     {
         checkLocked();
@@ -791,11 +806,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
         boolean removed = _columnMap.remove(column.getName()) != null;
         if (removed)
-        {
-            // Clear the cached resolved columns so we regenerate it if the shape of the table changes
-            _resolvedColumns.clear();
-            _referencedColumns.remove(column.getFieldKey());
-        }
+            clearColumnReferences();
 
         return removed;
     }
@@ -812,9 +823,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             assert false : message;
         }
         _columnMap.put(column.getName(), column);
-        // Clear the cached resolved columns so we regenerate it if the shape of the table changes
-        _resolvedColumns.clear();
-        updateReferencedColumns(column);
+        clearColumnReferences();
         assert !(column instanceof BaseColumnInfo) || ((BaseColumnInfo)column).lockName();
 
         return column;
@@ -839,11 +848,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             throw new IllegalStateException("Column must have the same name");
 
         _columnMap.put(updated.getName(), updated);
-        // Clear the cached resolved columns so we regenerate it if the shape of the table changes
-        _resolvedColumns.clear();
-
-        _referencedColumns.remove(existing.getFieldKey());
-        updateReferencedColumns(updated);
+        clearColumnReferences();
 
         return updated;
     }
@@ -1487,10 +1492,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                 try
                 {
                     var wrappedColumn = QueryService.get().createQueryExpressionColumn(this, FieldKey.fromParts(xmlColumn.getColumnName()), sql, xmlColumn);
-                    HashSet<FieldKey> referencedColumns = new HashSet<>();
-                    QueryService.get().bindQueryExpressionColumn(wrappedColumn, existingColumns, true, referencedColumns);
-                    if (!referencedColumns.isEmpty())
-                        _referencedColumns.put(wrappedColumn.getFieldKey(), referencedColumns);
+                    QueryService.get().bindQueryExpressionColumn(wrappedColumn, existingColumns, true, null);
                     calculatedFieldKeys.add(wrappedColumn.getFieldKey());
                     addColumn(wrappedColumn);
                 }

--- a/api/src/org/labkey/api/data/ColumnInfo.java
+++ b/api/src/org/labkey/api/data/ColumnInfo.java
@@ -35,8 +35,10 @@ import org.labkey.data.xml.ColumnType;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface ColumnInfo extends ColumnRenderProperties
 {
@@ -371,6 +373,12 @@ public interface ColumnInfo extends ColumnRenderProperties
 
     boolean isCalculated();
 
+    /** FieldKeys this column depends on at SQL generation time. */
+    default Set<FieldKey> getReferencedFieldKeys()
+    {
+        return Collections.emptySet();
+    }
+
     default boolean isValueExpressionColumn()
     {
         return getValueExpression() != null && getWrappedColumnName() == null;
@@ -405,6 +413,7 @@ public interface ColumnInfo extends ColumnRenderProperties
     {
         return BaseColumnInfo.booleanFromString(str);
     }
+
     static boolean booleanFromObj(Object o)
     {
         return BaseColumnInfo.booleanFromObj(o);
@@ -483,5 +492,3 @@ public interface ColumnInfo extends ColumnRenderProperties
         return ColumnRenderProperties.getDefaultConvertFn(col);
     }
 }
-
-

--- a/api/src/org/labkey/api/query/ExprColumn.java
+++ b/api/src/org/labkey/api/query/ExprColumn.java
@@ -16,7 +16,7 @@
 
 package org.labkey.api.query;
 
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.JdbcType;
@@ -24,6 +24,8 @@ import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -70,11 +72,10 @@ public class ExprColumn extends BaseColumnInfo
         this(parent, FieldKey.fromParts(name), sql, type, dependentColumns);
     }
 
-    public static MutableColumnInfo create(TableInfo parent, String name, JdbcType type, SQLFragment sqlf, ColumnInfo ... dependentColumns)
+    public static MutableColumnInfo create(TableInfo parent, String name, JdbcType type, SQLFragment sql, ColumnInfo ... dependentColumns)
     {
-        return new ExprColumn(parent, name, sqlf, type, dependentColumns);
+        return new ExprColumn(parent, name, sql, type, dependentColumns);
     }
-
 
     /*
      * Use this 'constructor' to create an ExprColumn whose SQL is generated on demand.  This is useful if generating
@@ -94,24 +95,21 @@ public class ExprColumn extends BaseColumnInfo
         };
     }
 
-
     @Override
     public SQLFragment getValueSql(String tableAlias)
     {
         if (tableAlias.equals(STR_TABLE_ALIAS))
             return _sql;
         SQLFragment ret = new SQLFragment(_sql);
-        ret.setSqlUnsafe(StringUtils.replace(_sql.getSQL(), STR_TABLE_ALIAS, tableAlias));
+        ret.setSqlUnsafe(Strings.CS.replace(_sql.getSQL(), STR_TABLE_ALIAS, tableAlias));
         return ret;
     }
-
 
     public void setValueSQL(SQLFragment sql)
     {
         _sql = sql;
     }
 
-    
     @Override
     public void declareJoins(String parentAlias, Map<String, SQLFragment> map)
     {
@@ -122,5 +120,12 @@ public class ExprColumn extends BaseColumnInfo
                 col.declareJoins(parentAlias, map);
             }
         }
+    }
+
+    public List<ColumnInfo> getDependentColumns()
+    {
+        if (_dependentColumns == null)
+            return Collections.emptyList();
+        return List.of(_dependentColumns);
     }
 }

--- a/api/src/org/labkey/api/query/ExprColumn.java
+++ b/api/src/org/labkey/api/query/ExprColumn.java
@@ -25,8 +25,9 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -122,10 +123,16 @@ public class ExprColumn extends BaseColumnInfo
         }
     }
 
-    public List<ColumnInfo> getDependentColumns()
+    @Override
+    public Set<FieldKey> getReferencedFieldKeys()
     {
-        if (_dependentColumns == null)
-            return Collections.emptyList();
-        return List.of(_dependentColumns);
+        if (_dependentColumns == null || _dependentColumns.length == 0)
+            return Collections.emptySet();
+
+        var keys = new HashSet<FieldKey>();
+        for (var c : _dependentColumns)
+            keys.add(c.getFieldKey());
+
+        return Collections.unmodifiableSet(keys);
     }
 }

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3040,7 +3040,7 @@ public class QueryServiceImpl implements QueryService
         return ret;
     }
 
-     /** Compute and set the metadata for this column based on the source expressoin and the xml override */
+     /** Compute and set the metadata for this column based on the source expression and the xml override */
     @Override
     public void bindQueryExpressionColumn(ColumnInfo col, Map<FieldKey,ColumnInfo> columns, boolean validateOnly, @Nullable Set<FieldKey> referencedKeys) throws QueryParseException
     {

--- a/query/src/org/labkey/query/sql/CalculatedExpressionColumn.java
+++ b/query/src/org/labkey/query/sql/CalculatedExpressionColumn.java
@@ -23,8 +23,8 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.data.xml.ColumnType;
 import org.labkey.data.xml.TableType;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -97,6 +97,14 @@ public class CalculatedExpressionColumn extends BaseColumnInfo
         }
     }
 
+    @Override
+    public Set<FieldKey> getReferencedFieldKeys()
+    {
+        if (_allFieldKeys == null)
+            return Collections.emptySet();
+
+        return Collections.unmodifiableSet(_allFieldKeys);
+    }
 
     public void computeMetaData(Map<FieldKey,ColumnInfo> columns)
     {
@@ -397,7 +405,7 @@ public class CalculatedExpressionColumn extends BaseColumnInfo
         }
 
         @Override
-        protected SchemaColumnMetaData createSchemaColumnMetaData() throws SQLException
+        protected SchemaColumnMetaData createSchemaColumnMetaData()
         {
             return new SchemaColumnMetaData(this, colsToAdd, xmlToApply);
         }


### PR DESCRIPTION
#### Rationale
This addresses [#1118](https://github.com/LabKey/internal-issues/issues/1118) where `ExprColumn` added via table customizers are not having their dependent columns included in the query. As a result the generated query attempts to refer to columns that have not been furnished by `getFromSQL()`.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2167

#### Changes
- When mutating the column set in `AbtractTableInfo`, check if the mutation is an `ExprColumn`, and update referenced columns
- Minor cleanup
