### PR TITLE
Removing obsolete code that was hitting a deleted table

### DIFF
--- a/api/src/org/labkey/api/visualization/VisDataRequest.java
+++ b/api/src/org/labkey/api/visualization/VisDataRequest.java
@@ -476,8 +476,6 @@ public class VisDataRequest
         String interval;
         Measure dateCol;
         Measure zeroDateCol;
-        String zeroDayVisitTag;
-        boolean isZeroDayVisitTagSet=false;  // for json compatibility
         boolean useProtocolDay=true;
         String altQueryName;
 
@@ -512,23 +510,6 @@ public class VisDataRequest
         {
             this.zeroDateCol = zeroDateCol;
             return this;
-        }
-
-        public String getZeroDayVisitTag()
-        {
-            return zeroDayVisitTag;
-        }
-
-        public DateOptions setZeroDayVisitTag(String zeroDayVisitTag)
-        {
-            this.isZeroDayVisitTagSet = true;
-            this.zeroDayVisitTag = zeroDayVisitTag;
-            return this;
-        }
-
-        public boolean isZeroDayVisitTagSet()
-        {
-            return isZeroDayVisitTagSet;
         }
 
         public boolean isUseProtocolDay()

--- a/api/src/org/labkey/api/visualization/VisualizationSourceColumn.java
+++ b/api/src/org/labkey/api/visualization/VisualizationSourceColumn.java
@@ -135,16 +135,6 @@ public class VisualizationSourceColumn
             return findOrAdd(col);
         }
 
-        public VisualizationSourceColumn create(UserSchema schema, String queryName, String name, Boolean allowNullResults, VisDataRequest.DateOptions dateOptions)
-        {
-            String encodedQueryName = queryName + "-" + (dateOptions.isUseProtocolDay() ? "true" : "false") + "-" + dateOptions.getZeroDayVisitTag();
-            if (dateOptions.getAltQueryName() != null)
-                encodedQueryName += "-" + dateOptions.getAltQueryName();
-
-            VisualizationSourceColumn col = new VisualizationSourceColumn(schema, encodedQueryName, name, allowNullResults, false);
-            return findOrAdd(col);
-        }
-
         public VisualizationSourceColumn getByAlias(String alias)
         {
             return _aliasMap.get(alias);

--- a/visualization/src/org/labkey/visualization/VisualizationController.java
+++ b/visualization/src/org/labkey/visualization/VisualizationController.java
@@ -1732,7 +1732,6 @@ public class VisualizationController extends SpringActionController
             assertEquals("day",dopt.getInterval());
             assertEquals("visitday", dopt.getDateCol().getName());
             assertEquals("enrolldate", dopt.getZeroDateCol().getName());
-            assertEquals("ZERO", dopt.getZeroDayVisitTag());
             assertFalse(dopt.isUseProtocolDay());
             assertEquals(0,mi.getFilterArray().size());
             assertEquals(1, vs.getSorts().size());

--- a/visualization/src/org/labkey/visualization/sql/VisualizationSQLGenerator.java
+++ b/visualization/src/org/labkey/visualization/sql/VisualizationSQLGenerator.java
@@ -241,23 +241,9 @@ public class VisualizationSQLGenerator implements HasViewContext
 
                                 newInterval = new VisualizationIntervalColumn(zeroDateCol, dateCol, interval, false);
                             }
-                            else if (dateOptions.isZeroDayVisitTagSet())
-                            {
-                                VisualizationSourceColumn zeroDayCol = null;
-                                boolean useProtocolDay = dateOptions.isUseProtocolDay();
-
-                                //  Issue 20459: handle 'Unaligned' (i.e. null zero day) case for calculating weeks/months
-                                if (null != dateOptions.getZeroDayVisitTag())
-                                {
-                                    zeroDayCol = _columnFactory.create(getPrimarySchema(), "VisualizationVisitTag", "ZeroDay", false, dateOptions);
-                                    ensureSourceQuery(_viewContext.getContainer(), zeroDayCol, query).addSelect(zeroDayCol, false);
-                                }
-
-                                newInterval = new VisualizationIntervalColumn(zeroDayCol, measureCol, interval, true);
-                            }
                             else
                             {
-                                throw new IllegalArgumentException("The 'zeroDayVisitTag' property or the 'dateCol' and 'zeroDateCol' properties are required.");
+                                throw new IllegalArgumentException("Either 'dateCol' or 'zeroDateCol' must be specified for date-based charts");
                             }
 
                             if (interval != null)


### PR DESCRIPTION
#### Rationale
A `claude` code analysis revealed a usage that was not detected when we initially deleted the `VisualizationVisitTag` table. It was thought that there might be some reliance on that code in the CDS application but further analysis concluded that no test or product code from that application relies on this.

We can safely remove this (and related) code.

#### Tasks 📍
- [x] Claude Code Review
