### PR TITLE
Workflow: Add Update Sample Status Action

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -907,7 +907,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         addAuditEvent(user, container, QueryService.AuditAction.UPDATE, configParameters, result, oldRows, providedValues);
         WorkflowService service = WorkflowService.get();
         if (service != null && configParameters != null && configParameters.containsKey(WorkflowService.WorkflowConfigs.ActionId))
-            service.onActionComplete(container, user, (Long) configParameters.get(WorkflowService.WorkflowConfigs.ActionId));
+            service.onActionComplete(container, user, (Long) configParameters.get(WorkflowService.WorkflowConfigs.ActionId), (String) configParameters.get(AuditUserComment));
 
         return result;
     }

--- a/api/src/org/labkey/api/workflow/Action.java
+++ b/api/src/org/labkey/api/workflow/Action.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -130,6 +131,14 @@ public abstract class Action extends CreatedModified
         _inputParameters = inputParameters;
     }
 
+    /**
+     * Validates that the status parameters are valid, according to the following rules:
+     *  - If updateKeyRequired is true, then STATUS_KEY and REMOVE_FROM_STORAGE_KEY may only be present if
+     *  UPDATE_STATUS_KEY is true
+     *  - STATUS_KEY is optional, but when present the value must be a valid status
+     *  - REMOVE_FROM_STORAGE_KEY may only be present when STATUS_KEY is also present
+     *  - If REMOVE_STORAGE_KEY is true, then the value for STATUS_KEY must represent a consumed state
+     */
     private @Nullable String validateStatus(Container container, String prefix, boolean updateKeyRequired)
     {
         boolean hasStatusKey = _inputParameters.has(STATUS_KEY);
@@ -141,7 +150,7 @@ public abstract class Action extends CreatedModified
         {
             updateStatus = hasUpdateStatusKey && _inputParameters.getBoolean(UPDATE_STATUS_KEY);
         }
-        catch (Exception e)
+        catch (JSONException e)
         {
             return prefix + UPDATE_STATUS_KEY + " must be a boolean.";
         }
@@ -151,7 +160,7 @@ public abstract class Action extends CreatedModified
         {
             removeFromStorage = hasRemoveFromStorageKey && _inputParameters.getBoolean(REMOVE_FROM_STORAGE_KEY);
         }
-        catch (Exception e)
+        catch (JSONException e)
         {
             return prefix + REMOVE_FROM_STORAGE_KEY + " must be a boolean.";
         }
@@ -177,7 +186,7 @@ public abstract class Action extends CreatedModified
             {
                 statusId = _inputParameters.getLong(STATUS_KEY);
             }
-            catch (Exception e)
+            catch (JSONException e)
             {
                 return prefix + STATUS_KEY + " must be a number.";
             }
@@ -197,6 +206,11 @@ public abstract class Action extends CreatedModified
     private static boolean isSampleStatusKey(String key)
     {
         return key.equals(STATUS_KEY) || key.equals(UPDATE_STATUS_KEY) || key.equals(REMOVE_FROM_STORAGE_KEY);
+    }
+
+    private boolean hasAnySampleStatusKey()
+    {
+        return _inputParameters != null && (_inputParameters.has(UPDATE_STATUS_KEY) || _inputParameters.has(STATUS_KEY) || _inputParameters.has(REMOVE_FROM_STORAGE_KEY));
     }
 
     @JsonIgnore
@@ -258,7 +272,7 @@ public abstract class Action extends CreatedModified
                 }
             }
 
