### PR TITLE
Supress stack trace display from error pages

### DIFF
--- a/api/src/org/labkey/api/view/template/errorView.jsp
+++ b/api/src/org/labkey/api/view/template/errorView.jsp
@@ -24,19 +24,6 @@
 
 <div id="<%=h(appId)%>"></div>
 
-<%
-    StringBuilder stackTrace = new StringBuilder();
-    if (null != model.getException())
-    {
-        stackTrace.append(model.getException().toString());
-        for (StackTraceElement stackTraceElement : model.getException().getStackTrace())
-        {
-            stackTrace.append("\n");
-            stackTrace.append(stackTraceElement.toString());
-        }
-    }
-%>
-
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     /*
          This error page may be invoked without the themes having been loaded for this container.
@@ -52,7 +39,6 @@
             errorDetails : {
                 message: <%=q(model.getHeading())%>,
                 errorType: <%=q(model.getErrorType())%>,
-                stackTrace: <%=q(stackTrace.toString())%>,
                 errorCode: <%=q(model.getErrorCode())%>,
                 advice: <%=q(model.getAdvice())%>
             }

--- a/core/src/client/ErrorHandler/ErrorHandler.test.tsx
+++ b/core/src/client/ErrorHandler/ErrorHandler.test.tsx
@@ -68,19 +68,15 @@ describe('ErrorHandlerImpl', () => {
     });
 
     test('Execution exception', async () => {
-        const expectedStackTrace = 'java.lang.NullPointerException: null';
-
         const errorDetails: ErrorDetails = {
-            errorType: ErrorType.execution,
+            errorType: ErrorType.permission,
             errorCode: '456AAA',
             message: 'This is a execution exception',
-            stackTrace: expectedStackTrace,
         };
         renderWithAppContext(<ErrorHandlerImpl context={{ errorDetails }} />);
         expect(document.querySelector('.labkey-error-subheading').innerHTML.includes(errorDetails.message)).toBeTruthy();
         expect(document.querySelectorAll('.error-details-container')).toHaveLength(0);
 
         await userEvent.click(document.querySelectorAll('.error-page-button')[2]);
-        expect(document.querySelector('pre').innerHTML.startsWith(expectedStackTrace)).toBeTruthy();
     });
 });

--- a/core/src/client/ErrorHandler/ErrorHandler.test.tsx
+++ b/core/src/client/ErrorHandler/ErrorHandler.test.tsx
@@ -69,7 +69,7 @@ describe('ErrorHandlerImpl', () => {
 
     test('Execution exception', async () => {
         const errorDetails: ErrorDetails = {
-            errorType: ErrorType.permission,
+            errorType: ErrorType.execution,
             errorCode: '456AAA',
             message: 'This is a execution exception',
         };

--- a/core/src/client/ErrorHandler/ErrorHandler.tsx
+++ b/core/src/client/ErrorHandler/ErrorHandler.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { ActionURL } from '@labkey/api';
 
-import { getErrorHeading, getImage, getInstruction, getSubHeading, getViewDetails } from './ErrorType';
+import { getErrorHeading, getImage, getInstruction, getShowDetailsBtn, getSubHeading, getViewDetails } from './ErrorType';
 import { ErrorDetails } from './model';
 import { withServerContext } from '@labkey/components';
 
@@ -61,7 +61,7 @@ export class ErrorHandlerImpl extends PureComponent<ErrorHandlerProps, ErrorHand
                                 <button className="btn btn-default error-page-button" onClick={this.onHomeClick}>
                                     Home
                                 </button>
-                                {!errorDetails.hideViewDetails &&
+                                {!errorDetails.hideViewDetails && getShowDetailsBtn(errorDetails) &&
                                     <button className="btn btn-default error-page-button" onClick={this.onViewDetailsClick}>
                                         {viewDetailsBtnText}
                                     </button>

--- a/core/src/client/ErrorHandler/ErrorType.tsx
+++ b/core/src/client/ErrorHandler/ErrorType.tsx
@@ -211,7 +211,6 @@ const CONFIGURATION_DETAILS = (errorDetails: ErrorDetails) => (
         </div>
 
         {DETAILS_SUB_INSTRUCTION}
-        <pre>{errorDetails.stackTrace}</pre>
     </>
 );
 
@@ -231,21 +230,21 @@ const EXECUTION_INSTRUCTION = (errorDetails: ErrorDetails) => (
                 {' '}
                 find help resources here{' '}
             </a>{' '}
-            and may find troubleshooting hints by reading the full stack trace in the View Details section
-            below.
+            and may find troubleshooting hints by reading the full stack trace in the server logs.
         </div>
         <div className="labkey-error-instruction">
             Your unique reference code is: <b>{errorDetails.errorCode}</b>
         </div>
     </>
 );
-const EXECUTION_DETAILS = (errorDetails: ErrorDetails) => <pre>{errorDetails.stackTrace}</pre>;
+const EXECUTION_DETAILS = (errorDetails: ErrorDetails) => <pre></pre>;
 
 type ErrorTypeInfo = {
     details: (errorDetails?: ErrorDetails) => ReactNode;
     heading: (errorMessage?: string) => ReactNode;
     imagePath: string;
     instruction: (errorDetails?: ErrorDetails) => ReactNode;
+    showDetailsBtn: boolean;
     subHeading: (errorMessage?: string) => ReactNode;
 };
 
@@ -257,6 +256,7 @@ const ERROR_TYPE_INFO: { [key in ErrorType]: ErrorTypeInfo } = {
         heading: CONFIGURATION_HEADING,
         imagePath: 'configuration_error.svg',
         instruction: CONFIGURATION_INSTRUCTION,
+        showDetailsBtn: true,
         subHeading: CONFIGURATION_SUBHEADING,
     },
     execution: {
@@ -264,6 +264,7 @@ const ERROR_TYPE_INFO: { [key in ErrorType]: ErrorTypeInfo } = {
         heading: ERROR_HEADING,
         imagePath: 'code_error.svg',
         instruction: EXECUTION_INSTRUCTION,
+        showDetailsBtn: false,
         subHeading: EXECUTION_SUB_HEADING,
     },
     notFound: {
@@ -271,6 +272,7 @@ const ERROR_TYPE_INFO: { [key in ErrorType]: ErrorTypeInfo } = {
         heading: NOTFOUND_HEADING,
         imagePath: 'notFound_error.svg',
         instruction: NOTFOUND_INSTRUCTION,
+        showDetailsBtn: true,
         subHeading: NOTFOUND_SUBHEADING,
     },
     permission: {
@@ -278,6 +280,7 @@ const ERROR_TYPE_INFO: { [key in ErrorType]: ErrorTypeInfo } = {
         heading: ERROR_HEADING,
         imagePath: 'permission_error.svg',
         instruction: PERMISSION_INSTRUCTION,
+        showDetailsBtn: true,
         subHeading: PERMISSION_SUBHEADING,
     },
 };
@@ -308,6 +311,11 @@ export const getInstruction = (errorDetails: ErrorDetails): ReactNode => {
     if (!info) return null;
 
     return <div className="labkey-error-instruction">{info.instruction(errorDetails)}</div>;
+};
+
+export const getShowDetailsBtn = (errorDetails: ErrorDetails): boolean => {
+    const info = ERROR_TYPE_INFO[errorDetails.errorType];
+    return info?.showDetailsBtn ?? true;
 };
 
 export const getViewDetails = (errorDetails: ErrorDetails): ReactNode => {

--- a/core/src/client/ErrorHandler/ErrorType.tsx
+++ b/core/src/client/ErrorHandler/ErrorType.tsx
@@ -237,7 +237,7 @@ const EXECUTION_INSTRUCTION = (errorDetails: ErrorDetails) => (
         </div>
     </>
 );
-const EXECUTION_DETAILS = (errorDetails: ErrorDetails) => <pre></pre>;
+const EXECUTION_DETAILS = () => null;
 
 type ErrorTypeInfo = {
     details: (errorDetails?: ErrorDetails) => ReactNode;

--- a/core/src/client/ErrorHandler/model.ts
+++ b/core/src/client/ErrorHandler/model.ts
@@ -9,7 +9,6 @@ export interface ErrorDetails {
     errorCode?: string;
     errorType: ErrorType;
     message?: string;
-    stackTrace?: string;
     hideViewDetails?: boolean;
     advice?: string;
 }


### PR DESCRIPTION
#### Rationale
This PR removes the stack trace from the error page details. In the case where the error type details only consists of a stacktrace (execution), the "Show Details" button won't be rendered.
