### PR TITLE
Prohibit HTTP GET parameters for jsessionid

### DIFF
--- a/api/webapp/WEB-INF/web.xml
+++ b/api/webapp/WEB-INF/web.xml
@@ -58,6 +58,11 @@
         <url-pattern>*.post</url-pattern>
     </filter-mapping>
 
+    <!-- Ensure that we never use GET parameters for session IDs -->
+    <session-config>
+        <tracking-mode>COOKIE</tracking-mode>
+    </session-config>
+
     <welcome-file-list>
         <welcome-file>/</welcome-file>
     </welcome-file-list>


### PR DESCRIPTION
#### Rationale
Servers that run both HTTP and HTTPS can end up choosing to send `jsessionid` values as GET parameters, because they may have an HTTP cookie that set to `Secure`. In scenarios like this, we want to be sure that we end up redirecting the client to HTTPS. We don't want session IDs to ever leak onto the URL.

#### Changes
- Tell Tomcat to only use cookies for communicating sessions

#### Tasks 📍
- [x] Claude Code Review
- [x] Manual Testing @labkey-tchad 
  - Configure HTTPS via `application.properties`
  - Enable a separate HTTP port
  - Don't have HTTP->HTTPS redirect enabled in Site Settings
  - Log in via HTTPS
  - Hit the server via HTTP
  - Ensure you don't see a session on the URL 
- ~Test Automation~
- ~Verify Fix~