-            if (_inputParameters != null && (_inputParameters.has(UPDATE_STATUS_KEY) || _inputParameters.has(STATUS_KEY) || _inputParameters.has(REMOVE_FROM_STORAGE_KEY)))
+            if (hasAnySampleStatusKey())
             {
                 String statusMessage = validateStatus(container, prefix, true);
                 if (statusMessage != null) messages.add(statusMessage);
@@ -327,7 +341,7 @@ public abstract class Action extends CreatedModified
             if (!invalidCounts.isEmpty())
                 messages.add(prefix + "invalid sample count values " + invalidCounts + ".");
 
-            if (_inputParameters.has(UPDATE_STATUS_KEY) || _inputParameters.has(STATUS_KEY) || _inputParameters.has(REMOVE_FROM_STORAGE_KEY))
+            if (hasAnySampleStatusKey())
             {
                 String statusMessage = validateStatus(container, prefix, true);
 

--- a/api/src/org/labkey/api/workflow/Action.java
+++ b/api/src/org/labkey/api/workflow/Action.java
@@ -15,7 +15,6 @@ import org.labkey.api.util.GUID;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -27,6 +26,7 @@ public abstract class Action extends CreatedModified
     public static final String ASSAY_TYPES_KEY = "assayTypes";
     public static final String NUM_PER_PARENT_KEY = "numPerParent";
     public static final String UPDATE_STATUS_KEY = "updateStatus";
+    public static final String REMOVE_FROM_STORAGE_KEY = "removeFromStorage";
     public static final String STATUS_KEY = "sampleStatus";
     protected Long _rowId;
     protected int _ordinal;
@@ -158,6 +158,11 @@ public abstract class Action extends CreatedModified
         return Collections.emptyList();
     }
 
+    private static boolean isSampleStatusKey(String key)
+    {
+        return key.equals(STATUS_KEY) || key.equals(UPDATE_STATUS_KEY) || key.equals(REMOVE_FROM_STORAGE_KEY);
+    }
+
     @JsonIgnore
     public List<String> validateInputParameters(int ordinal, Container container)
     {
@@ -201,19 +206,29 @@ public abstract class Action extends CreatedModified
         }
         else if (_type == WorkflowService.ActionType.AliquotSamples)
         {
+            List<String> messages = new ArrayList<>();
+
             if (_inputParameters == null || !_inputParameters.has(NUM_PER_PARENT_KEY))
-                return List.of(prefix + NUM_PER_PARENT_KEY + " is required for action of type " + _type + ".");
+                messages.add(prefix + NUM_PER_PARENT_KEY + " is required for action of type " + _type + ".");
             else
             {
                 try {
                     int numPerParent = _inputParameters.getInt(NUM_PER_PARENT_KEY);
                     if (numPerParent < 0)
-                        return List.of(prefix + NUM_PER_PARENT_KEY + " cannot be negative.");
+                        messages.add(prefix + NUM_PER_PARENT_KEY + " cannot be negative.");
                 }
                 catch (Exception e) {
-                    return List.of(prefix + NUM_PER_PARENT_KEY + " must be an integer.");
+                    messages.add(prefix + NUM_PER_PARENT_KEY + " must be an integer.");
                 }
             }
+
+            if (_inputParameters != null && (_inputParameters.has(UPDATE_STATUS_KEY) || _inputParameters.has(STATUS_KEY)))
+            {
+                List<String> statusMessages = validateStatus(container, prefix, true);
+                messages.addAll(statusMessages);
+            }
+
+            return messages;
         }
         else if (_type == WorkflowService.ActionType.DeriveSamples || _type == WorkflowService.ActionType.PoolSamples)
         {
@@ -225,7 +240,7 @@ public abstract class Action extends CreatedModified
             // sample type IDs and validate against those.
             List<String> sampleTypeIds = new ArrayList<>();
             _inputParameters.keys().forEachRemaining(id -> {
-                if (id.equals(UPDATE_STATUS_KEY) || id.equals(STATUS_KEY)) return;
+                if (isSampleStatusKey(id)) return;
                 sampleTypeIds.add(id);
             });
 
@@ -243,7 +258,7 @@ public abstract class Action extends CreatedModified
             for (String id : sampleTypeIds)
             {
                 // validated above
-                if (id.equals(UPDATE_STATUS_KEY) || id.equals(STATUS_KEY)) continue;
+                if (isSampleStatusKey(id)) continue;
 
                 try
                 {

--- a/api/src/org/labkey/api/workflow/Action.java
+++ b/api/src/org/labkey/api/workflow/Action.java
@@ -15,6 +15,7 @@ import org.labkey.api.util.GUID;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -126,6 +127,37 @@ public abstract class Action extends CreatedModified
         _inputParameters = inputParameters;
     }
 
+    private List<String> validateStatus(Container container, String prefix, boolean updateKeyExpected)
+    {
+        boolean updateStatus = true;
+
+        if (updateKeyExpected)
+        {
+            updateStatus = _inputParameters.getBoolean(UPDATE_STATUS_KEY);
+            if (updateStatus && !_inputParameters.has(STATUS_KEY))
+                return List.of(prefix + STATUS_KEY + " is required for action of type " + _type + " when " + UPDATE_STATUS_KEY + " is true.");
+            if (!updateStatus && _inputParameters.has(STATUS_KEY))
+                return List.of(prefix + STATUS_KEY + " is not allowed for action of type " + _type + " when " + UPDATE_STATUS_KEY + " is false.");
+        }
+
+        if (updateStatus && container != null)
+        {
+            try
+            {
+                long statusId = _inputParameters.getLong(STATUS_KEY);
+                SampleStatusService sampleStatusService = SampleStatusService.get();
+                if (sampleStatusService.getStateForRowId(container, statusId) == null)
+                    return List.of(prefix + "Invalid " + STATUS_KEY + " (" + statusId + ").");
+            }
+            catch (Exception e)
+            {
+                return List.of(prefix + "Invalid " + STATUS_KEY + ".");
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
     @JsonIgnore
     public List<String> validateInputParameters(int ordinal, Container container)
     {
@@ -185,15 +217,34 @@ public abstract class Action extends CreatedModified
         }
         else if (_type == WorkflowService.ActionType.DeriveSamples || _type == WorkflowService.ActionType.PoolSamples)
         {
-            if (_inputParameters == null || _inputParameters.isEmpty())
-                return List.of(prefix + "data about sample types and sample counts per parent is required for action of type " + _type + ".");
-            if (_type == WorkflowService.ActionType.PoolSamples && _inputParameters.length() > 1)
+            String emptyMessage = prefix + "data about sample types and sample counts per parent is required for action of type " + _type + ".";
+
+            if (_inputParameters == null) return List.of(emptyMessage);
+
+            // We can't just check _inputParameters size because it may include sample status keys, so we extract the
+            // sample type IDs and validate against those.
+            List<String> sampleTypeIds = new ArrayList<>();
+            _inputParameters.keys().forEachRemaining(id -> {
+                if (id.equals(UPDATE_STATUS_KEY) || id.equals(STATUS_KEY)) return;
+                sampleTypeIds.add(id);
+            });
+
+            if (sampleTypeIds.isEmpty())
+                return List.of(emptyMessage);
+
+            if (_type == WorkflowService.ActionType.PoolSamples && sampleTypeIds.size() > 1)
                 return List.of(prefix + "only one sample type can be specified for action of type " + _type + ".");
+
             SampleTypeService sampleTypeService = SampleTypeService.get();
             Set<String> invalidSampleTypeIds = new HashSet<>();
             List<Object> invalidCounts = new ArrayList<>();
+            List<String> messages = new ArrayList<>();
 
-            _inputParameters.keys().forEachRemaining(id -> {
+            for (String id : sampleTypeIds)
+            {
+                // validated above
+                if (id.equals(UPDATE_STATUS_KEY) || id.equals(STATUS_KEY)) continue;
+
                 try
                 {
                     if (sampleTypeService.getSampleType(Long.valueOf(id)) == null)
@@ -204,54 +255,51 @@ public abstract class Action extends CreatedModified
                     invalidSampleTypeIds.add(id);
                 }
                 Object countObj = _inputParameters.get(id);
-                if ((countObj instanceof String))
+                if (countObj instanceof String countStr)
                     try
                     {
-                        if (Integer.parseInt((String) countObj) < 0)
+                        if (Integer.parseInt(countStr) < 0)
                             invalidCounts.add(countObj);
                     }
                     catch (NumberFormatException e)
                     {
                         invalidCounts.add(countObj);
                     }
-                else if (countObj instanceof Integer)
+                else if (countObj instanceof Integer count)
                 {
-                    if (((Integer) countObj) < 0)
+                    if (count < 0)
                         invalidCounts.add(countObj);
                 }
                 else
                     invalidCounts.add(countObj);
-            });
-            List<String> messages = new ArrayList<>();
+            }
+
             if (!invalidSampleTypeIds.isEmpty())
                 messages.add(prefix + "invalid sample type IDs " + invalidSampleTypeIds + ".");
             if (!invalidCounts.isEmpty())
                 messages.add(prefix + "invalid sample count values " + invalidCounts + ".");
+
+            if (_inputParameters.has(UPDATE_STATUS_KEY) || _inputParameters.has(STATUS_KEY))
+            {
+                List<String> statusMessages = validateStatus(container, prefix, true);
+
+                if (!statusMessages.isEmpty())
+                    messages.addAll(statusMessages);
+            }
+
             return messages;
         }
         else if (_type == WorkflowService.ActionType.RemoveFromStorage)
         {
             if (_inputParameters == null || _inputParameters.isEmpty())
                 return Collections.emptyList();
-            boolean updateStatus = _inputParameters.getBoolean(UPDATE_STATUS_KEY);
-            if (updateStatus && !_inputParameters.has(STATUS_KEY))
-                return List.of(prefix + STATUS_KEY + " is required for action of type " + _type + " when " + UPDATE_STATUS_KEY + " is true.");
-            if (!updateStatus && _inputParameters.has(STATUS_KEY))
-                return List.of(prefix + STATUS_KEY + " is not allowed for action of type " + _type + " when " + UPDATE_STATUS_KEY + " is false.");
-            if (updateStatus && container != null)
-            {
-                try
-                {
-                    long statusId = _inputParameters.getLong(STATUS_KEY);
-                    SampleStatusService sampleStatusService = SampleStatusService.get();
-                    if (sampleStatusService.getStateForRowId(container, statusId) == null)
-                        return List.of(prefix + "Invalid " + STATUS_KEY + " (" + statusId + ").");
-                }
-                catch (Exception e)
-                {
-                    return List.of(prefix + "Invalid " + STATUS_KEY + ".");
-                }
-            }
+
+            return validateStatus(container, prefix, true);
+        } else if (_type == WorkflowService.ActionType.UpdateSampleStatus) {
+            if (_inputParameters == null || _inputParameters.isEmpty())
+                return Collections.emptyList();
+
+            return validateStatus(container, prefix, false);
         } else {
             if (_inputParameters != null && !_inputParameters.isEmpty())
                 return List.of(prefix + "input parameters are not allowed for action of type " + _type + ".");

--- a/api/src/org/labkey/api/workflow/Action.java
+++ b/api/src/org/labkey/api/workflow/Action.java
@@ -137,7 +137,7 @@ public abstract class Action extends CreatedModified
      *  UPDATE_STATUS_KEY is true
      *  - STATUS_KEY is optional, but when present the value must be a valid status
      *  - REMOVE_FROM_STORAGE_KEY may only be present when STATUS_KEY is also present
-     *  - If REMOVE_STORAGE_KEY is true, then the value for STATUS_KEY must represent a consumed state
+     *  - If REMOVE_FROM_STORAGE_KEY is true, then the value for STATUS_KEY must represent a consumed state
      */
     private @Nullable String validateStatus(Container container, String prefix, boolean updateKeyRequired)
     {
@@ -194,7 +194,7 @@ public abstract class Action extends CreatedModified
             DataState state = SampleStatusService.get().getStateForRowId(container, statusId);
 
             if (state == null)
-                return prefix + "Invalid " + STATUS_KEY + " (" + statusId + ").";
+                return prefix + "Invalid " + STATUS_KEY + " (" + statusId + ") for container " + container.getPath() + ".";
 
             if (removeFromStorage && !ExpSchema.SampleStateType.Consumed.name().equals(state.getStateType()))
                 return prefix + STATUS_KEY + " (" + statusId + ") must represent a " + ExpSchema.SampleStateType.Consumed.name() + " state when " + REMOVE_FROM_STORAGE_KEY + " is true.";

--- a/api/src/org/labkey/api/workflow/Action.java
+++ b/api/src/org/labkey/api/workflow/Action.java
@@ -2,6 +2,7 @@ package org.labkey.api.workflow;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.data.Container;
@@ -129,50 +130,68 @@ public abstract class Action extends CreatedModified
         _inputParameters = inputParameters;
     }
 
-    private List<String> validateStatus(Container container, String prefix, boolean updateKeyExpected)
+    private @Nullable String validateStatus(Container container, String prefix, boolean updateKeyRequired)
     {
-        boolean updateStatus = true;
-        boolean removeFromStorage = _inputParameters.has(REMOVE_FROM_STORAGE_KEY) && _inputParameters.getBoolean(REMOVE_FROM_STORAGE_KEY);
+        boolean hasStatusKey = _inputParameters.has(STATUS_KEY);
+        boolean hasUpdateStatusKey = _inputParameters.has(UPDATE_STATUS_KEY);
+        boolean hasRemoveFromStorageKey = _inputParameters.has(REMOVE_FROM_STORAGE_KEY);
 
-        if (updateKeyExpected)
+        boolean updateStatus;
+        try
         {
-            updateStatus = _inputParameters.has(UPDATE_STATUS_KEY) && _inputParameters.getBoolean(UPDATE_STATUS_KEY);
-            if (updateStatus && !_inputParameters.has(STATUS_KEY))
-                return List.of(prefix + STATUS_KEY + " is required for action of type " + _type + " when " + UPDATE_STATUS_KEY + " is true.");
-            if (!updateStatus && _inputParameters.has(STATUS_KEY))
-                return List.of(prefix + STATUS_KEY + " is not allowed for action of type " + _type + " when " + UPDATE_STATUS_KEY + " is false.");
+            updateStatus = hasUpdateStatusKey && _inputParameters.getBoolean(UPDATE_STATUS_KEY);
+        }
+        catch (Exception e)
+        {
+            return prefix + UPDATE_STATUS_KEY + " must be a boolean.";
         }
 
-        if (removeFromStorage && !_inputParameters.has(STATUS_KEY))
-            return List.of(prefix + STATUS_KEY + " is required for action of type " + _type + " when " + REMOVE_FROM_STORAGE_KEY + " is true.");
-
-        if ((updateStatus || removeFromStorage) && _inputParameters.has(STATUS_KEY) && container != null)
+        boolean removeFromStorage;
+        try
         {
-            DataState state;
+            removeFromStorage = hasRemoveFromStorageKey && _inputParameters.getBoolean(REMOVE_FROM_STORAGE_KEY);
+        }
+        catch (Exception e)
+        {
+            return prefix + REMOVE_FROM_STORAGE_KEY + " must be a boolean.";
+        }
+
+        // If we're expecting an UPDATE_STATUS_KEY (aliquot / derive / pool actions), then the key must be present and
+        // set to true in order for us to honor the STATUS_KEY and REMOVE_FROM_STORAGE_KEY.
+        if (updateKeyRequired && !updateStatus)
+        {
+            if (hasStatusKey)
+                return prefix + STATUS_KEY + " is not allowed for action of type " + _type + " when " + UPDATE_STATUS_KEY + " is false.";
+
+            if (hasRemoveFromStorageKey)
+                return prefix + REMOVE_FROM_STORAGE_KEY + " is not allowed for action of type " + _type + " when " + UPDATE_STATUS_KEY + " is false.";
+        }
+
+        if (removeFromStorage && !hasStatusKey)
+            return prefix + STATUS_KEY + " is required for action of type " + _type + " when " + REMOVE_FROM_STORAGE_KEY + " is true.";
+
+        if (hasStatusKey && container != null)
+        {
             long statusId;
             try
             {
                 statusId = _inputParameters.getLong(STATUS_KEY);
-                state = SampleStatusService.get().getStateForRowId(container, statusId);
             }
             catch (Exception e)
             {
-                return List.of(prefix + "Invalid " + STATUS_KEY + ".");
+                return prefix + STATUS_KEY + " must be a number.";
             }
 
+            DataState state = SampleStatusService.get().getStateForRowId(container, statusId);
+
             if (state == null)
-                return List.of(prefix + "Invalid " + STATUS_KEY + " (" + statusId + ").");
+                return prefix + "Invalid " + STATUS_KEY + " (" + statusId + ").";
 
             if (removeFromStorage && !ExpSchema.SampleStateType.Consumed.name().equals(state.getStateType()))
-                return List.of(prefix + STATUS_KEY + " (" + statusId + ") must represent a " + ExpSchema.SampleStateType.Consumed.name() + " state when " + REMOVE_FROM_STORAGE_KEY + " is true.");
-        }
-        else if (!updateKeyExpected && !_inputParameters.has(STATUS_KEY) && !removeFromStorage)
-        {
-            // UpdateSampleStatus with non-empty params but no STATUS_KEY or REMOVE_FROM_STORAGE_KEY is invalid
-            return List.of(prefix + "Invalid " + STATUS_KEY + ".");
+                return prefix + STATUS_KEY + " (" + statusId + ") must represent a " + ExpSchema.SampleStateType.Consumed.name() + " state when " + REMOVE_FROM_STORAGE_KEY + " is true.";
         }
 
-        return Collections.emptyList();
+        return null;
     }
 
     private static boolean isSampleStatusKey(String key)
@@ -241,8 +260,8 @@ public abstract class Action extends CreatedModified
 
             if (_inputParameters != null && (_inputParameters.has(UPDATE_STATUS_KEY) || _inputParameters.has(STATUS_KEY) || _inputParameters.has(REMOVE_FROM_STORAGE_KEY)))
             {
-                List<String> statusMessages = validateStatus(container, prefix, true);
-                messages.addAll(statusMessages);
+                String statusMessage = validateStatus(container, prefix, true);
+                if (statusMessage != null) messages.add(statusMessage);
             }
 
             return messages;
@@ -274,9 +293,6 @@ public abstract class Action extends CreatedModified
 
             for (String id : sampleTypeIds)
             {
-                // validated above
-                if (isSampleStatusKey(id)) continue;
-
                 try
                 {
                     if (sampleTypeService.getSampleType(Long.valueOf(id)) == null)
@@ -313,26 +329,27 @@ public abstract class Action extends CreatedModified
 
             if (_inputParameters.has(UPDATE_STATUS_KEY) || _inputParameters.has(STATUS_KEY) || _inputParameters.has(REMOVE_FROM_STORAGE_KEY))
             {
-                List<String> statusMessages = validateStatus(container, prefix, true);
+                String statusMessage = validateStatus(container, prefix, true);
 
-                if (!statusMessages.isEmpty())
-                    messages.addAll(statusMessages);
+                if (statusMessage != null) messages.add(statusMessage);
             }
 
             return messages;
         }
-        else if (_type == WorkflowService.ActionType.RemoveFromStorage)
+        else if (_type == WorkflowService.ActionType.RemoveFromStorage || _type == WorkflowService.ActionType.UpdateSampleStatus)
         {
             if (_inputParameters == null || _inputParameters.isEmpty())
                 return Collections.emptyList();
 
-            return validateStatus(container, prefix, true);
-        } else if (_type == WorkflowService.ActionType.UpdateSampleStatus) {
-            if (_inputParameters == null || _inputParameters.isEmpty())
-                return Collections.emptyList();
+            boolean updateKeyRequired = _type == WorkflowService.ActionType.RemoveFromStorage;
+            String statusMessage = validateStatus(container, prefix, updateKeyRequired);
 
-            return validateStatus(container, prefix, false);
-        } else {
+            if (statusMessage != null) return List.of(statusMessage);
+
+            return Collections.emptyList();
+        }
+        else
+        {
             if (_inputParameters != null && !_inputParameters.isEmpty())
                 return List.of(prefix + "input parameters are not allowed for action of type " + _type + ".");
         }

--- a/api/src/org/labkey/api/workflow/Action.java
+++ b/api/src/org/labkey/api/workflow/Action.java
@@ -10,6 +10,8 @@ import org.labkey.api.data.CreatedModified;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.SampleTypeService;
+import org.labkey.api.exp.query.ExpSchema;
+import org.labkey.api.qc.DataState;
 import org.labkey.api.qc.SampleStatusService;
 import org.labkey.api.util.GUID;
 
@@ -130,29 +132,44 @@ public abstract class Action extends CreatedModified
     private List<String> validateStatus(Container container, String prefix, boolean updateKeyExpected)
     {
         boolean updateStatus = true;
+        boolean removeFromStorage = _inputParameters.has(REMOVE_FROM_STORAGE_KEY) && _inputParameters.getBoolean(REMOVE_FROM_STORAGE_KEY);
 
         if (updateKeyExpected)
         {
-            updateStatus = _inputParameters.getBoolean(UPDATE_STATUS_KEY);
+            updateStatus = _inputParameters.has(UPDATE_STATUS_KEY) && _inputParameters.getBoolean(UPDATE_STATUS_KEY);
             if (updateStatus && !_inputParameters.has(STATUS_KEY))
                 return List.of(prefix + STATUS_KEY + " is required for action of type " + _type + " when " + UPDATE_STATUS_KEY + " is true.");
             if (!updateStatus && _inputParameters.has(STATUS_KEY))
                 return List.of(prefix + STATUS_KEY + " is not allowed for action of type " + _type + " when " + UPDATE_STATUS_KEY + " is false.");
         }
 
-        if (updateStatus && container != null)
+        if (removeFromStorage && !_inputParameters.has(STATUS_KEY))
+            return List.of(prefix + STATUS_KEY + " is required for action of type " + _type + " when " + REMOVE_FROM_STORAGE_KEY + " is true.");
+
+        if ((updateStatus || removeFromStorage) && _inputParameters.has(STATUS_KEY) && container != null)
         {
+            DataState state;
+            long statusId;
             try
             {
-                long statusId = _inputParameters.getLong(STATUS_KEY);
-                SampleStatusService sampleStatusService = SampleStatusService.get();
-                if (sampleStatusService.getStateForRowId(container, statusId) == null)
-                    return List.of(prefix + "Invalid " + STATUS_KEY + " (" + statusId + ").");
+                statusId = _inputParameters.getLong(STATUS_KEY);
+                state = SampleStatusService.get().getStateForRowId(container, statusId);
             }
             catch (Exception e)
             {
                 return List.of(prefix + "Invalid " + STATUS_KEY + ".");
             }
+
+            if (state == null)
+                return List.of(prefix + "Invalid " + STATUS_KEY + " (" + statusId + ").");
+
+            if (removeFromStorage && !ExpSchema.SampleStateType.Consumed.name().equals(state.getStateType()))
+                return List.of(prefix + STATUS_KEY + " (" + statusId + ") must represent a " + ExpSchema.SampleStateType.Consumed.name() + " state when " + REMOVE_FROM_STORAGE_KEY + " is true.");
+        }
+        else if (!updateKeyExpected && !_inputParameters.has(STATUS_KEY) && !removeFromStorage)
+        {
+            // UpdateSampleStatus with non-empty params but no STATUS_KEY or REMOVE_FROM_STORAGE_KEY is invalid
+            return List.of(prefix + "Invalid " + STATUS_KEY + ".");
         }
 
         return Collections.emptyList();
@@ -222,7 +239,7 @@ public abstract class Action extends CreatedModified
                 }
             }
 
-            if (_inputParameters != null && (_inputParameters.has(UPDATE_STATUS_KEY) || _inputParameters.has(STATUS_KEY)))
+            if (_inputParameters != null && (_inputParameters.has(UPDATE_STATUS_KEY) || _inputParameters.has(STATUS_KEY) || _inputParameters.has(REMOVE_FROM_STORAGE_KEY)))
             {
                 List<String> statusMessages = validateStatus(container, prefix, true);
                 messages.addAll(statusMessages);
@@ -294,7 +311,7 @@ public abstract class Action extends CreatedModified
             if (!invalidCounts.isEmpty())
                 messages.add(prefix + "invalid sample count values " + invalidCounts + ".");
 
-            if (_inputParameters.has(UPDATE_STATUS_KEY) || _inputParameters.has(STATUS_KEY))
+            if (_inputParameters.has(UPDATE_STATUS_KEY) || _inputParameters.has(STATUS_KEY) || _inputParameters.has(REMOVE_FROM_STORAGE_KEY))
             {
                 List<String> statusMessages = validateStatus(container, prefix, true);
 

--- a/api/src/org/labkey/api/workflow/WorkflowService.java
+++ b/api/src/org/labkey/api/workflow/WorkflowService.java
@@ -29,7 +29,8 @@ public interface WorkflowService
         MoveInStorage("input parameters", "Moved samples in storage"),
         CheckOut("input parameters", "Checked out samples"),
         CheckIn("input parameters", "Checked in samples"),
-        RemoveFromStorage("sample status value", "Removed samples from storage");
+        RemoveFromStorage("sample status value", "Removed samples from storage"),
+        UpdateSampleStatus("sample status value", "Updated sample status");
 
         private final String _inputDescription;
         private final String _auditMessage;

--- a/api/src/org/labkey/api/workflow/WorkflowService.java
+++ b/api/src/org/labkey/api/workflow/WorkflowService.java
@@ -2,6 +2,7 @@ package org.labkey.api.workflow;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.query.ValidationException;
@@ -9,7 +10,6 @@ import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
 
 import java.util.Map;
-import org.jetbrains.annotations.Nullable;
 
 public interface WorkflowService
 {
@@ -66,7 +66,7 @@ public interface WorkflowService
 
     void populateConfigParams(HttpServletRequest request, Map<Enum, Object> configParameters) throws ValidationException;
     Map<String, Object> getConfigParameters(HttpServletRequest request) throws ValidationException;
-    void onActionComplete(@NotNull Container container, @NotNull User user, @NotNull Long actionId);
+    void onActionComplete(@NotNull Container container, @NotNull User user, @NotNull Long actionId, @Nullable String userAuditComment);
     void onActionComplete(@NotNull Container container, @NotNull User user, @NotNull Long taskId, @NotNull ActionType actionType);
     boolean actionWillAddSamples(Long actionId);
 

--- a/api/src/org/labkey/api/workflow/WorkflowService.java
+++ b/api/src/org/labkey/api/workflow/WorkflowService.java
@@ -68,6 +68,7 @@ public interface WorkflowService
     Map<String, Object> getConfigParameters(HttpServletRequest request) throws ValidationException;
     void onActionComplete(@NotNull Container container, @NotNull User user, @NotNull Long actionId);
     void onActionComplete(@NotNull Container container, @NotNull User user, @NotNull Long taskId, @NotNull ActionType actionType);
+    boolean actionWillAddSamples(Long actionId);
 
     DataIteratorBuilder getSampleCreationDataIteratorBuilder(DataIteratorBuilder data, Container container, User user);
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -420,7 +420,13 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             {
                 if (context.getConfigParameter(WorkflowService.WorkflowConfigs.ActionId) != null)
                 {
-                    dib = workService.getSampleCreationDataIteratorBuilder(dib, userSchema.getContainer(), userSchema.getUser());
+                    Long actionId = (Long) context.getConfigParameter(WorkflowService.WorkflowConfigs.ActionId);
+
+                    if (WorkflowService.get().actionWillAddSamples(actionId))
+                    {
+                        dib = workService.getSampleCreationDataIteratorBuilder(dib, userSchema.getContainer(), userSchema.getUser());
+                    }
+
                     dib = workService.getActionAuditDataIteratorBuilder(dib, userSchema.getContainer(), userSchema.getUser());
                 }
             }


### PR DESCRIPTION
Add validation for sample status changes during Aliquot/Derive/Pool actions

#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/953
- https://github.com/LabKey/platform/pull/7667
- https://github.com/LabKey/limsModules/pull/2207
- https://github.com/LabKey/testAutomation/pull/3007

#### Changes
- Add UpdateSampleStatus action type
- Add validation for UpdateSampleStatus
  - Share validation logic for Derive, Pool, Aliquot, and Remove from Storage actions


#### Tasks 📍
- [x] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation


