### PR TITLE
GitHub Issue 1188: Stop JDBC caching by default in QueryService

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -240,7 +240,7 @@ public abstract class AbstractAssayProvider implements AssayProvider
             ColumnInfo rowIdColumn = columns.get(objectIdFK);
             ColumnInfo runLSIDColumn = columns.get(runLSIDFK);
 
-            SQLFragment sql = QueryService.get().getSelectSQL(dataTable, columns.values(), filter, null, Table.ALL_ROWS, Table.NO_OFFSET, false);
+            SQLFragment sql = QueryService.get().getSelectBuilder(dataTable).columns(columns.values()).filter(filter).buildSqlFragment();
 
             List<Map<String, Object>> dataMaps = new ArrayList<>();
             Container sourceContainer = null;

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -2128,7 +2128,7 @@ public class DataRegion extends DisplayElement
         for (Map.Entry<FieldKey, ColumnInfo> entry : selectKeyMap.entrySet())
         {
             ColumnInfo col = entry.getValue();
-            SQLFragment selectSql = service.getSelectSQL(table, Collections.singletonList(col), pkFilter, null, Table.ALL_ROWS, Table.NO_OFFSET, false, queryLogging);
+            SQLFragment selectSql = service.getSelectBuilder(table).columns(Collections.singletonList(col)).filter(pkFilter).queryLogging(queryLogging).buildSqlFragment();
 
             SQLFragment sql = new SQLFragment("SELECT DISTINCT ").appendIdentifier(col.getAlias()).append(" AS value FROM (");
             sql.append(selectSql);

--- a/api/src/org/labkey/api/data/GroupTableInfo.java
+++ b/api/src/org/labkey/api/data/GroupTableInfo.java
@@ -95,7 +95,7 @@ public class GroupTableInfo extends VirtualTable
         sql.append("\nFROM (\n");
         TableInfo source = getSourceTable();
 
-        sql.append(QueryService.get().getSelectSQL(source, getDistinctColumns(), _sourceFilter, null, Table.ALL_ROWS, Table.NO_OFFSET, false));
+        sql.append(QueryService.get().getSelectBuilder(source).columns(getDistinctColumns()).filter(_sourceFilter).buildSqlFragment());
         sql.append("\n) AS ");
         sql.append(ALIAS_SOURCE);
 

--- a/api/src/org/labkey/api/data/NestedRenderContext.java
+++ b/api/src/org/labkey/api/data/NestedRenderContext.java
@@ -111,8 +111,8 @@ public class NestedRenderContext extends RenderContext
             fromSQL.append(" ) FilterOnly ");
 
             Collection<ColumnInfo> cols = Collections.singletonList(groupColumn);
-            SQLFragment withoutSort = QueryService.get().getSelectSQL(tinfo, cols, new SimpleFilter(), new Sort(), Table.ALL_ROWS, Table.NO_OFFSET, false);
-            SQLFragment withSort = QueryService.get().getSelectSQL(tinfo, cols, new SimpleFilter(), groupingSort, Table.ALL_ROWS, Table.NO_OFFSET, false);
+            SQLFragment withoutSort = QueryService.get().getSelectBuilder(tinfo).columns(cols).buildSqlFragment();
+            SQLFragment withSort = QueryService.get().getSelectBuilder(tinfo).columns(cols).sort(groupingSort).buildSqlFragment();
 
             // Figure out what the ORDER BY is
             String sortSQL = withSort.getSQL().substring(withSort.getSQL().toUpperCase().lastIndexOf("ORDER BY"));
@@ -205,7 +205,7 @@ public class NestedRenderContext extends RenderContext
 
         // We need to stick the GROUP BY before the ORDER BY. QueryService won't help us generate
         // the GROUP BY, so get the query with and without the ORDER BY
-        SQLFragment withoutSort = QueryService.get().getSelectSQL(tinfo, cols, filter, new Sort(), Table.ALL_ROWS, Table.NO_OFFSET, false);
+        SQLFragment withoutSort = QueryService.get().getSelectBuilder(tinfo).columns(cols).filter(filter).buildSqlFragment();
 
         sql.append(withoutSort);
 

--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -1240,7 +1240,7 @@ public class Table
 
     public static SQLFragment getSelectSQL(TableInfo table, @Nullable Collection<ColumnInfo> columns, @Nullable Filter filter, @Nullable Sort sort)
     {
-        return QueryService.get().getSelectSQL(table, columns, filter, sort, ALL_ROWS, NO_OFFSET, false);
+        return QueryService.get().getSelectBuilder(table).columns(columns).filter(filter).sort(sort).buildSqlFragment();
     }
 
     public static void ensureRequiredColumns(TableInfo table, Map<FieldKey, ColumnInfo> cols, @Nullable Filter filter, @Nullable Sort sort, @Nullable List<Aggregate> aggregates)

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -618,9 +618,9 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
             {
                 Map<FieldKey, ColumnInfo> map = getDisplayColumnsList(_columns);
 
-                // QueryService.getSelectSQL() also calls ensureRequiredColumns, so this call is redundant. However, we
-                // need to know the actual select columns (e.g., if the caller is building a Results) and getSelectSQL()
-                // doesn't return them. TODO: Provide a way to return the selected columns from getSelectSQL()
+                // SelectBuilderImpl.buildSqlFragment() also calls ensureRequiredColumns, so this call is redundant.
+                // However, we need to know the actual select columns (e.g., if the caller is building a Results)
+                // and buildSqlFragment() doesn't return them.
                 Table.ensureRequiredColumns(_table, map, _filter, _sort, null);
                 _columns = map.values();
             }
@@ -646,7 +646,7 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
             }
 
             int selectMaxRows = (Table.ALL_ROWS == _maxRows || Table.NO_ROWS == _maxRows) ? _maxRows : (int)_scrollOffset + _maxRows + _extraRows;
