### PR TITLE
Query metadata editor: use AppContexts

### DIFF
--- a/core/src/client/QueryMetadataEditor/QueryMetadataEditor.tsx
+++ b/core/src/client/QueryMetadataEditor/QueryMetadataEditor.tsx
@@ -15,9 +15,10 @@
  */
 
 import { List } from 'immutable';
-import React, { PureComponent } from 'react';
+import React, { FC, PureComponent } from 'react';
 import {
     Alert,
+    AppContexts,
     BeforeUnload,
     DomainDesign,
     DomainField,
@@ -25,7 +26,6 @@ import {
     IBannerMessage,
     LoadingSpinner,
     Modal,
-    withServerContext,
     IFieldChange,
 } from '@labkey/components';
 import { ActionURL, getServerContext } from '@labkey/api';
@@ -435,4 +435,8 @@ class QueryMetadataEditor extends PureComponent<any, Partial<IAppState>> {
     }
 }
 
-export const App = withServerContext(QueryMetadataEditor);
+export const App: FC = () => (
+    <AppContexts includeGlobalState={false}>
+        <QueryMetadataEditor />
+    </AppContexts>
+);


### PR DESCRIPTION
#### Rationale
Use `<AppContexts />` to supply server and application context to components under the `<QueryMetadataEditor />`. This was a case I missed in the refactor from #7665.

#### Related Pull Requests
- #7665

#### Changes
- Use `AppContexts` in lieu of `withServerContext` to supply application context
