### PR TITLE
Describe "Documentation Menu" correctly

### DIFF
--- a/api/src/org/labkey/api/settings/LookAndFeelProperties.java
+++ b/api/src/org/labkey/api/settings/LookAndFeelProperties.java
@@ -39,7 +39,6 @@ import static org.labkey.api.settings.LookAndFeelProperties.Properties.folderDis
 import static org.labkey.api.settings.LookAndFeelProperties.Properties.helpMenuEnabled;
 import static org.labkey.api.settings.LookAndFeelProperties.Properties.logoHref;
 import static org.labkey.api.settings.LookAndFeelProperties.Properties.reportAProblemPath;
-import static org.labkey.api.settings.LookAndFeelProperties.Properties.restrictedColumnsEnabled;
 import static org.labkey.api.settings.LookAndFeelProperties.Properties.supportEmail;
 import static org.labkey.api.settings.LookAndFeelProperties.Properties.systemDescription;
 import static org.labkey.api.settings.LookAndFeelProperties.Properties.systemEmailAddress;
@@ -68,7 +67,7 @@ public class LookAndFeelProperties extends LookAndFeelFolderProperties
         themeName("Server color scheme. Valid values: " + Arrays.toString(Theme.values())),
         folderDisplayMode("Show project and folder navigation. Valid values: " + Arrays.toString(FolderDisplayMode.values())),
         applicationMenuDisplayMode("Show application selection menu. Valid values: " + Arrays.toString(FolderDisplayMode.values())),
-        helpMenuEnabled("Show LabKey Help menu item"),
+        helpMenuEnabled("Show LabKey Documentation menu item"),
         logoHref("Logo link (specifies page to which header logo links)"),
         reportAProblemPath("Support link (specifies page where users can request support)"),
         supportEmail("Support email (shown to users if they don't have permission to see a page, or are having trouble logging in)"),
@@ -246,14 +245,14 @@ public class LookAndFeelProperties extends LookAndFeelFolderProperties
         return displayMode != null ? FolderDisplayMode.fromString(lookupStringValue(applicationMenuDisplayMode, null)) : null;
     }
 
-    public boolean isHelpMenuEnabled()
+    public boolean isDocumentationMenuEnabled()
     {
         return lookupBooleanValue(helpMenuEnabled, true);
     }
 
-    public Boolean isHelpMenuEnabledStored()
+    public Boolean isDocumentationMenuEnabledStored()
     {
-        String stored = getStoredValue(restrictedColumnsEnabled);
+        String stored = getStoredValue(helpMenuEnabled);
         return null == stored ? null : "TRUE".equals(stored);
     }
 

--- a/api/src/org/labkey/api/settings/WriteableLookAndFeelProperties.java
+++ b/api/src/org/labkey/api/settings/WriteableLookAndFeelProperties.java
@@ -139,12 +139,12 @@ public class WriteableLookAndFeelProperties extends WriteableFolderLookAndFeelPr
         remove(applicationMenuDisplayMode);
     }
 
-    public void setHelpMenuEnabled(boolean enabled)
+    public void setDocumentationMenuEnabled(boolean enabled)
     {
         storeBooleanValue(helpMenuEnabled, enabled);
     }
 
-    public void clearHelpMenuEnabled()
+    public void clearDocumentationMenuEnabled()
     {
         remove(helpMenuEnabled);
     }

--- a/api/src/org/labkey/api/view/PopupHelpView.java
+++ b/api/src/org/labkey/api/view/PopupHelpView.java
@@ -51,7 +51,7 @@ public class PopupHelpView extends PopupMenuView
                 menu.addChild("Support", reportAProblemPath);
         }
 
-        if (laf.isHelpMenuEnabled())
+        if (laf.isDocumentationMenuEnabled())
             menu.addChild(topic.getNavTree("LabKey Documentation"));
 
         return menu;

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11722,7 +11722,7 @@ public class AdminController extends SpringActionController
         setProperty(form.isThemeNameInherited(), props::clearThemeName, () -> props.setThemeName(form.getThemeName()));
         setProperty(form.isFolderDisplayModeInherited(), props::clearFolderDisplayMode, () -> props.setFolderDisplayMode(FolderDisplayMode.fromString(form.getFolderDisplayMode())));
         setProperty(form.isApplicationMenuDisplayModeInherited(), props::clearApplicationMenuDisplayMode, () -> props.setApplicationMenuDisplayMode(FolderDisplayMode.fromString(form.getApplicationMenuDisplayMode())));
-        setProperty(form.isHelpMenuEnabledInherited(), props::clearHelpMenuEnabled, () -> props.setHelpMenuEnabled(form.isHelpMenuEnabled()));
+        setProperty(form.isHelpMenuEnabledInherited(), props::clearDocumentationMenuEnabled, () -> props.setDocumentationMenuEnabled(form.isHelpMenuEnabled()));
 
         // a few properties on this page should be restricted to operational permissions (i.e. site admin)
         if (hasAdminOpsPerm)

--- a/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
+++ b/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
@@ -198,10 +198,10 @@
     }
 %>
 <tr>
-    <td class="labkey-form-label"><label for="<%=helpMenuEnabled%>">Show LabKey Help menu item</label></td>
-    <% inherited = isInherited(laf.isHelpMenuEnabledStored()); %>
+    <td class="labkey-form-label"><label for="<%=helpMenuEnabled%>">Show LabKey Documentation menu item</label></td>
+    <% inherited = isInherited(laf.isDocumentationMenuEnabledStored()); %>
     <%=inheritCheckbox(inherited, helpMenuEnabled)%>
-    <td><input type="checkbox" id="<%=helpMenuEnabled%>" name="<%=helpMenuEnabled%>" size="<%=standardInputWidth%>"<%=checked(laf.isHelpMenuEnabled())%><%=disabled(inherited)%>></td>
+    <td><input type="checkbox" id="<%=helpMenuEnabled%>" name="<%=helpMenuEnabled%>" size="<%=standardInputWidth%>"<%=checked(laf.isDocumentationMenuEnabled())%><%=disabled(inherited)%>></td>
 </tr>
 <tr>
     <td class="labkey-form-label"><label for="<%=logoHref%>">Logo link (specifies page that header logo links to)</label></td>


### PR DESCRIPTION
#### Rationale
The "Show LabKey Help menu item" Look & Feel and Project setting actually controls the "LabKey Documentation" menu item. We might as well describe it correctly. And adjust some of the related method names for clarity.

Also, its inherit checkbox was broken because it was checking the wrong property name.

**User Education**
- No release note needed
- Consider updating text and screenshots on this page: https://www.labkey.org/Documentation/wiki-page.view?name=customizeLook

#### Tasks
- [x] Dev
- [x] Claude code review
- [x] User education handoff ([SOP](https://docs.google.com/document/d/1kmHZK73PG1A46I7QVacJYoIRfKpQwpxp0YgP7Y7a-b4/edit?usp=sharing))
- [x] Code review @labkey-klum 
- [x] Manual test / Verify fix @labkey-klum 
- [x] TeamCity review and merge