### PR TITLE
Move ExtJS 3.x options to Deprecated Features page

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -217,6 +217,9 @@ public class ApiModule extends CodeOnlyModule
     private static final String CORS_PREFIX = "cors.";
     private static final String CORS_FILTER_NAME = "CorsFilter";
 
+    public static final String EXTJS_3_REQUIRED = "ExtJs3Required";
+    public static final String EXTJS_3_API_REQUIRED = "ExtJs3ApiRequired";
+
     @Override
     protected void init()
     {
@@ -244,6 +247,22 @@ public class ApiModule extends CodeOnlyModule
             false,
             false,
             OptionalFeatureService.FeatureType.Optional
+        ));
+        OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(
+            EXTJS_3_REQUIRED,
+            "Require that ExtJS v3.4.1 is loaded on every page",
+            "This option will be removed in LabKey Server 26.11",
+            false,
+            false,
+            FeatureType.Deprecated
+        ));
+        OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(
+            EXTJS_3_API_REQUIRED,
+            "Require that ExtJS v3.x-based Client API is loaded on every page",
+            "This option will be removed in LabKey Server 26.11",
+            false,
+            false,
+            FeatureType.Deprecated
         ));
     }
 

--- a/api/src/org/labkey/api/Constants.java
+++ b/api/src/org/labkey/api/Constants.java
@@ -56,7 +56,7 @@ public class Constants
      */
     public static String getDocumentationVersion()
     {
-        return "26.3";
+        return "26.7";
     }
 
     /**

--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -174,10 +174,6 @@ public interface AppProps
 
     int getMaxBLOBSize();
 
-    boolean isExt3Required();
-
-    boolean isExt3APIRequired();
-
     ExceptionReportingLevel getExceptionReportingLevel();
 
     /**

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -328,18 +328,6 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
     }
 
     @Override
-    public boolean isExt3Required()
-    {
-        return lookupBooleanValue(ext3Required, false);
-    }
-
-    @Override
-    public boolean isExt3APIRequired()
-    {
-        return lookupBooleanValue(ext3APIRequired, false);
-    }
-
-    @Override
     public boolean isSelfReportExceptions()
     {
         return MothershipReport.isShowSelfReportExceptions() && lookupBooleanValue(selfReportExceptions, true);

--- a/api/src/org/labkey/api/settings/SiteSettingsProperties.java
+++ b/api/src/org/labkey/api/settings/SiteSettingsProperties.java
@@ -98,22 +98,6 @@ public enum SiteSettingsProperties implements StartupProperty, SafeToRenderEnum
             writeable.setMaxBLOBSize(Integer.parseInt(value));
         }
     },
-    ext3Required("Require ExtJS v3.4.1 be loaded on each page (DEPRECATED)")
-    {
-        @Override
-        public void setValue(WriteableAppProps writeable, String value)
-        {
-            writeable.setExt3Required(Boolean.parseBoolean(value));
-        }
-    },
-    ext3APIRequired("Require ExtJS v3.x based Client API be loaded on each page (DEPRECATED)")
-    {
-        @Override
-        public void setValue(WriteableAppProps writeable, String value)
-        {
-            writeable.setExt3APIRequired(Boolean.parseBoolean(value));
-        }
-    },
     sslRequired("Require SSL connections (users must connect via SSL)")
     {
         @Override

--- a/api/src/org/labkey/api/settings/WriteableAppProps.java
+++ b/api/src/org/labkey/api/settings/WriteableAppProps.java
@@ -106,16 +106,6 @@ public class WriteableAppProps extends AppPropsImpl
         storeBooleanValue(selfReportExceptions, selfReport);
     }
 
-    public void setExt3Required(boolean required)
-    {
-        storeBooleanValue(ext3Required, required);
-    }
-
-    public void setExt3APIRequired(boolean required)
-    {
-        storeBooleanValue(ext3APIRequired, required);
-    }
-
     public void setBLASTServerBaseURL(String blastServerBaseURL)
     {
         storeStringValue(BLASTBaseURL, blastServerBaseURL);

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.ApiModule;
 import org.labkey.api.action.UrlProvider;
 import org.labkey.api.action.UrlProviderOverrideHandler;
 import org.labkey.api.action.UrlProviderService;
@@ -67,6 +68,7 @@ import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.CustomLabelService;
 import org.labkey.api.settings.LookAndFeelProperties;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.settings.ResourceURL;
 import org.labkey.api.settings.TemplateResourceHandler;
 import org.labkey.api.settings.Theme;
@@ -1661,9 +1663,9 @@ public class PageFlowUtil
         if (includeDefaultResources)
         {
             // Respect App Properties regarding Ext3 configuration
-            if (AppProps.getInstance().isExt3APIRequired())
+            if (OptionalFeatureService.get().isFeatureEnabled(ApiModule.EXTJS_3_API_REQUIRED))
                 resources.add(ClientDependency.fromPath("clientapi/ext3"));
-            else if (AppProps.getInstance().isExt3Required())
+            else if (OptionalFeatureService.get().isFeatureEnabled(ApiModule.EXTJS_3_REQUIRED))
                 resources.add(ClientDependency.fromPath("Ext3"));
 
             // TODO: Turn this into a lib.xml

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1410,8 +1410,6 @@ public class AdminController extends SpringActionController
             props.setMemoryUsageDumpInterval(form.getMemoryUsageDumpInterval());
             props.setReadOnlyHttpRequestTimeout(form.getReadOnlyHttpRequestTimeout());
             props.setMaxBLOBSize(form.getMaxBLOBSize());
-            props.setExt3Required(form.isExt3Required());
-            props.setExt3APIRequired(form.isExt3APIRequired());
             props.setSelfReportExceptions(form.isSelfReportExceptions());
 
             props.setAdminOnlyMessage(form.getAdminOnlyMessage());
@@ -2348,8 +2346,6 @@ public class AdminController extends SpringActionController
         private boolean _sslRequired;
         private boolean _adminOnlyMode;
         private boolean _showRibbonMessage;
-        private boolean _ext3Required;
-        private boolean _ext3APIRequired;
         private boolean _selfReportExceptions;
         private String _adminOnlyMessage;
         private String _ribbonMessage;
@@ -2399,26 +2395,6 @@ public class AdminController extends SpringActionController
         public void setSslRequired(boolean sslRequired)
         {
             _sslRequired = sslRequired;
-        }
-
-        public boolean isExt3Required()
-        {
-            return _ext3Required;
-        }
-
-        public void setExt3Required(boolean ext3Required)
-        {
-            _ext3Required = ext3Required;
-        }
-
-        public boolean isExt3APIRequired()
-        {
-            return _ext3APIRequired;
-        }
-
-        public void setExt3APIRequired(boolean ext3APIRequired)
-        {
-            _ext3APIRequired = ext3APIRequired;
         }
 
         public int getSslPort()

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -308,20 +308,12 @@ Click the Save button at any time to accept the current settings and continue.</
 </tr>
 <tr>
     <td class="labkey-form-label"><label for="<%=readOnlyHttpRequestTimeout%>">Timeout for read-only HTTP requests, in seconds<%=helpPopup("Read-only HTTP request timeout",
-            "After the timeout, resources like database connections and spawned processes will be killed to abort processing the request. Set to 0 to disable the timeout.")%></label></td>
+        "After the timeout, resources like database connections and spawned processes will be killed to abort processing the request. Set to 0 to disable the timeout.")%></label></td>
     <td><input type="text" name="<%=readOnlyHttpRequestTimeout%>" id="<%=readOnlyHttpRequestTimeout%>" size="4" value="<%=appProps.getReadOnlyHttpRequestTimeout()%>"></td>
 </tr>
 <tr>
     <td class="labkey-form-label"><label for="<%=maxBLOBSize%>">Maximum file size, in bytes, to allow in database BLOBs</label></td>
     <td><input type="text" name="<%=maxBLOBSize%>" id="<%=maxBLOBSize%>" size="10" value="<%=appProps.getMaxBLOBSize()%>"></td>
-</tr>
-<tr>
-    <td class="labkey-form-label"><label for="<%=ext3Required%>">Require ExtJS v3.4.1 be loaded on each page</label></td>
-    <td><input type="checkbox" name="<%=ext3Required%>" id="<%=ext3Required%>"<%=checked(appProps.isExt3Required())%>></td>
-</tr>
-<tr>
-    <td class="labkey-form-label"><label for="<%=ext3APIRequired%>">Require ExtJS v3.x based Client API be loaded on each page</label></td>
-    <td><input type="checkbox" name="<%=ext3APIRequired%>" id="<%=ext3APIRequired%>"<%=checked(appProps.isExt3APIRequired())%>></td>
 </tr>
 <tr>
     <td>&nbsp;</td>


### PR DESCRIPTION
#### Rationale
Move the two ExtJS 3.x library options from the Site Settings page to the Deprecated Features page, off by default. https://github.com/LabKey/internal-issues/issues/1177

Also, bump `Constants.getDocumentationVersion()` to 26.7