-            SQLFragment sql = QueryService.get().getSelectSQL(_table, _columns, _filter, _sort, selectMaxRows, selectOffset, forceSort, getQueryLogging());
+            SQLFragment sql = QueryService.get().getSelectBuilder(_table).columns(_columns).filter(_filter).sort(_sort).maxRows(selectMaxRows).offset(selectOffset).forceSort(forceSort).queryLogging(getQueryLogging()).buildSqlFragment();
 
             // This is for SAS, which doesn't support a SQL LIMIT syntax, so we must set Statement.maxRows() instead
             _statementMaxRows = _table.getSqlDialect().requiresStatementMaxRows() ? selectMaxRows : null;

--- a/api/src/org/labkey/api/dataiterator/QueryDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/QueryDataIteratorBuilder.java
@@ -162,7 +162,7 @@ public class QueryDataIteratorBuilder implements DataIteratorBuilder
         try
         {
             var select = qs.getSelectBuilder(t).columns(selectCols).filter(_filter);
-            ResultSet rs = select.select(_parameters, false);
+            ResultSet rs = select.select(false, _parameters);
             return new ResultSetDataIterator(rs, context);
         }
         catch (QueryParseException x)

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -260,24 +260,15 @@ public interface QueryService
     Results select(QuerySchema schema, String sql, @Nullable Map<String, TableInfo> tableMap, boolean strictColumnList, boolean cached);
 
     /** superseded by {@link QueryService#getSelectBuilder}  */
-    Results selectResults(@NotNull QuerySchema schema, String sql, @Nullable Map<String, TableInfo> tableMap, Map<String, Object> parameters, boolean strictColumnList, boolean cached);
-
-    /** superseded by {@link QueryService#getSelectBuilder}  */
     default Results select(TableInfo table, Collection<ColumnInfo> columns, @Nullable Filter filter, @Nullable Sort sort)
     {
         return getSelectBuilder(table).columns(columns).filter(filter).sort(sort).select();
     }
 
-    /** superseded by {@link QueryService#getSelectBuilder}  */
-    Results select(TableInfo table, Collection<ColumnInfo> columns, @Nullable Filter filter, @Nullable Sort sort, Map<String, Object> parameters, boolean cached);
-
-    /** superseded by {@link QueryService#getSelectBuilder}  */
-    SQLFragment getSelectSQL(TableInfo table, @Nullable Collection<ColumnInfo> columns, @Nullable Filter filter, @Nullable Sort sort, int maxRows, long offset, boolean forceSort);
-    /** superseded by {@link QueryService#getSelectBuilder}  */
-    SQLFragment getSelectSQL(TableInfo table, @Nullable Collection<ColumnInfo> columns, @Nullable Filter filter, @Nullable Sort sort, int maxRows, long offset, boolean forceSort, @NotNull QueryLogging queryLogging);
-
     SelectBuilder getSelectBuilder(TableInfo table);
     SelectBuilder getSelectBuilder(QuerySchema schema, String sql);
+    /** Use when the query must not return extra hidden sort columns (e.g. HTTP endpoints that reflect column names to callers). */
+    SelectBuilder getSelectBuilder(QuerySchema schema, String sql, boolean strictColumnList);
 
     MutableColumnInfo createQueryExpressionColumn(TableInfo table, FieldKey key, String labKeySql, ColumnType columnType);
     MutableColumnInfo createQueryExpressionColumn(TableInfo table, FieldKey key, FieldKey wrapped, ColumnType columnType);
@@ -697,13 +688,19 @@ public interface QueryService
         SelectBuilder forceSort(boolean b);
         SelectBuilder queryLogging(QueryLogging queryLogging);
         SelectBuilder distinct(boolean b);
+        /** Enable PostgreSQL JDBC-level result buffering. Rarely needed; defaults to false (streaming). */
+        SelectBuilder jdbcCaching(boolean jdbcCaching);
 
         SQLFragment buildSqlFragment();
-        SqlSelector buildSqlSelector(@Nullable Map<String, Object> parameters);
-        Results select(@Nullable Map<String, Object> parameters, boolean cache);
+        SqlSelector buildSqlSelector();
+        Results select(boolean labkeyCachedResultSet, @NotNull Map<String, Object> parameters);
+        default Results select(boolean labkeyCachedResultSet)
+        {
+            return select(labkeyCachedResultSet, Map.of());
+        }
         default Results select()
         {
-            return select(Map.of(), true);
+            return select(true);
         }
 
         QueryLogging getQueryLogging();

