### PR TITLE
Query: remove defunct assertion

### DIFF
--- a/query/src/org/labkey/query/sql/QIfDefined.java
+++ b/query/src/org/labkey/query/sql/QIfDefined.java
@@ -48,7 +48,6 @@ public class QIfDefined extends QExpr
     @Override
     public FieldKey getFieldKey()
     {
-        assert null != select;
         return ((QExpr)getFirstChild()).getFieldKey();
     }
 


### PR DESCRIPTION
#### Rationale
This assertion is defunct now that we are validating expressions. Prevents expression assistant tool chain from failing when validating generated queries.

#### Changes
- Remove assertion