### PR TITLE
ProcessBuilder -> LabKeyProcessBuilder

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -53,6 +53,7 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.Job;
 import org.labkey.api.util.JsonUtil;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.QuietCloser;
 import org.labkey.api.util.URLHelper;
@@ -81,7 +82,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.sql.Time;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -101,7 +101,7 @@ import java.util.concurrent.atomic.AtomicLong;
 @JsonIgnoreProperties(value={"_logFilePathName"}, allowGetters = true)  //Property removed. Added here for backwards compatibility
 abstract public class PipelineJob extends Job implements Serializable, ContainerUser
 {
-    public static final FileType FT_LOG = new FileType(Arrays.asList(".log"), ".log", Arrays.asList("text/plain"));
+    public static final FileType FT_LOG = new FileType(List.of(".log"), ".log", List.of("text/plain"));
 
     public static final String PIPELINE_EMAIL_ADDRESS_PARAM = "pipeline, email address";
     public static final String PIPELINE_USERNAME_PARAM = "pipeline, username";
@@ -1259,7 +1259,7 @@ abstract public class PipelineJob extends Job implements Serializable, Container
         }
     }
 
-    public void runSubProcess(ProcessBuilder pb, FileLike dirWork) throws PipelineJobException
+    public void runSubProcess(LabKeyProcessBuilder pb, FileLike dirWork) throws PipelineJobException
     {
         runSubProcess(pb, dirWork, null, 0, false);
     }
@@ -1268,13 +1268,13 @@ abstract public class PipelineJob extends Job implements Serializable, Container
      * If logLineInterval is greater than 1, the first logLineInterval lines of output will be written to the
      * job's main log file.
      */
-    public void runSubProcess(ProcessBuilder pb, FileLike dirWork, FileLike outputFile, int logLineInterval, boolean append)
+    public void runSubProcess(LabKeyProcessBuilder pb, FileLike dirWork, FileLike outputFile, int logLineInterval, boolean append)
             throws PipelineJobException
     {
         runSubProcess(pb, dirWork, outputFile, logLineInterval, append, 0, null);
     }
 
-    public void runSubProcess(ProcessBuilder pb, FileLike dirWork, FileLike outputFile, int logLineInterval, boolean append, long timeout, TimeUnit timeoutUnit)
+    public void runSubProcess(LabKeyProcessBuilder pb, FileLike dirWork, FileLike outputFile, int logLineInterval, boolean append, long timeout, TimeUnit timeoutUnit)
             throws PipelineJobException
     {
         Process proc;

--- a/api/src/org/labkey/api/util/LabKeyProcessBuilder.java
+++ b/api/src/org/labkey/api/util/LabKeyProcessBuilder.java
@@ -100,4 +100,9 @@ public class LabKeyProcessBuilder
         return lc.contains("secret") || lc.contains("password") || lc.contains("apikey") || lc.contains("_key") || lc.contains("token") ||
                 (secrets != null && secrets.isRegisteredSecret(propertyName));
     }
+
+    public void redirectOutput(ProcessBuilder.Redirect redirect)
+    {
+        _pb.redirectOutput(redirect);
+    }
 }

--- a/api/src/org/labkey/api/util/LabKeyProcessBuilder.java
+++ b/api/src/org/labkey/api/util/LabKeyProcessBuilder.java
@@ -6,6 +6,7 @@ import org.labkey.api.services.ServiceRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -16,8 +17,7 @@ import java.util.Map;
  * <p>Variables are removed (silently) if their name:
  * <ul>
  *   <li>matches any property name registered with {@link SecretService}, or</li>
- *   <li>contains "secret" (case-insensitive), or</li>
- *   <li>contains "password" (case-insensitive).</li>
+ *   <li>contains (case-insensitive) any of "secret", "password", "apikey", "_key", or "token".</li>
  * </ul>
  *
  * <p>Use this class wherever {@link ProcessBuilder} would otherwise be used. An IntelliJ inspection
@@ -96,13 +96,14 @@ public class LabKeyProcessBuilder
     public static boolean isSecret(String propertyName)
     {
         SecretService secrets = ServiceRegistry.get().getService(SecretService.class);
-        String lc = propertyName.toLowerCase();
+        String lc = propertyName.toLowerCase(Locale.ROOT);
         return lc.contains("secret") || lc.contains("password") || lc.contains("apikey") || lc.contains("_key") || lc.contains("token") ||
                 (secrets != null && secrets.isRegisteredSecret(propertyName));
     }
 
-    public void redirectOutput(ProcessBuilder.Redirect redirect)
+    public LabKeyProcessBuilder redirectOutput(ProcessBuilder.Redirect redirect)
     {
         _pb.redirectOutput(redirect);
+        return this;
     }
 }

--- a/pipeline/src/org/labkey/pipeline/analysis/CommandTaskImpl.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/CommandTaskImpl.java
@@ -622,7 +622,7 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
             // Input file location must be determined before creating the process command.
             if (!_factory.getInputPaths().isEmpty())
             {
-                try (WorkDirectory.CopyingResource lock = _wd.ensureCopyingLock())
+                try (WorkDirectory.CopyingResource _ = _wd.ensureCopyingLock())
                 {
                     for (Map.Entry<String, TaskPath> entry : _factory.getInputPaths().entrySet())
                     {
@@ -733,7 +733,7 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
         action.setStartTime(new Date());
         action.addParameter(RecordedAction.COMMAND_LINE_PARAM, commandLine);
         int timeout = _factory._timeout != null ? _factory._timeout : 0;
-        getJob().runSubProcess(pb.processBuilder(), _wd.getDir(), fileOutput, lineInterval, false, timeout, TimeUnit.SECONDS);
+        getJob().runSubProcess(pb, _wd.getDir(), fileOutput, lineInterval, false, timeout, TimeUnit.SECONDS);
         action.setEndTime(new Date());
         return true;
     }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -70,6 +70,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.JunitUtil;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.MinorConfigurationException;
 import org.labkey.api.util.NetworkDrive;
@@ -945,7 +946,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
     private String getToolsPath()
     {
         String toolsDir = getAppProperties().getToolsDirectory();
-        CaseInsensitiveHashMap<String> ciEnvMap = new CaseInsensitiveHashMap<>((new ProcessBuilder()).environment());
+        CaseInsensitiveHashMap<String> ciEnvMap = new CaseInsensitiveHashMap<>((new LabKeyProcessBuilder()).environment());
         String path = ciEnvMap.get("PATH");
         return toolsDir + File.pathSeparator + path;
     }


### PR DESCRIPTION
#### Rationale
We want to consistently use our own `ProcessBuilder` variant, `LabKeyProcessBuilder` to standardize the environment variables we pass to forked processes.

#### Changes
- Adopt LabKeyProcessBuilder
- Misc cleanup

#### Tasks 📍
- [x] Claude Code Review
- ~Manual Testing~
- ~Test Automation~
