### PR TITLE
Admin option to customize frame-ancestors

### DIFF
--- a/api/src/org/labkey/api/security/Directive.java
+++ b/api/src/org/labkey/api/security/Directive.java
@@ -19,8 +19,9 @@ import org.labkey.api.settings.StartupProperty;
 import org.labkey.api.util.SafeToRenderEnum;
 
 /**
- * All CSP directives that support substitutions. These constant names are persisted to the database, so be careful with
- * any changes. If adding a Directive, make sure to add the corresponding substitutions in LabKeyServer baseCsp.
+ * All CSP directives that support substitutions. These constant names are persisted to the database, so be careful
+ * with any changes. If adding a Directive, make sure to add the corresponding substitutions to the appropriate CSP
+ * template(s) in LabKeyServer.
  */
 public enum Directive implements StartupProperty, SafeToRenderEnum
 {

--- a/api/src/org/labkey/api/security/Directive.java
+++ b/api/src/org/labkey/api/security/Directive.java
@@ -27,6 +27,7 @@ public enum Directive implements StartupProperty, SafeToRenderEnum
     Connection("connect-src", "Sources for fetch/XHR requests"),
     Font("font-src", "Sources for fonts"),
     Frame("frame-src", "Sources for iframes"),
+    FrameAncestors("frame-ancestors", "Parent hosts allowed to embed this site's resources in an <iframe>, etc."),
     Image("image-src", "Sources for images"),
     Object("object-src", "Sources for objects"), // Issue 53226
     Script("script-src", "Sources for scripts"),

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -212,11 +212,9 @@ public class ContentSecurityPolicyFilter implements Filter
 
             if (csp != null)
             {
-                if ("https".equals(req.getScheme()))
+                if ("https".equals(req.getScheme()) && resp.getHeader(REPORTING_ENDPOINTS_HEADER) == null)
                 {
-                    if (resp.getHeader(REPORTING_ENDPOINTS_HEADER) == null)
-                        resp.addHeader(REPORTING_ENDPOINTS_HEADER, _reportingEndpointsHeaderValue);
-                    csp = csp + " report-to csp-report ;";
+                    resp.addHeader(REPORTING_ENDPOINTS_HEADER, _reportingEndpointsHeaderValue);
                 }
 
                 resp.setHeader(getType().getHeaderName(), csp);
@@ -594,6 +592,21 @@ public class ContentSecurityPolicyFilter implements Filter
                     verifySubstitutionInPolicyExpressions("'none'", 0);
                     verifySubstitutionInPolicyExpressions("ObjectSource", 1);
                     verifySubstitutionInPolicyExpressions("BetterObjectStore", 1);
+
+                    unregisterAllowedSources("frameancestors", Directive.FrameAncestors);
+                    registerAllowedSources("frameancestors", Directive.FrameAncestors, "AncestorSource", "AnotherAncestor");
+                    assertEquals(7, ALLOWED_SOURCES.size());
+                    verifySubstitutionMapSize(5);
+                    // frame-ancestors is enforce-only (absent from the report CSP template), so check the substitution map directly
+                    String ancestorKey = Directive.FrameAncestors.getSubstitutionKey();
+                    assertTrue(SUBSTITUTION_MAP.get(ancestorKey).contains("AncestorSource"));
+                    assertTrue(SUBSTITUTION_MAP.get(ancestorKey).contains("AnotherAncestor"));
+                    unregisterAllowedSources("frameancestors", Directive.FrameAncestors);
+                    assertEquals(7, ALLOWED_SOURCES.size()); // Entry still exists but should be empty
+                    assertTrue(ALLOWED_SOURCES.get(Directive.FrameAncestors).isEmpty());
+                    verifySubstitutionMapSize(4); // Back to the way it was
+                    verifySubstitutionInPolicyExpressions("AncestorSource", 0);
+                    verifySubstitutionInPolicyExpressions("AnotherAncestor", 0);
                 }
                 finally
                 {

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -86,7 +86,7 @@ public class ContentSecurityPolicyFilter implements Filter
     // Per-filter-instance parameters that are set in init() and never changed
     private ContentSecurityPolicyType _type = ContentSecurityPolicyType.Enforce;
     private @NotNull String _cspVersion = "Unknown";
-    // These two are effectively @NotNull since they are set to non-null values in init() and never changed
+    // This is effectively @NotNull since it's set to non-null values in init() and never changed
     private String _stashedTemplate = null;
 
     // We can't set this statically because the class is referenced before URLProviders are available
@@ -208,13 +208,10 @@ public class ContentSecurityPolicyFilter implements Filter
     {
         if (request instanceof HttpServletRequest req && response instanceof HttpServletResponse resp)
         {
-            StringExpression expression = ensurePolicyExpression();
+            String csp = getSubstitutedCsp(req);
 
-            if (getType() != ContentSecurityPolicyType.Enforce || !OptionalFeatureService.get().isFeatureEnabled(FEATURE_FLAG_DISABLE_ENFORCE_CSP))
+            if (csp != null)
             {
-                Map<String, String> map = Map.of(NONCE_SUBST, getScriptNonceHeader(req));
-                String csp = expression.eval(map);
-
                 if ("https".equals(req.getScheme()))
                 {
                     if (resp.getHeader(REPORTING_ENDPOINTS_HEADER) == null)
@@ -226,6 +223,26 @@ public class ContentSecurityPolicyFilter implements Filter
             }
         }
         chain.doFilter(request, response);
+    }
+
+    private String getSubstitutedCsp(HttpServletRequest req)
+    {
+        StringExpression expression = ensurePolicyExpression();
+
+        if (getType() != ContentSecurityPolicyType.Enforce || !OptionalFeatureService.get().isFeatureEnabled(FEATURE_FLAG_DISABLE_ENFORCE_CSP))
+        {
+            Map<String, String> map = Map.of(NONCE_SUBST, getScriptNonceHeader(req));
+            String csp = expression.eval(map);
+
+            if ("https".equals(req.getScheme()))
+            {
+                csp = csp + " report-to csp-report ;";
+            }
+
+            return csp;
+        }
+
+        return null;
     }
 
     public ContentSecurityPolicyType getType()
@@ -345,6 +362,18 @@ public class ContentSecurityPolicyFilter implements Filter
     public static boolean hasCsp(ContentSecurityPolicyType type)
     {
         return CSP_FILTERS.get(type) != null;
+    }
+
+    public static @Nullable String getStashedTemplate(ContentSecurityPolicyType type)
+    {
+        var filter = CSP_FILTERS.get(type);
+        return filter != null ? filter._stashedTemplate : null;
+    }
+
+    public static @Nullable String getSubstitutedCsp(ContentSecurityPolicyType type, HttpServletRequest req)
+    {
+        var filter = CSP_FILTERS.get(type);
+        return filter != null ? filter.getSubstitutedCsp(req) : null;
     }
 
     public static @NotNull String getCspVersion(@Nullable String disposition)

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -317,8 +317,8 @@ import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.ViewServlet;
 import org.labkey.api.view.WebPartView;
-import org.labkey.api.view.template.EmptyView;
 import org.labkey.api.view.template.ClientDependency;
+import org.labkey.api.view.template.EmptyView;
 import org.labkey.api.view.template.PageConfig;
 import org.labkey.api.view.template.PageConfig.Template;
 import org.labkey.api.wiki.WikiRendererType;
@@ -343,6 +343,7 @@ import org.labkey.core.security.BlockListFilter;
 import org.labkey.core.security.SecurityController;
 import org.labkey.data.xml.TablesDocument;
 import org.labkey.filters.ContentSecurityPolicyFilter;
+import org.labkey.filters.ContentSecurityPolicyFilter.ContentSecurityPolicyType;
 import org.labkey.security.xml.GroupEnumType;
 import org.labkey.vfs.FileLike;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -427,9 +428,10 @@ import static org.labkey.api.util.DOM.DIV;
 import static org.labkey.api.util.DOM.IMG;
 import static org.labkey.api.util.DOM.LI;
 import static org.labkey.api.util.DOM.P;
+import static org.labkey.api.util.DOM.PRE;
 import static org.labkey.api.util.DOM.SPAN;
-import static org.labkey.api.util.DOM.STYLE;
 import static org.labkey.api.util.DOM.STRONG;
+import static org.labkey.api.util.DOM.STYLE;
 import static org.labkey.api.util.DOM.TABLE;
 import static org.labkey.api.util.DOM.TD;
 import static org.labkey.api.util.DOM.TH;
@@ -11587,6 +11589,18 @@ public class AdminController extends SpringActionController
         {
             boolean isTroubleshooter = !getContainer().hasPermission(getUser(), ApplicationAdminPermission.class);
 
+            String template = formatCsp(ContentSecurityPolicyFilter.getStashedTemplate(ContentSecurityPolicyType.Enforce), "No enforce CSP is present!");
+            String substituted = formatCsp(ContentSecurityPolicyFilter.getSubstitutedCsp(ContentSecurityPolicyType.Enforce, getViewContext().getRequest()), "Enforce CSP is disabled!");
+            HtmlView csps = new HtmlView("Current Enforce CSP",
+                TABLE(
+                    TR(
+                        TH(STRONG("With Substitution Placeholders")), TH(STRONG("With Substituted Values"))
+                    ),
+                    TR(
+                        TD(at(style, "padding-right: 20px;"), PRE(template)), TD(PRE(substituted))
+                    )
+                )
+            );
             JspView<ExternalSourcesForm> newView = new JspView<>("/org/labkey/core/admin/addNewExternalSource.jsp", form, errors);
             newView.setTitle(isTroubleshooter ? "Overview" : "Register New External Resource Host");
             newView.setFrame(WebPartView.FrameType.PORTAL);
@@ -11594,7 +11608,22 @@ public class AdminController extends SpringActionController
             existingView.setTitle("Existing External Resource Hosts");
             existingView.setFrame(WebPartView.FrameType.PORTAL);
 
-            return new VBox(newView, existingView);
+            return new VBox(csps, newView, existingView);
+        }
+
+        private String formatCsp(@Nullable String csp, String defaultValue)
+        {
+            if (csp != null)
+            {
+                csp = csp.replace("frame-ancestors", "\nframe-ancestors");
+                return Arrays.stream(csp.split(";"))
+                    .map(String::trim)
+                    .collect(Collectors.joining(" ;\n"));
+            }
+            else
+            {
+                return defaultValue;
+            }
         }
 
         private static final Object HOST_LOCK = new Object();

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11611,11 +11611,14 @@ public class AdminController extends SpringActionController
             return new VBox(csps, newView, existingView);
         }
 
+        private static final String UPGRADE_INSECURE_REQUESTS = "${UPGRADE.INSECURE.REQUESTS}";
+
         private String formatCsp(@Nullable String csp, String defaultValue)
         {
             if (csp != null)
             {
-                csp = csp.replace("frame-ancestors", "\nframe-ancestors");
+                // There's no semicolon at the end of this substitution, but we want it to show it on its own line
+                csp = csp.replace(UPGRADE_INSECURE_REQUESTS + " ", UPGRADE_INSECURE_REQUESTS + "\n");
                 return Arrays.stream(csp.split(";"))
                     .map(String::trim)
                     .collect(Collectors.joining(" ;\n"));

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11587,28 +11587,36 @@ public class AdminController extends SpringActionController
         @Override
         public ModelAndView getView(ExternalSourcesForm form, boolean reshow, BindException errors)
         {
-            boolean isTroubleshooter = !getContainer().hasPermission(getUser(), ApplicationAdminPermission.class);
+            VBox vbox = new VBox();
 
-            String template = formatCsp(ContentSecurityPolicyFilter.getStashedTemplate(ContentSecurityPolicyType.Enforce), "No enforce CSP is present!");
-            String substituted = formatCsp(ContentSecurityPolicyFilter.getSubstitutedCsp(ContentSecurityPolicyType.Enforce, getViewContext().getRequest()), "Enforce CSP is disabled!");
-            HtmlView csps = new HtmlView("Current Enforce CSP",
-                TABLE(
-                    TR(
-                        TH(STRONG("With Substitution Placeholders")), TH(STRONG("With Substituted Values"))
-                    ),
-                    TR(
-                        TD(at(style, "padding-right: 20px;"), PRE(template)), TD(PRE(substituted))
+            String template = formatCsp(ContentSecurityPolicyFilter.getStashedTemplate(ContentSecurityPolicyType.Enforce), null);
+            if (template != null)
+            {
+                String substituted = formatCsp(ContentSecurityPolicyFilter.getSubstitutedCsp(ContentSecurityPolicyType.Enforce, getViewContext().getRequest()), "Enforce CSP is disabled!");
+                vbox.addView(new HtmlView("Current Enforce CSP",
+                    TABLE(
+                        TR(
+                            TH(STRONG("With Substitution Placeholders")), TH(STRONG("With Substituted Values"))
+                        ),
+                        TR(
+                            TD(at(style, "padding-right: 20px;"), PRE(template)), TD(PRE(substituted))
+                        )
                     )
-                )
-            );
+                ));
+            }
+
             JspView<ExternalSourcesForm> newView = new JspView<>("/org/labkey/core/admin/addNewExternalSource.jsp", form, errors);
+            boolean isTroubleshooter = !getContainer().hasPermission(getUser(), ApplicationAdminPermission.class);
             newView.setTitle(isTroubleshooter ? "Overview" : "Register New External Resource Host");
             newView.setFrame(WebPartView.FrameType.PORTAL);
+            vbox.addView(newView);
+
             JspView<ExternalSourcesForm> existingView = new JspView<>("/org/labkey/core/admin/existingExternalSources.jsp", form, errors);
             existingView.setTitle("Existing External Resource Hosts");
             existingView.setFrame(WebPartView.FrameType.PORTAL);
+            vbox.addView(existingView);
 
-            return new VBox(csps, newView, existingView);
+            return vbox;
         }
 
         private static final String UPGRADE_INSECURE_REQUESTS = "${UPGRADE.INSECURE.REQUESTS}";


### PR DESCRIPTION
#### Rationale
Client request: https://github.com/LabKey/internal-issues/issues/1196

Also displaying the template and substituted CSP on the "Allowed External Resource Hosts" page now

#### Related Pull Requests
- https://github.com/LabKey/server/pull/1404

<img width="2590" height="1753" alt="image" src="https://github.com/user-attachments/assets/ade0893d-797a-4f54-a7a9-13897ca02959" />