--- a/api/src/org/labkey/api/study/assay/SpecimenForeignKey.java
+++ b/api/src/org/labkey/api/study/assay/SpecimenForeignKey.java
@@ -363,7 +363,7 @@ public class SpecimenForeignKey extends LookupForeignKey
             // Select all the assay-side specimen columns that we'll need to do the comparison
 // TODO ContainerFilter make sure all callers of new SpecimenForeignKey() pass in appropriately constructed _assayDataTable
 //            ((ContainerFilterable)_assayDataTable).setContainerFilter(foreignKey.getParentTable().getContainerFilter());
-            SQLFragment targetStudySQL = QueryService.get().getSelectSQL(_assayDataTable, _assayColumns.values(), null, null, Table.ALL_ROWS, Table.NO_OFFSET, false);
+            SQLFragment targetStudySQL = QueryService.get().getSelectBuilder(_assayDataTable).columns(_assayColumns.values()).buildSqlFragment();
             sql.append(targetStudySQL);
 
             String baseAlias = getBaseAlias(parentAlias, foreignKey.getAlias());

--- a/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
+++ b/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
@@ -143,7 +143,7 @@ public class NAbSpecimenTable extends FilteredTable<AssayProtocolSchema>
         if (samplesTable != null && samplesTable.getColumn("InitialDilution") != null)
         {
             List<ColumnInfo> columns = Arrays.asList(samplesTable.getColumn("LSID"), samplesTable.getColumn("InitialDilution"));
-            SQLFragment samplesSql = QueryService.get().getSelectSQL(samplesTable, columns, null, null, Table.ALL_ROWS, 0, false);
+            SQLFragment samplesSql = QueryService.get().getSelectBuilder(samplesTable).columns(columns).buildSqlFragment();
             return sql.append(" LEFT JOIN (").append(samplesSql).append(" ) x ON x.LSID = ").append(ExprColumn.STR_TABLE_ALIAS + ".SpecimenLsid")
                     .append(" WHERE dd.RunDataId = ").append(ExprColumn.STR_TABLE_ALIAS + ".RowId")
                     .append(" AND dd.Dilution = x.InitialDilution)");

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -4248,7 +4248,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             FROM plate.Well WHERE PlateId.PlateSet.RowId = %s AND ReplicateGroup IS NOT NULL
         """, plateSetRowId);
 
-        return QueryService.get().getSelectBuilder(plateSchema, labkeySql).buildSqlSelector(null).getRowCount();
+        return QueryService.get().getSelectBuilder(plateSchema, labkeySql).buildSqlSelector().getRowCount();
     }
 
     private String getReplicateGroupLabKeySql(@NotNull UserSchema plateSchema, @NotNull Long plateSetRowId)
@@ -4349,7 +4349,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     private long getSampleGroupCount(@NotNull UserSchema plateSchema, @NotNull Long plateSetRowId)
     {
         String labkeySql = getSampleGroupLabKeySql(plateSetRowId, false);
-        return QueryService.get().getSelectBuilder(plateSchema, labkeySql).buildSqlSelector(null).getRowCount();
+        return QueryService.get().getSelectBuilder(plateSchema, labkeySql).buildSqlSelector().getRowCount();
     }
 
     private void validatePlateSetSampleGroups(Container container, User user, @NotNull Long plateSetRowId) throws ValidationException

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -2096,7 +2096,7 @@ public final class PlateManagerTest
         return QueryService.get().getSelectBuilder(wellTable)
                 .columns(getWellTableColumns(wellTable).values())
                 .filter(filter)
-                .buildSqlSelector(null)
+                .buildSqlSelector()
                 .getMap();
     }
 

--- a/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
@@ -413,7 +413,7 @@ public final class WellTriggerFactory implements TriggerFactory
         UserSchema schema = QueryService.get().getUserSchema(user, container, "plate");
         SQLFragment sql = new SQLFragment("SELECT RowId, Type FROM plate.Well WHERE PlateId = ?").add(plateRowId);
         QueryService.get().getSelectBuilder(schema, sql.toDebugString())
-                .buildSqlSelector(null)
+                .buildSqlSelector()
                 .forEach(r -> map.put(r.getLong(WellTable.Column.RowId.name()), r.getString(WellTable.Column.Type.name())));
 
         return map;
@@ -425,7 +425,7 @@ public final class WellTriggerFactory implements TriggerFactory
         UserSchema schema = QueryService.get().getUserSchema(user, container, "plate");
         SQLFragment sql = new SQLFragment("SELECT RowId, ReplicateGroup FROM plate.Well WHERE PlateId = ?").add(plateRowId);
         QueryService.get().getSelectBuilder(schema, sql.toDebugString())
-                .buildSqlSelector(null)
+                .buildSqlSelector()
                 .forEach(r -> map.put(r.getLong(WellTable.Column.RowId.name()), r.getString(WellTable.Column.ReplicateGroup.name())));
 
         return map;

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -779,11 +779,10 @@ public class CoreQuerySchema extends UserSchema
 
                     settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("UserId"), user.getUserId()));
 
-                    Map<String, Object> params = Collections.emptyMap();
                     TableInfo table = schema.getTable(CoreQuerySchema.USERS_TABLE_NAME);
 
-                    try (Results results = QueryService.get().select(table, table.getColumns(),
-                            new SimpleFilter(FieldKey.fromParts("UserId"), user.getUserId()), null, params, true))
+                    try (Results results = QueryService.get().getSelectBuilder(table).filter(
+                            new SimpleFilter(FieldKey.fromParts("UserId"), user.getUserId())).select(true))
                     {
                         if (results.next())
                         {

--- a/experiment/src/org/labkey/experiment/api/LineageTest.java
+++ b/experiment/src/org/labkey/experiment/api/LineageTest.java
@@ -243,7 +243,7 @@ public class LineageTest extends ExpProvisionedTableTestHelper
                         "FROM exp.data." + firstDataClassName + " AS dc\n" +
                         "ORDER BY dc.RowId\n";
 
-        try (Results rs = QueryService.get().selectResults(schema, sql, null, null, true, true))
+        try (Results rs = QueryService.get().getSelectBuilder(schema, sql, true).select())
         {
             RenderContext ctx = new RenderContext(new ViewContext());
             ctx.getViewContext().setRequest(TestContext.get().getRequest());

--- a/experiment/src/org/labkey/experiment/lineage/LineagePerfTest.java
+++ b/experiment/src/org/labkey/experiment/lineage/LineagePerfTest.java
@@ -422,7 +422,7 @@ public class LineagePerfTest extends Assert
                 "FROM samples.MySamples AS ss\n";
 
         final UserSchema schema = QueryService.get().getUserSchema(_user, _container, "samples");
-        final TableSelector ts = QueryService.get().selector(schema, sql);
+        final SqlSelector ts = QueryService.get().getSelectBuilder(schema, sql).buildSqlSelector();
 
         final ExpLineageOptions opt = new ExpLineageOptions();
         final ViewBackgroundInfo info = new ViewBackgroundInfo(_container, _user, null);

--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -257,7 +257,7 @@ public class IssueManager
             if (table != null)
             {
                 var select = QueryService.get().getSelectBuilder(table).filter(filter);
-                try (Results rs = select.select(Map.of(), false))
+                try (Results rs = select.select(false))
                 {
                     Map<String, Object> rowMap = new CaseInsensitiveHashMap<>();
                     if (rs.next())

--- a/list/src/org/labkey/list/model/ListWriter.java
+++ b/list/src/org/labkey/list/model/ListWriter.java
@@ -181,7 +181,7 @@ public class ListWriter
 
                     // NOTE: TSVGridWriter generates and closes Results
 
-                    try (TSVGridWriter tsvWriter = new TSVGridWriter(()->QueryService.get().getSelectBuilder(ti).columns(columns).sort(sort).select(null, false), displayColumns))
+                    try (TSVGridWriter tsvWriter = new TSVGridWriter(()->QueryService.get().getSelectBuilder(ti).columns(columns).sort(sort).select(false), displayColumns))
                     {
                         tsvWriter.setApplyFormats(false);
                         tsvWriter.setColumnHeaderType(ColumnHeaderType.ImportField); // Issue 53431
@@ -292,7 +292,7 @@ public class ListWriter
             List<ColumnInfo> selectColumns = new ArrayList<>(attachmentColumns);
             selectColumns.addFirst(ti.getColumn("EntityId"));
 
-            try (ResultSet rs = QueryService.get().getSelectBuilder(ti).columns(selectColumns).select(null, false))
+            try (ResultSet rs = QueryService.get().getSelectBuilder(ti).columns(selectColumns).select(false))
             {
                 while (rs.next())
                 {

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -374,7 +374,7 @@ public class QueryServiceImpl implements QueryService
         }
     };
 
-    private static SQLFragment getColumnInSql(@NotNull FieldKey fieldKey, Object value, User user, Container container, Map<FieldKey, ? extends ColumnInfo> columnMap, @NotNull List<ColumnInfo> selectColumns, boolean negate)
+    private static SQLFragment getColumnInSql(@NotNull FieldKey fieldKey, Object value, User user, Container container, Map<FieldKey, ? extends ColumnInfo> columnMap, boolean negate)
     {
         if (user == null || container == null)
             throw new NotFoundException("Invalid context");
@@ -423,7 +423,7 @@ public class QueryServiceImpl implements QueryService
                 @Override
                 public SQLFragment toSQLFragment(Map<FieldKey, ? extends ColumnInfo> columnMap, SqlDialect dialect)
                 {
-                    return getColumnInSql(fieldKey, value, user, container, columnMap, _selectColumns, false);
+                    return getColumnInSql(fieldKey, value, user, container, columnMap, false);
                 }
             };
         }
@@ -445,7 +445,7 @@ public class QueryServiceImpl implements QueryService
                 @Override
                 public SQLFragment toSQLFragment(Map<FieldKey, ? extends ColumnInfo> columnMap, SqlDialect dialect)
                 {
-                    return getColumnInSql(fieldKey, value, user, container, columnMap, _selectColumns, true);
+                    return getColumnInSql(fieldKey, value, user, container, columnMap, true);
                 }
             };
         }
@@ -2733,19 +2733,7 @@ public class QueryServiceImpl implements QueryService
         q.setTableMap(tableMap);
         q.parse(sql);
 
-        return getSelectBuilder(q).select(Map.of(), cached);
-    }
-
-
-    @Override
-    public Results selectResults(@NotNull QuerySchema schema, String sql, @Nullable Map<String, TableInfo> tableMap, Map<String, Object> parameters, boolean strictColumnList, boolean cached)
-    {
-        Query q = new Query(schema);
-        q.setStrictColumnList(strictColumnList);
-        q.setTableMap(tableMap);
-        q.parse(sql);
-
-        return getSelectBuilder(q).select(parameters, cached);
+        return getSelectBuilder(q).select(cached);
     }
 
 
@@ -2810,45 +2798,6 @@ public class QueryServiceImpl implements QueryService
     }
 
     @Override
-    public Results select(TableInfo table, Collection<ColumnInfo> columns, @Nullable Filter filter, @Nullable Sort sort, Map<String, Object> parameters, boolean cache)
-    {
-        return getSelectBuilder(table)
-                .columns(columns)
-                .filter(filter)
-                .sort(sort)
-                .select(parameters, cache);
-    }
-
-    @Override
-    public SQLFragment getSelectSQL(TableInfo table, @Nullable Collection<ColumnInfo> selectColumns, @Nullable Filter filter, @Nullable Sort sort,
-                                    int maxRows, long offset, boolean forceSort)
-    {
-        return getSelectBuilder(table)
-                .columns(selectColumns)
-                .filter(filter)
-                .sort(sort)
-                .maxRows(maxRows)
-                .offset(offset)
-                .forceSort(forceSort)
-                .buildSqlFragment();
-    }
-
-    @Override
-    public SQLFragment getSelectSQL(TableInfo table, @Nullable Collection<ColumnInfo> selectColumns, @Nullable Filter filter, @Nullable Sort sort,
-                                    int maxRows, long offset, boolean forceSort, @NotNull QueryLogging queryLogging)
-    {
-        return getSelectBuilder(table)
-                .columns(selectColumns)
-                .filter(filter)
-                .sort(sort)
-                .maxRows(maxRows)
-                .offset(offset)
-                .forceSort(forceSort)
-                .queryLogging(queryLogging)
-                .buildSqlFragment();
-    }
-
-    @Override
     public SelectBuilder getSelectBuilder(TableInfo table)
     {
         return new SelectBuilderImpl(table);
@@ -2862,8 +2811,14 @@ public class QueryServiceImpl implements QueryService
     @Override
     public SelectBuilder getSelectBuilder(QuerySchema schema, String sql)
     {
+        return getSelectBuilder(schema, sql, false);
+    }
+
+    @Override
+    public SelectBuilder getSelectBuilder(QuerySchema schema, String sql, boolean strictColumnList)
+    {
         Query q = new Query(schema);
-        q.setStrictColumnList(false);
+        q.setStrictColumnList(strictColumnList);
         q.setTableMap(null);
         q.parse(sql);
         return getSelectBuilder(q);
@@ -2882,6 +2837,7 @@ public class QueryServiceImpl implements QueryService
         boolean forceSort = false;
         QueryLogging queryLogging = new QueryLogging();
         boolean distinct = false;
+        boolean jdbcCaching = false;
 
         SelectBuilderImpl(TableInfo table)
         {
@@ -2959,6 +2915,13 @@ public class QueryServiceImpl implements QueryService
         }
 
         @Override
+        public SelectBuilder jdbcCaching(boolean jdbcCaching)
+        {
+            this.jdbcCaching = jdbcCaching;
+            return this;
+        }
+
+        @Override
         public SQLFragment buildSqlFragment()
         {
             if (null == queryLogging)
@@ -2973,7 +2936,12 @@ public class QueryServiceImpl implements QueryService
         }
 
         @Override
-        public SqlSelector buildSqlSelector(@Nullable Map<String, Object> parameters)
+        public SqlSelector buildSqlSelector()
+        {
+            return buildSqlSelector(Map.of());
+        }
+
+        private SqlSelector buildSqlSelector(@NotNull Map<String, Object> parameters)
         {
             SQLFragment sql = buildSqlFragment();
             bindNamedParameters(sql, parameters);
@@ -2983,10 +2951,10 @@ public class QueryServiceImpl implements QueryService
         }
 
         @Override
-        public Results select(@Nullable Map<String, Object> parameters, boolean cache)
+        public Results select(boolean labkeyCachedResultSet, @NotNull Map<String, Object> parameters)
         {
-            SqlSelector selector = buildSqlSelector(parameters).setJdbcCaching(cache);
-            ResultSet rs = selector.getResultSet(cache, cache);
+            SqlSelector selector = buildSqlSelector(parameters).setJdbcCaching(jdbcCaching);
+            ResultSet rs = selector.getResultSet(labkeyCachedResultSet, labkeyCachedResultSet);
 
             // Keep track of whether we've successfully created the ResultSetImpl to return. If not, we should
             // close the underlying ResultSet before returning since it won't be accessible anywhere else
@@ -3034,8 +3002,7 @@ public class QueryServiceImpl implements QueryService
     public MutableColumnInfo createQueryExpressionColumn(TableInfo table, FieldKey key, FieldKey wrapped, ColumnType columnType)
     {
         // TODO short-circuit parsing/binding in this code path
-        var ret = new CalculatedExpressionColumn(table, key, LabKeySql.quoteIdentifier(wrapped.getName()), columnType);
-        return ret;
+        return new CalculatedExpressionColumn(table, key, LabKeySql.quoteIdentifier(wrapped.getName()), columnType);
     }
 
      /** Compute and set the metadata for this column based on the source expression and the xml override */
@@ -3556,7 +3523,7 @@ public class QueryServiceImpl implements QueryService
             TableInfo target = fk.getLookupTableInfo();
             if (null == target)
                 continue;
-            if (!_includeLookupDependency(source, target))
+            if (!_includeLookupDependency(target))
                 continue;
             var type = target instanceof QueryTableInfo ? DependencyType.Query : DependencyType.Table;
             Container c = fk.getLookupContainer();
@@ -3580,7 +3547,7 @@ public class QueryServiceImpl implements QueryService
 
     final static SchemaKey coreSchemaKey = SchemaKey.fromParts("core");
 
-    private boolean _includeLookupDependency(TableInfo from, TableInfo to)
+    private boolean _includeLookupDependency(TableInfo to)
     {
         // ignore core schema
         if (to.getUserSchema() == null)

--- a/query/src/org/labkey/query/QueryServiceImplTestCase.jsp
+++ b/query/src/org/labkey/query/QueryServiceImplTestCase.jsp
@@ -64,37 +64,27 @@
         var xyz = wrapped.getColumn("xyz");
 
         // test choose PK
-        SQLFragment test1 = QueryServiceImpl.get().getSelectSQL(wrapped,
-                List.of(C,B,A), null,
-                null, 1000, 0, true);
+        SQLFragment test1 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(C,B,A)).buildSqlFragment();
         assertTrue(test1.toDebugString().contains("ORDER BY A ASC"));
         assertTrue(isSorted(test1,3));
 
         // test choose non-PK
-        SQLFragment test2 = QueryServiceImpl.get().getSelectSQL(wrapped,
-                List.of(C), null,
-                null, 1000, 0, true);
+        SQLFragment test2 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(C)).buildSqlFragment();
         assertTrue(test2.toDebugString().contains("ORDER BY C ASC"));
         assertTrue(isSorted(test2,1));
 
         // test explicit in select list
-        SQLFragment test3 = QueryServiceImpl.get().getSelectSQL(wrapped,
-                List.of(A,C), null,
-                new Sort("C"), 1000, 0, true);
+        SQLFragment test3 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,C)).sort(new Sort("C")).buildSqlFragment();
         assertTrue(test3.toDebugString().contains("ORDER BY C ASC"));
         assertTrue(isSorted(test3,2));
 
         // test explicit not in select list
-        SQLFragment test4 = QueryServiceImpl.get().getSelectSQL(wrapped,
-                List.of(A,B,xyz), null,
-                new Sort("C"), 1000, 0, true);
+        SQLFragment test4 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,B,xyz)).sort(new Sort("C")).buildSqlFragment();
         assertTrue(test4.toDebugString().contains("ORDER BY C ASC"));
         assertTrue(isSorted(test4,3));
 
         // test sortFieldKeys
-        SQLFragment test5 = QueryServiceImpl.get().getSelectSQL(wrapped,
-                List.of(A,B,xyz), null,
-                new Sort("B"), 1000, 0, true);
+        SQLFragment test5 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,B,xyz)).sort(new Sort("B")).buildSqlFragment();
         assertFalse(test5.toDebugString().contains("ORDER BY B ASC"));
         assertTrue(test5.toDebugString().contains("ORDER BY C ASC"));
         assertTrue(isSorted(test5,3));
@@ -103,18 +93,14 @@
         (wrapped.getMutableColumn("B")).setSortFieldKeys(Arrays.asList(new FieldKey(null,"D")));
 
         // implicit sort, sort by B because D not found
-        SQLFragment test6 = QueryServiceImpl.get().getSelectSQL(wrapped,
-                List.of(B), null,
-                null, 1000, 0, true);
+        SQLFragment test6 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(B)).buildSqlFragment();
         assertFalse(test6.toDebugString().contains("ORDER BY D ASC"));
         assertTrue(test6.toDebugString().contains("ORDER BY B ASC"));
         assertTrue(isSorted(test6,1));
 
         // explicit sort, sort by B because D not found
         (wrapped.getMutableColumn("B")).setSortFieldKeys(Arrays.asList(new FieldKey(null,"D")));
-        SQLFragment test7 = QueryServiceImpl.get().getSelectSQL(wrapped,
-                List.of(A,B,C), null,
-                new Sort("B"), 1000, 0, true);
+        SQLFragment test7 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,B,C)).sort(new Sort("B")).buildSqlFragment();
         assertFalse(test7.toDebugString().contains("ORDER BY D ASC"));
         assertTrue(test7.toDebugString().contains("ORDER BY B ASC"));
         assertTrue(isSorted(test7,2));

--- a/query/src/org/labkey/query/QueryServiceImplTestCase.jsp
+++ b/query/src/org/labkey/query/QueryServiceImplTestCase.jsp
@@ -64,27 +64,27 @@
         var xyz = wrapped.getColumn("xyz");
 
         // test choose PK
-        SQLFragment test1 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(C,B,A)).buildSqlFragment();
+        SQLFragment test1 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(C,B,A)).forceSort(true).buildSqlFragment();
         assertTrue(test1.toDebugString().contains("ORDER BY A ASC"));
         assertTrue(isSorted(test1,3));
 
         // test choose non-PK
-        SQLFragment test2 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(C)).buildSqlFragment();
+        SQLFragment test2 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(C)).forceSort(true).buildSqlFragment();
         assertTrue(test2.toDebugString().contains("ORDER BY C ASC"));
         assertTrue(isSorted(test2,1));
 
         // test explicit in select list
-        SQLFragment test3 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,C)).sort(new Sort("C")).buildSqlFragment();
+        SQLFragment test3 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,C)).sort(new Sort("C")).forceSort(true).buildSqlFragment();
         assertTrue(test3.toDebugString().contains("ORDER BY C ASC"));
         assertTrue(isSorted(test3,2));
 
         // test explicit not in select list
-        SQLFragment test4 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,B,xyz)).sort(new Sort("C")).buildSqlFragment();
+        SQLFragment test4 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,B,xyz)).sort(new Sort("C")).forceSort(true).buildSqlFragment();
         assertTrue(test4.toDebugString().contains("ORDER BY C ASC"));
         assertTrue(isSorted(test4,3));
 
         // test sortFieldKeys
-        SQLFragment test5 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,B,xyz)).sort(new Sort("B")).buildSqlFragment();
+        SQLFragment test5 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,B,xyz)).sort(new Sort("B")).forceSort(true).buildSqlFragment();
         assertFalse(test5.toDebugString().contains("ORDER BY B ASC"));
         assertTrue(test5.toDebugString().contains("ORDER BY C ASC"));
         assertTrue(isSorted(test5,3));
@@ -93,14 +93,14 @@
         (wrapped.getMutableColumn("B")).setSortFieldKeys(Arrays.asList(new FieldKey(null,"D")));
 
         // implicit sort, sort by B because D not found
-        SQLFragment test6 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(B)).buildSqlFragment();
+        SQLFragment test6 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(B)).forceSort(true).buildSqlFragment();
         assertFalse(test6.toDebugString().contains("ORDER BY D ASC"));
         assertTrue(test6.toDebugString().contains("ORDER BY B ASC"));
         assertTrue(isSorted(test6,1));
 
         // explicit sort, sort by B because D not found
         (wrapped.getMutableColumn("B")).setSortFieldKeys(Arrays.asList(new FieldKey(null,"D")));
-        SQLFragment test7 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,B,C)).sort(new Sort("B")).buildSqlFragment();
+        SQLFragment test7 = QueryServiceImpl.get().getSelectBuilder(wrapped).columns(List.of(A,B,C)).sort(new Sort("B")).forceSort(true).buildSqlFragment();
         assertFalse(test7.toDebugString().contains("ORDER BY D ASC"));
         assertTrue(test7.toDebugString().contains("ORDER BY B ASC"));
         assertTrue(isSorted(test7,2));

--- a/query/src/org/labkey/query/controllers/SqlController.java
+++ b/query/src/org/labkey/query/controllers/SqlController.java
@@ -212,7 +212,7 @@ public class SqlController extends SpringActionController
                 return null;
             }
 
-            try (Results rs = QueryService.get().selectResults(schema, form.getSql(), null, form.getParameterMap(), true, false))
+            try (Results rs = QueryService.get().getSelectBuilder(schema, form.getSql(), true).select(false, form.getParameterMap()))
             {
                 getViewContext().getResponse().setContentType("text/plain");
                 if (form.compact)

--- a/query/src/org/labkey/query/sql/QuerySelectView.java
+++ b/query/src/org/labkey/query/sql/QuerySelectView.java
@@ -184,8 +184,7 @@ public class QuerySelectView extends AbstractQueryRelation
 
 
     /*
-     * This code used to live in QueryService.getSelectSQL().  That code is still public and supported, but eventually
-     * calls this implementation.
+     * Called from SelectBuilderImpl.buildSqlFragment() via QuerySelectView.create().
      */
     private SQLFragment getSelectSQL(TableInfo table, @Nullable Collection<ColumnInfo> selectColumns, @Nullable Filter filter, @Nullable Sort sort,
                                     int maxRows, long offset, boolean forceSort, @NotNull QueryLogging queryLogging, boolean distinct)

--- a/specimen/src/org/labkey/specimen/SpecimenRequestManager.java
+++ b/specimen/src/org/labkey/specimen/SpecimenRequestManager.java
@@ -949,7 +949,7 @@ public class SpecimenRequestManager
                     TableInfo tableInfo = schema.getTable(SpecimenTablesProvider.SPECIMEN_WRAP_TABLE_NAME);
                     Map<FieldKey, ColumnInfo> columnMap = queryService.getColumns(tableInfo, fieldKeys);
 
-                    SQLFragment inner = queryService.getSelectSQL(tableInfo, columnMap.values(), null, null, -1, 0, false);
+                    SQLFragment inner = queryService.getSelectBuilder(tableInfo).columns(columnMap.values()).buildSqlFragment();
 
                     // Insert COUNT
                     String sampleCountName = tableInfo.getSqlDialect().makeLegalIdentifier("SampleCount");

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -1370,7 +1370,7 @@ public class StudyPublishManager implements StudyPublishService
                 final Map<Long, PublishKey> keys = new LongHashMap<>();
                 assert cols.get(runFK) != null : "Could not find object id column: " + objectIdFK;
 
-                SQLFragment sql = QueryService.get().getSelectSQL(resultTable, cols.values(), new SimpleFilter(runFK, run.getRowId()), null, Table.ALL_ROWS, Table.NO_OFFSET, false);
+                SQLFragment sql = QueryService.get().getSelectBuilder(resultTable).columns(cols.values()).filter(new SimpleFilter(runFK, run.getRowId())).buildSqlFragment();
 
                 Container targetContainer = targetStudyContainer;
                 new SqlSelector(resultTable.getSchema(), sql).forEach(rs -> {

--- a/study/src/org/labkey/study/writer/DatasetDataWriter.java
+++ b/study/src/org/labkey/study/writer/DatasetDataWriter.java
@@ -162,7 +162,7 @@ public class DatasetDataWriter implements InternalStudyWriter
             if (ctx.isDataspaceProject())
                 DefaultStudyDesignWriter.createExtraForeignKeyColumns(ti, columns);
             var select = QueryService.get().getSelectBuilder(ti).columns(columns).filter(filter).sort(sort);
-            ResultsFactory factory = ()->select.select(Map.of(),false);
+            ResultsFactory factory = ()->select.select(false);
             writeResultsToTSV(factory, vf, def.getFileName());
         }
     }

--- a/study/src/org/labkey/study/writer/DefaultStudyDesignWriter.java
+++ b/study/src/org/labkey/study/writer/DefaultStudyDesignWriter.java
@@ -72,7 +72,7 @@ public abstract class DefaultStudyDesignWriter
         if (table != null)
         {
             var select = QueryService.get().getSelectBuilder(table).columns(columns);
-            ResultsFactory factory = ()->select.select(Map.of(),false);
+            ResultsFactory factory = ()->select.select(false);
             writeResultsToTSV(factory, vf, getFileName(table));
         }
     }

--- a/visualization/src/org/labkey/visualization/VisualizationController.java
+++ b/visualization/src/org/labkey/visualization/VisualizationController.java
@@ -383,7 +383,7 @@ public class VisualizationController extends SpringActionController
                             }
 
                             QueryLogging queryLogging = new QueryLogging();
-                            SQLFragment sql = QueryService.get().getSelectSQL(tinfo, Collections.singleton(col), filter, null, Table.ALL_ROWS, Table.NO_OFFSET, false, queryLogging);
+                            SQLFragment sql = QueryService.get().getSelectBuilder(tinfo).columns(Collections.singleton(col)).filter(filter).queryLogging(queryLogging).buildSqlFragment();
                             SQLFragment distinctSql = new SQLFragment(sql);
                             int i = StringUtils.indexOf(sql.getSqlCharSequence(), "SELECT");
                             if (i >= 0)

--- a/visualization/src/org/labkey/visualization/sql/VisualizationCDSGenerator.java
+++ b/visualization/src/org/labkey/visualization/sql/VisualizationCDSGenerator.java
@@ -537,7 +537,7 @@ public class VisualizationCDSGenerator
             BindException errors = new NullSafeBindException(q,"query");
             String sql = gen.getSQL(errors);
             assertFalse(errors.hasErrors());
-            return QueryService.get().selectResults(schema, sql, null, null, true, true);
+            return QueryService.get().getSelectBuilder(schema, sql, true).select();
         }
 
         List<Map<String,String>> getColumnAliases(VisDataRequest q) throws SQLGenerationException, SQLException

--- a/visualization/src/org/labkey/visualization/sql/VisualizationSQLGenerator.java
+++ b/visualization/src/org/labkey/visualization/sql/VisualizationSQLGenerator.java
@@ -1140,7 +1140,7 @@ public class VisualizationSQLGenerator implements HasViewContext
             VisualizationSQLGenerator gen = getVSQL(q);
             UserSchema schema = new VisTestSchema(context.getUser(), context.getContainer());
             String sql = gen.getSQL();
-            return QueryService.get().selectResults(schema, sql, null, null, true, true);
+            return QueryService.get().getSelectBuilder(schema, sql, true).select();
         }
 
 


### PR DESCRIPTION
#### Rationale
We can improve our memory usage by avoiding unwanted JDBC caching. We can also simplify `QueryService` usage by consolidating to use `SelectBuilder`.

#### Changes
- Disable Postgres JDBC caching by default for `QueryService` method like `select()`
- Switch to `getSelectBuilder()` and `SelectBuilder` patterns
- Eliminate unneeded parameters, using defaults when possible