### PR TITLE
Remove unused getIndexRenames()

### DIFF
--- a/api/src/org/labkey/api/data/TableChange.java
+++ b/api/src/org/labkey/api/data/TableChange.java
@@ -51,7 +51,6 @@ public class TableChange
     private final Collection<PropertyStorageSpec> _columns = new LinkedHashSet<>();
     private final Map<String, String> _columnRenames = new LinkedHashMap<>();
     private final Map<String, Integer> _columnResizes = new LinkedHashMap<>();
-    private final Map<Index, Index> _indexRenames = new LinkedHashMap<>();
     private final Domain _domain;
 
     private Collection<Index> _indices = new LinkedHashSet<>();
@@ -158,7 +157,7 @@ public class TableChange
                     // SQLServer creates a non-unique index for single large text columns with a "_hashed_" prefix.
                     // The uniqueness is enforced by a database trigger.
                     boolean unique = index.indexType() == TableInfo.IndexType.Unique ||
-                            (schema.getSqlDialect().isSqlServer() && columnNames.size() == 1 && columnNames.get(0).startsWith(PropertyStorageSpec.HASHED_COLUMN_PREFIX));
+                            (schema.getSqlDialect().isSqlServer() && columnNames.size() == 1 && columnNames.getFirst().startsWith(PropertyStorageSpec.HASHED_COLUMN_PREFIX));
 
                     // remove the _hashed_ column prefix for SQLServer
                     if (schema.getSqlDialect().isSqlServer() && unique)
@@ -250,19 +249,6 @@ public class TableChange
         _columnRenames.put(oldName, newName);
     }
 
-    /**
-     * Index will be renamed using the columns listed in the Index.
-     * The columns used by the index won't be changed. We need to
-     * pass the list of columns since the index name is created by the dialect.
-     *
-     * @param oldIndex Old index to be renamed.
-     * @param newIndex New index to be renamed.
-     */
-    public void addIndexRename(Index oldIndex, Index newIndex)
-    {
-        _indexRenames.put(oldIndex, newIndex);
-    }
-
     public void dropColumnExactName(String name)
     {
         if (_type != ChangeType.DropColumns)
@@ -290,22 +276,9 @@ public class TableChange
         return Collections.unmodifiableMap(_columnRenames);
     }
 
-    /**
-     * @return  map where key = old index, value = new index
-     */
-    public Map<Index, Index> getIndexRenames()
-    {
-        return Collections.unmodifiableMap(_indexRenames);
-    }
-
     public Collection<Index> getIndexedColumns()
     {
         return _indices;
-    }
-
-    public void setIndexedColumns(Collection<Index> indices)
-    {
-        _indices = indices;
     }
 
     public void setIndexedColumns(Domain domain, Collection<Index> indices)

--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -807,24 +807,6 @@ abstract class PostgreSql92Dialect extends BasePostgreSqlDialect
             }
         }
 
-        // TODO: This loop should not guess the name of the old indices; instead, it should look them up.
-        // TableChange.setIndexedColumns() could set _indexRenames providing the name, and then this code uses that info.
-        // Or maybe schemaTableInfo.getAllIndices() and then use Index.isSameIndex() to find names. Issue 53838.
-        for (Map.Entry<PropertyStorageSpec.Index, PropertyStorageSpec.Index> oldToNew : change.getIndexRenames().entrySet())
-        {
-            PropertyStorageSpec.Index oldIndex = oldToNew.getKey();
-            PropertyStorageSpec.Index newIndex = oldToNew.getValue();
-            String oldName = nameIndex(change.getTableName(), oldIndex.columnNames); // TODO: Look up name
-            String newName = nameIndex(change.getTableName(), newIndex.columnNames);
-            if (!oldName.equals(newName))
-            {
-                SQLFragment f = new SQLFragment("ALTER INDEX ");
-                f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(oldName);
-                f.append(" RENAME TO ").appendIdentifier(newName);
-                statements.add(f);
-            }
-        }
-
         return statements;
     }
 

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -97,6 +97,7 @@ import org.springframework.validation.BindException;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -110,7 +111,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static org.labkey.api.data.ColumnRenderPropertiesImpl.TEXT_CHOICE_CONCEPT_URI;
@@ -138,7 +138,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
     // #42641: Track recently created tables in a cache to limit size and duration
     private static final Cache<@NotNull String, StackTraceElement @NotNull []> RECENTLY_CREATED_TABLES = CacheBuilder.newBuilder()
         .maximumSize(10000)
-        .expireAfterWrite(1, TimeUnit.DAYS)
+        .expireAfterWrite(Duration.ofDays(1))
         .build();
 
     private String _create(DbScope scope, DomainKind<?> kind, Domain domain, boolean useProvidedStorageName)


### PR DESCRIPTION
#### Rationale
`TableChange.addIndexRename()` was never called, therefore `_indexRenames` was always empty, therefore the callers of `getIndexRenames()` in the dialects never had anything to iterate over. Get rid of the whole lot. https://github.com/LabKey/internal-issues/issues/493

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/552