### PR TITLE
1185: Support incremental update of materialized samples view

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-26.006-26.007.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-26.006-26.007.sql
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+-- For samples, incremental materialized-view updates filter exp.material by (CpasType, Modified) to find rows changed
+-- since modification began. This index allows for the query to avoid a full table scan.
+CREATE INDEX IX_Material_CpasType_Modified ON exp.material (CpasType, Modified);

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-26.006-26.007.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-26.006-26.007.sql
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+-- For samples, incremental materialized-view updates filter exp.material by (CpasType, Modified) to find rows changed
+-- since modification began. This index allows for the query to avoid a full table scan.
+CREATE INDEX IX_Material_CpasType_Modified ON exp.Material (CpasType, Modified);

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -123,6 +123,7 @@ import org.labkey.experiment.api.ExpDataClassTableImpl;
 import org.labkey.experiment.api.ExpDataClassType;
 import org.labkey.experiment.api.ExpDataImpl;
 import org.labkey.experiment.api.ExpDataTableImpl;
+import org.labkey.experiment.api.ExpMaterialTableImpl;
 import org.labkey.experiment.api.ExpMaterialImpl;
 import org.labkey.experiment.api.ExpProtocolImpl;
 import org.labkey.experiment.api.ExpSampleTypeImpl;
@@ -1119,6 +1120,7 @@ public class ExperimentModule extends SpringModule
             DomainImpl.TestCase.class,
             DomainPropertyImpl.TestCase.class,
             ExpDataTableImpl.TestCase.class,
+            ExpMaterialTableImpl.IncrementalUpdateTestCase.class,
             ExperimentServiceImpl.AuditDomainUriTest.class,
             ExperimentServiceImpl.LineageQueryTestCase.class,
             ExperimentServiceImpl.ParseInputOutputAliasTestCase.class,

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -208,7 +208,7 @@ public class ExperimentModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 26.006;
+        return 26.007;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -19,6 +19,8 @@ package org.labkey.experiment.api;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.util.Precision;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.AfterClass;
@@ -136,6 +138,8 @@ import org.labkey.experiment.lineage.LineageMethod;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -168,6 +172,7 @@ import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.s
 
 public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.Column> implements ExpMaterialTable
 {
+    private static final Logger _log = LogManager.getLogger(ExpMaterialTableImpl.class);
     ExpSampleTypeImpl _ss;
     Set<String> _uniqueIdFields;
     boolean _supportTableRules = true;
@@ -185,6 +190,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         amountValidator.setColumnNameProvidedData(PROVIDED_DATA_PREFIX + StoredAmount.name());
         AMOUNT_RANGE_VALIDATORS.add(amountValidator);
     }
+
+    private static Boolean _incrementalUpdateDisabled = null;
 
     public ExpMaterialTableImpl(UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType)
     {
@@ -1358,15 +1365,43 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
              */
             List<ColumnInfo> updateColumns = new ArrayList<>();
             SQLFragment viewSql = getJoinSQL(null, updateColumns).append(" WHERE CpasType = ").appendValue(_ss.getLSID());
-            return (_MaterializedQueryHelper) new _MaterializedQueryHelper.Builder(_ss.getLSID(), "", getExpSchema().getDbSchema().getScope(), viewSql)
+            MaterializedQueryHelper.Builder builder = new _MaterializedQueryHelper.Builder(_ss.getLSID(), "", getExpSchema().getDbSchema().getScope(), viewSql)
                 .updateColumns(updateColumns)
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_rowid ON temp.${NAME} (rowid)")
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_lsid ON temp.${NAME} (lsid)")
                 .addIndex("CREATE INDEX idx_${NAME}_container ON temp.${NAME} (container)")
-                .addIndex("CREATE INDEX idx_${NAME}_root ON temp.${NAME} (rootmaterialrowid)")
-                .build();
+                .addIndex("CREATE INDEX idx_${NAME}_root ON temp.${NAME} (rootmaterialrowid)");
+
+            if (isIncrementalUpdateDisabled())
+                builder.addInvalidCheck(() -> String.valueOf(getInvalidateCounters(_ss.getLSID()).update.get()));
+
+            return (_MaterializedQueryHelper) builder.build();
         });
         return new SQLFragment("SELECT * FROM ").append(mqh.getFromSql("_cached_view_"));
+    }
+
+    /**
+     * Incremental update is dependent upon the web server and database server time being consistent.
+     * If they differ, then it can lead to stale materialized results which can lead to data integrity issues.
+     */
+    private static boolean isIncrementalUpdateDisabled()
+    {
+        if (_incrementalUpdateDisabled == null)
+        {
+            // borrowed from core/admin.jsp
+            LocalDateTime databaseTime = new SqlSelector(DbScope.getLabKeyScope(), "SELECT CURRENT_TIMESTAMP").getObject(LocalDateTime.class);
+            LocalDateTime serverTime = LocalDateTime.now();
+
+            // Disable if greater than this many seconds
+            long thresholdSeconds = 10;
+            long deltaSeconds = Math.abs(Duration.between(serverTime, databaseTime).toSeconds());
+            _incrementalUpdateDisabled = deltaSeconds > thresholdSeconds;
+
+            if (_incrementalUpdateDisabled)
+                _log.warn("Incremental update disabled for samples. Web and database server time differ by {} seconds which exceeds the threshold of {} seconds. You may experience degraded sample query performance.", deltaSeconds, thresholdSeconds);
+        }
+
+        return _incrementalUpdateDisabled;
     }
 
     /**
@@ -1536,7 +1571,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         {
             InvalidationCounters counters = getInvalidateCounters(_lsid);
             Timestamp since = counters.drainPendingUpdate();
-            if (since == null)
+            if (since == null || isIncrementalUpdateDisabled())
                 return;
 
             try

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1564,8 +1564,13 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
         SQLFragment buildIncrementalUpdateSql(@NotNull Timestamp changedSince)
         {
-            var d = CoreSchema.getInstance().getSchema().getSqlDialect();
-            SQLFragment src = appendChangedSincePredicate(getViewSourceSql(), changedSince);
+            SqlDialect d = CoreSchema.getInstance().getSchema().getSqlDialect();
+            SQLFragment src = new SQLFragment()
+                    .append(getViewSourceSql().append(" AND m.modified >= ?").add(changedSince))
+                    .append("\nUNION ALL\n")
+                    .append(getViewSourceSql()
+                            .append(" AND EXISTS (SELECT 1 FROM exp.material r WHERE r.rowid = m.rootmaterialrowid AND r.cpastype = ").appendValue(_lsid, d)
+                            .append(" AND r.modified >= ?").add(changedSince).append(")"));
 
             SQLFragment sql = new SQLFragment();
             if (d.isPostgreSQL())
@@ -1583,7 +1588,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             return sql;
         }
 
-        /** {@code col = src.col} for every re-derivable column. Both PostgreSQL and SQL Server want a bare column name on the SET left-hand side. */
         private void appendSetFromSrc(SQLFragment sql)
         {
             String comma = "";
@@ -1592,14 +1596,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 sql.append(comma).append(col).append(" = src.").append(col);
                 comma = ", ";
             }
-        }
-
-        private SQLFragment appendChangedSincePredicate(SQLFragment viewSource, @NotNull Timestamp changedSince)
-        {
-            viewSource.append(" AND (m.modified >= ?").add(changedSince);
-            viewSource.append(" OR m.rootmaterialrowid IN (SELECT rowid FROM exp.material WHERE cpastype = ").appendValue(_lsid)
-                    .append(" AND modified >= ?").add(changedSince).append("))");
-            return viewSource;
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.util.Precision;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jspecify.annotations.NonNull;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -1232,14 +1231,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     static class InvalidationCounters
     {
         public final AtomicLong update, insert, delete, rollup;
-
-        /**
-         * The earliest {@code exp.material.Modified} timestamp from which existing rows must be re-derived by the next
-         * targeted incremental update. Populated by {@link RefreshMaterializedViewRunnable#run()} <b>before</b> the
-         * {@code update} counter is incremented, so any reader that observes the new counter-value is guaranteed to see
-         * this watermark when it drains the pending state. {@code null} means no targeted update is pending. Min-merged so
-         * the watermark always covers the oldest not-yet-applied change.
-         */
         public final AtomicReference<Timestamp> pendingUpdateSince = new AtomicReference<>();
 
         InvalidationCounters()
@@ -1251,17 +1242,11 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             rollup = new AtomicLong(l);
         }
 
-        /** Record the watermark for one update (before its counter-increment), min-merged so it covers the oldest pending change. */
         void recordPendingUpdate(@NotNull Timestamp changedSince)
         {
             pendingUpdateSince.accumulateAndGet(changedSince, (cur, next) -> cur == null || next.before(cur) ? next : cur);
         }
 
-        /**
-         * Atomically take and clear the pending watermark. Should be called under the {@code _Materialized} loading lock.
-         * Read with {@code getAndSet(null)} so a timestamp recorded concurrently by a later POSTCOMMIT runnable survives
-         * for the next drain. Returns null when no targeted update is pending.
-         */
         @Nullable Timestamp drainPendingUpdate()
         {
             return pendingUpdateSince.getAndSet(null);
@@ -1342,7 +1327,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
 
         @Override
-        public @NonNull String toString()
+        public @NotNull String toString()
         {
             return "RefreshMaterializedViewRunnable{lsid=" + lsid + ", reason=" + reason + ", changedSince=" + changedSince + "}";
         }
@@ -1368,11 +1353,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
              * Previously it has been used on non-provisioned tables.  It might be helpful to have a pattern,
              * even if just to help with race-conditions.
              *
-             * Maybe have a callback to generate the SQL dynamically, and verify that the sql is unchanged.
+             * Maybe have a callback to generate the SQL dynamically and verify that the SQL is unchanged.
              */
-            // Collect the temp-table column identifiers (minus immutable join keys) from the same SELECT that builds the
-            // view, so the incremental UPDATE re-assigns exactly the columns this SELECT produces. Safe to cache: a schema
-            // change drops this MQH from the cache (reason == schema), so a changed column set always rebuilds fresh.
             List<SQLFragment> updateColumns = new ArrayList<>();
             SQLFragment viewSql = getJoinSQL(null, updateColumns).append(" WHERE CpasType = ").appendValue(_ss.getLSID());
             return (_MaterializedQueryHelper) new _MaterializedQueryHelper.Builder(_ss.getLSID(), "", getExpSchema().getDbSchema().getScope(), viewSql)
@@ -1381,9 +1363,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_lsid ON temp.${NAME} (lsid)")
                 .addIndex("CREATE INDEX idx_${NAME}_container ON temp.${NAME} (container)")
                 .addIndex("CREATE INDEX idx_${NAME}_root ON temp.${NAME} (rootmaterialrowid)")
-                // NOTE: no addInvalidCheck for the update counter. Updates are now applied incrementally by
-                // executeIncrementalUpdate() (like insert/delete/rollup) rather than triggering a full drop-and-rebuild.
-                // The MQH is still dropped on schema changes and on incremental-update errors (see incrementalUpdateBeforeSelect).
                 .build();
         });
         return new SQLFragment("SELECT * FROM ").append(mqh.getFromSql("_cached_view_"));
@@ -1397,7 +1376,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     static class _MaterializedQueryHelper extends MaterializedQueryHelper
     {
         final String _lsid;
-        /** The temp-table column identifiers (minus immutable join keys) that an incremental UPDATE re-derives. */
         final List<SQLFragment> _updateColumns;
 
         static class Builder extends MaterializedQueryHelper.Builder
@@ -1424,8 +1402,18 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             }
         }
 
-        _MaterializedQueryHelper(String lsid, List<SQLFragment> updateColumns, String prefix, DbScope scope, SQLFragment select, @Nullable SQLFragment uptodate, Supplier<String> supplier, @Nullable Collection<String> indexes, long maxTimeToCache,
-                                        boolean isSelectIntoSql)
+        _MaterializedQueryHelper(
+            String lsid,
+            List<SQLFragment> updateColumns,
+            String prefix,
+            DbScope scope,
+            SQLFragment select,
+            @Nullable SQLFragment uptodate,
+            Supplier<String> supplier,
+            @Nullable Collection<String> indexes,
+            long maxTimeToCache,
+            boolean isSelectIntoSql
+        )
         {
             super(prefix, scope, select, uptodate, supplier, indexes, maxTimeToCache, isSelectIntoSql);
             this._lsid = lsid;
@@ -1565,12 +1553,16 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         SQLFragment buildIncrementalUpdateSql(@NotNull Timestamp changedSince)
         {
             SqlDialect d = CoreSchema.getInstance().getSchema().getSqlDialect();
+            // SQL Server's datetime type lacks microsecond precision
+            Timestamp comparison = d.isSqlServer() ? new Timestamp(changedSince.getTime() - 500) : changedSince;
+
             SQLFragment src = new SQLFragment()
-                    .append(getViewSourceSql().append(" AND m.modified >= ?").add(changedSince))
+                    .append(getViewSourceSql().append(" AND m.modified >= ?").add(comparison))
                     .append("\nUNION ALL\n")
                     .append(getViewSourceSql()
+                            .append(" AND m.rootmaterialrowid <> m.rowid")
                             .append(" AND EXISTS (SELECT 1 FROM exp.material r WHERE r.rowid = m.rootmaterialrowid AND r.cpastype = ").appendValue(_lsid, d)
-                            .append(" AND r.modified >= ?").add(changedSince).append(")"));
+                            .append(" AND r.modified >= ?").add(comparison).append(")"));
 
             SQLFragment sql = new SQLFragment();
             if (d.isPostgreSQL())
@@ -1585,6 +1577,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 appendSetFromSrc(sql);
                 sql.append("\nFROM temp.${NAME} st INNER JOIN (").append(src).append("\n) src ON st.rowid = src.rowid");
             }
+
             return sql;
         }
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -41,6 +41,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DataRegion;
+import org.labkey.api.data.DatabaseIdentifier;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.ForeignKey;
@@ -1355,7 +1356,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
              *
              * Maybe have a callback to generate the SQL dynamically and verify that the SQL is unchanged.
              */
-            List<SQLFragment> updateColumns = new ArrayList<>();
+            List<ColumnInfo> updateColumns = new ArrayList<>();
             SQLFragment viewSql = getJoinSQL(null, updateColumns).append(" WHERE CpasType = ").appendValue(_ss.getLSID());
             return (_MaterializedQueryHelper) new _MaterializedQueryHelper.Builder(_ss.getLSID(), "", getExpSchema().getDbSchema().getScope(), viewSql)
                 .updateColumns(updateColumns)
@@ -1376,12 +1377,12 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     static class _MaterializedQueryHelper extends MaterializedQueryHelper
     {
         final String _lsid;
-        final List<SQLFragment> _updateColumns;
+        final List<ColumnInfo> _updateColumns;
 
         static class Builder extends MaterializedQueryHelper.Builder
         {
             String _lsid;
-            List<SQLFragment> _updateColumns = List.of();
+            List<ColumnInfo> _updateColumns = List.of();
 
             public Builder(String lsid, String prefix, DbScope scope, SQLFragment select)
             {
@@ -1389,7 +1390,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 this._lsid = lsid;
             }
 
-            public Builder updateColumns(List<SQLFragment> updateColumns)
+            public Builder updateColumns(List<ColumnInfo> updateColumns)
             {
                 this._updateColumns = updateColumns;
                 return this;
@@ -1404,7 +1405,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
         _MaterializedQueryHelper(
             String lsid,
-            List<SQLFragment> updateColumns,
+            List<ColumnInfo> updateColumns,
             String prefix,
             DbScope scope,
             SQLFragment select,
@@ -1584,9 +1585,10 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         private void appendSetFromSrc(SQLFragment sql)
         {
             String comma = "";
-            for (SQLFragment col : _updateColumns)
+            for (ColumnInfo col : _updateColumns)
             {
-                sql.append(comma).append(col).append(" = src.").append(col);
+                DatabaseIdentifier identifier = col.getSelectIdentifier();
+                sql.append(comma).appendIdentifier(identifier).append(" = src.").appendIdentifier(identifier);
                 comma = ", ";
             }
         }
@@ -1627,7 +1629,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     }
 
     /** Immutable join-key columns that an incremental UPDATE never re-derives (excluded from the re-assign list). */
-    static final Set<String> IMMUTABLE_UPDATE_COLUMNS = new CaseInsensitiveHashSet(RowId.name(), LSID.name(), CpasType.name(), RootMaterialRowId.name());
+    static final Set<FieldKey> IMMUTABLE_UPDATE_COLUMNS = Set.of(RowId.fieldKey(), LSID.fieldKey(), CpasType.fieldKey(), RootMaterialRowId.fieldKey());
 
     /* SELECT and JOIN, does not include WHERE */
     private SQLFragment getJoinSQL(Set<FieldKey> selectedColumns)
@@ -1635,7 +1637,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         return getJoinSQL(selectedColumns, null);
     }
 
-    private SQLFragment getJoinSQL(Set<FieldKey> selectedColumns, @Nullable List<SQLFragment> outUpdateColumns)
+    private SQLFragment getJoinSQL(Set<FieldKey> selectedColumns, @Nullable List<ColumnInfo> outUpdateColumns)
     {
         TableInfo provisioned = null == _ss ? null : _ss.getTinfo();
         Set<String> provisionedCols = new CaseInsensitiveHashSet(provisioned != null ? provisioned.getColumnNameSet() : Collections.emptySet());
@@ -1645,22 +1647,22 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         boolean hasSampleColumns = false;
         boolean hasAliquotColumns = false;
 
-        Set<String> materialCols = new CaseInsensitiveHashSet(_rootTable.getColumnNameSet());
+        List<ColumnInfo> materialCols = _rootTable.getColumns();
         selectedColumns = computeInnerSelectedColumns(selectedColumns);
 
         SQLFragment sql = new SQLFragment();
         sql.appendComment("<ExpMaterialTableImpl.getJoinSQL(" + (null == _ss ? "" : _ss.getName()) + ")>", getSqlDialect());
         sql.append("SELECT ");
         String comma = "";
-        for (String materialCol : materialCols)
+        for (ColumnInfo materialCol : materialCols)
         {
             // don't need to generate SQL for columns that aren't selected
-            if (ALL_COLUMNS == selectedColumns || selectedColumns.contains(new FieldKey(null, materialCol)))
+            if (ALL_COLUMNS == selectedColumns || selectedColumns.contains(materialCol.getFieldKey()))
             {
-                sql.append(comma).append("m.").appendIdentifier(materialCol);
+                sql.append(comma).append("m.").appendIdentifier(materialCol.getSelectIdentifier());
                 comma = ", ";
-                if (null != outUpdateColumns && !IMMUTABLE_UPDATE_COLUMNS.contains(materialCol))
-                    outUpdateColumns.add(new SQLFragment().appendIdentifier(materialCol));
+                if (null != outUpdateColumns && !IMMUTABLE_UPDATE_COLUMNS.contains(materialCol.getFieldKey()))
+                    outUpdateColumns.add(materialCol);
             }
         }
 
@@ -1682,7 +1684,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 {
                     boolean rootField = StringUtils.isEmpty(propertyColumn.getDerivationDataScope())
                             || ExpSchema.DerivationDataScopeType.ParentOnly.name().equalsIgnoreCase(propertyColumn.getDerivationDataScope());
-                    SQLFragment tempColumnSql = propertyColumn.getSelectIdentifier().getSql();
                     String alias;
                     if ("genid".equalsIgnoreCase(propertyColumn.getColumnName()) || propertyColumn.isUniqueIdField())
                     {
@@ -1699,11 +1700,13 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                         alias = "m_aliquot";
                         hasAliquotColumns = true;
                     }
-                    sql.append(comma).append(propertyColumn.getValueSql(alias)).append(" AS ").append(tempColumnSql);
+
+                    sql.append(comma).append(propertyColumn.getValueSql(alias)).append(" AS ").appendIdentifier(propertyColumn.getSelectIdentifier());
                     comma = ", ";
+
                     // provisioned columns are never immutable join keys, so always re-derivable on update
                     if (null != outUpdateColumns)
-                        outUpdateColumns.add(tempColumnSql);
+                        outUpdateColumns.add(propertyColumn);
                 }
             }
         }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1370,12 +1370,13 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
              *
              * Maybe have a callback to generate the SQL dynamically, and verify that the sql is unchanged.
              */
-            SQLFragment viewSql = getJoinSQL(null).append(" WHERE CpasType = ").appendValue(_ss.getLSID());
-            // Capture the column mapping for incremental updates. Safe to cache: a schema change drops this MQH from the
-            // cache (reason == schema), so a changed column set always rebuilds with a fresh mapping.
-            JoinColumns joinColumns = getJoinColumns(null);
+            // Collect the temp-table column identifiers (minus immutable join keys) from the same SELECT that builds the
+            // view, so the incremental UPDATE re-assigns exactly the columns this SELECT produces. Safe to cache: a schema
+            // change drops this MQH from the cache (reason == schema), so a changed column set always rebuilds fresh.
+            List<SQLFragment> updateColumns = new ArrayList<>();
+            SQLFragment viewSql = getJoinSQL(null, updateColumns).append(" WHERE CpasType = ").appendValue(_ss.getLSID());
             return (_MaterializedQueryHelper) new _MaterializedQueryHelper.Builder(_ss.getLSID(), "", getExpSchema().getDbSchema().getScope(), viewSql)
-                .joinColumns(joinColumns)
+                .updateColumns(updateColumns)
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_rowid ON temp.${NAME} (rowid)")
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_lsid ON temp.${NAME} (lsid)")
                 .addIndex("CREATE INDEX idx_${NAME}_container ON temp.${NAME} (container)")
@@ -1395,17 +1396,14 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
      */
     static class _MaterializedQueryHelper extends MaterializedQueryHelper
     {
-        /** Columns that an incremental UPDATE never re-derives */
-        static final Set<String> IMMUTABLE_UPDATE_COLUMNS = new CaseInsensitiveHashSet(RowId.name(), LSID.name(), CpasType.name(), RootMaterialRowId.name());
-
         final String _lsid;
-        /** The column mapping that produced the temp table, used to build the incremental UPDATE SET clauses. */
-        final JoinColumns _joinColumns;
+        /** The temp-table column identifiers (minus immutable join keys) that an incremental UPDATE re-derives. */
+        final List<SQLFragment> _updateColumns;
 
         static class Builder extends MaterializedQueryHelper.Builder
         {
             String _lsid;
-            JoinColumns _joinColumns;
+            List<SQLFragment> _updateColumns = List.of();
 
             public Builder(String lsid, String prefix, DbScope scope, SQLFragment select)
             {
@@ -1413,25 +1411,25 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 this._lsid = lsid;
             }
 
-            public Builder joinColumns(JoinColumns joinColumns)
+            public Builder updateColumns(List<SQLFragment> updateColumns)
             {
-                this._joinColumns = joinColumns;
+                this._updateColumns = updateColumns;
                 return this;
             }
 
             @Override
             public _MaterializedQueryHelper build()
             {
-                return new _MaterializedQueryHelper(_lsid, _joinColumns, _prefix, _scope, _select, _uptodate, _supplier, _indexes, _max, _isSelectInto);
+                return new _MaterializedQueryHelper(_lsid, _updateColumns, _prefix, _scope, _select, _uptodate, _supplier, _indexes, _max, _isSelectInto);
             }
         }
 
-        _MaterializedQueryHelper(String lsid, JoinColumns joinColumns, String prefix, DbScope scope, SQLFragment select, @Nullable SQLFragment uptodate, Supplier<String> supplier, @Nullable Collection<String> indexes, long maxTimeToCache,
+        _MaterializedQueryHelper(String lsid, List<SQLFragment> updateColumns, String prefix, DbScope scope, SQLFragment select, @Nullable SQLFragment uptodate, Supplier<String> supplier, @Nullable Collection<String> indexes, long maxTimeToCache,
                                         boolean isSelectIntoSql)
         {
             super(prefix, scope, select, uptodate, supplier, indexes, maxTimeToCache, isSelectIntoSql);
             this._lsid = lsid;
-            this._joinColumns = joinColumns;
+            this._updateColumns = updateColumns;
         }
 
         @Override
@@ -1567,84 +1565,41 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         SQLFragment buildIncrementalUpdateSql(@NotNull Timestamp changedSince)
         {
             var d = CoreSchema.getInstance().getSchema().getSqlDialect();
-            JoinColumns jc = _joinColumns;
-
-            // Re-derive every temp column except the join key and immutable columns
-            List<JoinColumn> setColumns = jc.columns.stream()
-                    .filter(c -> !IMMUTABLE_UPDATE_COLUMNS.contains(c.tempColumnName()))
-                    .toList();
+            SQLFragment src = appendChangedSincePredicate(getViewSourceSql(), changedSince);
 
             SQLFragment sql = new SQLFragment();
             if (d.isPostgreSQL())
             {
                 sql.append("UPDATE temp.${NAME} AS st\nSET ");
-                appendSetClause(sql, setColumns);
-                sql.append("\nFROM exp.Material m");
-                appendProvisionedJoins(sql, jc);
-                sql.append("\nWHERE st.rowid = m.rowid AND m.cpastype = ").appendValue(_lsid, d);
-                appendModifiedSincePredicate(sql, d, changedSince);
-                sql.append(" AND (");
-                String or = "";
-                for (JoinColumn c : setColumns)
-                {
-                    sql.append(or).append("st.").append(c.tempColumnSql()).append(" IS DISTINCT FROM ").append(c.sourceSql());
-                    or = " OR ";
-                }
-                sql.append(")");
+                appendSetFromSrc(sql);
+                sql.append("\nFROM (").append(src).append("\n) src\n").append("WHERE st.rowid = src.rowid");
             }
             else
             {
                 sql.append("UPDATE st\nSET ");
-                appendSetClause(sql, setColumns);
-                sql.append("\nFROM temp.${NAME} st INNER JOIN exp.Material m ON st.rowid = m.rowid");
-                appendProvisionedJoins(sql, jc);
-                sql.append("\nWHERE m.cpastype = ").appendValue(_lsid, d);
-                appendModifiedSincePredicate(sql, d, changedSince);
-                // SQL Server before 2022 has no IS DISTINCT FROM; "SELECT <st cols> EXCEPT SELECT <src cols>" is a portable
-                // null-safe tuple comparison that yields a row iff the tuples differ.
-                sql.append(" AND EXISTS (SELECT ");
-                String comma = "";
-                for (JoinColumn c : setColumns)
-                {
-                    sql.append(comma).append("st.").append(c.tempColumnSql());
-                    comma = ", ";
-                }
-                sql.append(" EXCEPT SELECT ");
-                comma = "";
-                for (JoinColumn c : setColumns)
-                {
-                    sql.append(comma).append(c.sourceSql());
-                    comma = ", ";
-                }
-                sql.append(")");
+                appendSetFromSrc(sql);
+                sql.append("\nFROM temp.${NAME} st INNER JOIN (").append(src).append("\n) src ON st.rowid = src.rowid");
             }
             return sql;
         }
 
-        private static void appendSetClause(SQLFragment sql, List<JoinColumn> setColumns)
+        /** {@code col = src.col} for every re-derivable column. Both PostgreSQL and SQL Server want a bare column name on the SET left-hand side. */
+        private void appendSetFromSrc(SQLFragment sql)
         {
             String comma = "";
-            for (JoinColumn c : setColumns)
+            for (SQLFragment col : _updateColumns)
             {
-                // PostgreSQL and SQL Server both want bare column names on the SET left-hand side.
-                sql.append(comma).append(c.tempColumnSql()).append(" = ").append(c.sourceSql());
+                sql.append(comma).append(col).append(" = src.").append(col);
                 comma = ", ";
             }
         }
 
-        private static void appendProvisionedJoins(SQLFragment sql, JoinColumns jc)
+        private SQLFragment appendChangedSincePredicate(SQLFragment viewSource, @NotNull Timestamp changedSince)
         {
-            if (jc.hasSampleColumns)
-                sql.append(" INNER JOIN ").append(jc.provisioned, "m_sample").append(" ON m.RootMaterialRowId = m_sample.RowId");
-            if (jc.hasAliquotColumns)
-                sql.append(" INNER JOIN ").append(jc.provisioned, "m_aliquot").append(" ON m.RowId = m_aliquot.RowId");
-        }
-
-        private void appendModifiedSincePredicate(SQLFragment sql, SqlDialect d, @NotNull Timestamp changedSince)
-        {
-            sql.append(" AND (m.modified >= ?").add(changedSince);
-            sql.append(" OR m.rootmaterialrowid IN (SELECT rowid FROM exp.material WHERE cpastype = ").appendValue(_lsid, d)
+            viewSource.append(" AND (m.modified >= ?").add(changedSince);
+            viewSource.append(" OR m.rootmaterialrowid IN (SELECT rowid FROM exp.material WHERE cpastype = ").appendValue(_lsid)
                     .append(" AND modified >= ?").add(changedSince).append("))");
+            return viewSource;
         }
     }
 
@@ -1682,68 +1637,47 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
     }
 
-    /**
-     * Which join alias a materialized-view column is sourced from:
-     * <ul>
-     *   <li>{@code m} &ndash; the row's own {@code exp.material} record</li>
-     *   <li>{@code m_sample} &ndash; the <b>root</b> material's provisioned row (root-derived / {@code ParentOnly} columns)</li>
-     *   <li>{@code m_aliquot} &ndash; the row's <b>own</b> provisioned row (aliquot-scoped columns plus {@code genid} / unique-id fields)</li>
-     * </ul>
-     */
-    enum JoinAlias { m, m_sample, m_aliquot }
+    /** Immutable join-key columns that an incremental UPDATE never re-derives (excluded from the re-assign list). */
+    static final Set<String> IMMUTABLE_UPDATE_COLUMNS = new CaseInsensitiveHashSet(RowId.name(), LSID.name(), CpasType.name(), RootMaterialRowId.name());
 
-    /**
-     * One column of the materialized join: the unencoded temp-table column name, the SQL reference to that column, the SQL
-     * expression that produces its value, and which join alias that expression reads from. This is the single source of
-     * truth shared by {@link #getJoinSQL} (which builds the SELECT that creates the temp table) and the incremental
-     * {@code UPDATE} paths (which build the SET clause). Keeping both consumers on this one mapping guarantees the temp
-     * column references and the SET expressions can never drift. {@code tempColumnSql} is the valid SQL reference (e.g., a
-     * quoted identifier) by which the column is named in the temp table; use it bare as an UPDATE SET target, or prefix it
-     * with a table alias (e.g., {@code st.}) to reference it elsewhere. {@code tempColumnName} is the unencoded name, useful
-     * for identifying a specific column (e.g., the {@code rowid} join key).
-     */
-    record JoinColumn(String tempColumnName, SQLFragment tempColumnSql, SQLFragment sourceSql, JoinAlias alias) {}
-
-    /**
-     * The ordered column mapping for the materialized join plus which provisioned joins are actually needed. Mirrors the
-     * {@code hasSampleColumns} / {@code hasAliquotColumns} bookkeeping that {@link #getJoinSQL} previously tracked inline.
-     */
-    static class JoinColumns
+    /* SELECT and JOIN, does not include WHERE */
+    private SQLFragment getJoinSQL(Set<FieldKey> selectedColumns)
     {
-        final List<JoinColumn> columns = new ArrayList<>();
-        TableInfo provisioned = null;
-        boolean hasSampleColumns = false;   // m_sample join required
-        boolean hasAliquotColumns = false;  // m_aliquot join required
+        return getJoinSQL(selectedColumns, null);
     }
 
-    /**
-     * Classify every selected column into its temp-table name, source expression, and join alias, preserving exactly the
-     * rules previously inlined in {@link #getJoinSQL}: material columns &rarr; {@code m}; {@code genid} / unique-id fields
-     * &rarr; {@code m_aliquot}; root-derived ({@code ParentOnly} or empty derivation scope) &rarr; {@code m_sample}; all
-     * other provisioned columns &rarr; {@code m_aliquot}; MV-indicator columns are always included.
-     */
-    private JoinColumns getJoinColumns(Set<FieldKey> selectedColumns)
+    private SQLFragment getJoinSQL(Set<FieldKey> selectedColumns, @Nullable List<SQLFragment> outUpdateColumns)
     {
-        JoinColumns result = new JoinColumns();
-        result.provisioned = null == _ss ? null : _ss.getTinfo();
-        Set<String> provisionedCols = new CaseInsensitiveHashSet(result.provisioned != null ? result.provisioned.getColumnNameSet() : Collections.emptySet());
+        TableInfo provisioned = null == _ss ? null : _ss.getTinfo();
+        Set<String> provisionedCols = new CaseInsensitiveHashSet(provisioned != null ? provisioned.getColumnNameSet() : Collections.emptySet());
         provisionedCols.remove(RowId.name());
         provisionedCols.remove(Name.name());
         boolean hasProvisionedColumns = containsProvisionedColumns(selectedColumns, provisionedCols);
+        boolean hasSampleColumns = false;
+        boolean hasAliquotColumns = false;
 
         Set<String> materialCols = new CaseInsensitiveHashSet(_rootTable.getColumnNameSet());
         selectedColumns = computeInnerSelectedColumns(selectedColumns);
 
+        SQLFragment sql = new SQLFragment();
+        sql.appendComment("<ExpMaterialTableImpl.getJoinSQL(" + (null == _ss ? "" : _ss.getName()) + ")>", getSqlDialect());
+        sql.append("SELECT ");
+        String comma = "";
         for (String materialCol : materialCols)
         {
             // don't need to generate SQL for columns that aren't selected
             if (ALL_COLUMNS == selectedColumns || selectedColumns.contains(new FieldKey(null, materialCol)))
-                result.columns.add(new JoinColumn(materialCol, new SQLFragment().appendIdentifier(materialCol), new SQLFragment("m.").appendIdentifier(materialCol), JoinAlias.m));
+            {
+                sql.append(comma).append("m.").appendIdentifier(materialCol);
+                comma = ", ";
+                if (null != outUpdateColumns && !IMMUTABLE_UPDATE_COLUMNS.contains(materialCol))
+                    outUpdateColumns.add(new SQLFragment().appendIdentifier(materialCol));
+            }
         }
 
-        if (null != result.provisioned && hasProvisionedColumns)
+        if (null != provisioned && hasProvisionedColumns)
         {
-            for (ColumnInfo propertyColumn : result.provisioned.getColumns())
+            for (ColumnInfo propertyColumn : provisioned.getColumns())
             {
                 // don't select twice
                 if (
@@ -1759,54 +1693,38 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 {
                     boolean rootField = StringUtils.isEmpty(propertyColumn.getDerivationDataScope())
                             || ExpSchema.DerivationDataScopeType.ParentOnly.name().equalsIgnoreCase(propertyColumn.getDerivationDataScope());
-                    String tempColumnName = propertyColumn.getSelectIdentifier().getId();
                     SQLFragment tempColumnSql = propertyColumn.getSelectIdentifier().getSql();
+                    String alias;
                     if ("genid".equalsIgnoreCase(propertyColumn.getColumnName()) || propertyColumn.isUniqueIdField())
                     {
-                        result.columns.add(new JoinColumn(tempColumnName, tempColumnSql, propertyColumn.getValueSql("m_aliquot"), JoinAlias.m_aliquot));
-                        result.hasAliquotColumns = true;
+                        alias = "m_aliquot";
+                        hasAliquotColumns = true;
                     }
                     else if (rootField)
                     {
-                        result.columns.add(new JoinColumn(tempColumnName, tempColumnSql, propertyColumn.getValueSql("m_sample"), JoinAlias.m_sample));
-                        result.hasSampleColumns = true;
+                        alias = "m_sample";
+                        hasSampleColumns = true;
                     }
                     else
                     {
-                        result.columns.add(new JoinColumn(tempColumnName, tempColumnSql, propertyColumn.getValueSql("m_aliquot"), JoinAlias.m_aliquot));
-                        result.hasAliquotColumns = true;
+                        alias = "m_aliquot";
+                        hasAliquotColumns = true;
                     }
+                    sql.append(comma).append(propertyColumn.getValueSql(alias)).append(" AS ").append(tempColumnSql);
+                    comma = ", ";
+                    // provisioned columns are never immutable join keys, so always re-derivable on update
+                    if (null != outUpdateColumns)
+                        outUpdateColumns.add(tempColumnSql);
                 }
             }
         }
 
-        return result;
-    }
-
-    /* SELECT and JOIN, does not include WHERE */
-    private SQLFragment getJoinSQL(Set<FieldKey> selectedColumns)
-    {
-        JoinColumns joinColumns = getJoinColumns(selectedColumns);
-
-        SQLFragment sql = new SQLFragment();
-        sql.appendComment("<ExpMaterialTableImpl.getJoinSQL(" + (null == _ss ? "" : _ss.getName()) + ")>", getSqlDialect());
-        sql.append("SELECT ");
-        String comma = "";
-        for (JoinColumn joinColumn : joinColumns.columns)
-        {
-            sql.append(comma).append(joinColumn.sourceSql());
-            // material columns are selected by name (no alias); provisioned columns are aliased to their temp-table column name
-            if (JoinAlias.m != joinColumn.alias())
-                sql.append(" AS ").append(joinColumn.tempColumnSql());
-            comma = ", ";
-        }
-
         sql.append("\nFROM ");
         sql.append(_rootTable, "m");
-        if (joinColumns.hasSampleColumns)
-            sql.append(" INNER JOIN ").append(joinColumns.provisioned, "m_sample").append(" ON m.RootMaterialRowId = m_sample.RowId");
-        if (joinColumns.hasAliquotColumns)
-            sql.append(" INNER JOIN ").append(joinColumns.provisioned, "m_aliquot").append(" ON m.RowId = m_aliquot.RowId");
+        if (hasSampleColumns)
+            sql.append(" INNER JOIN ").append(provisioned, "m_sample").append(" ON m.RootMaterialRowId = m_sample.RowId");
+        if (hasAliquotColumns)
+            sql.append(" INNER JOIN ").append(provisioned, "m_aliquot").append(" ON m.RowId = m_aliquot.RowId");
 
         sql.appendComment("</ExpMaterialTableImpl.getJoinSQL()>", getSqlDialect());
         return sql;

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -134,6 +134,7 @@ import org.labkey.experiment.lineage.LineageMethod;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -144,10 +145,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -1226,32 +1227,23 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     }
 
 
-    /**
-     * Once the pending changed-rowid set for a single update grows past this size, a targeted incremental update is no
-     * longer worth it (the changed-rowid IN list grows and the win over a whole-join re-sync shrinks), so we escalate to a
-     * full re-sync instead. Chosen to match the application's bulk-edit cap of 1,000 rows, so a normal single update stays
-     * targeted.
-     * <p>
-     * This value is also bounded by SQL Server's 2,100-bind-parameter limit: the targeted predicate references the changed
-     * set twice ({@code m.rowid IN (...) OR m.rootmaterialrowid IN (...)}), so a targeted statement binds {@code 2*N + 1}
-     * parameters. At 1,000 that is 2,001, safely under the cap. Raising this past ~1,049 would require restructuring the
-     * predicate to avoid using the set twice.
-     */
-    static final int UPDATE_ROWID_THRESHOLD = 1_000;
-
     static class InvalidationCounters
     {
         public final AtomicLong update, insert, delete, rollup;
 
         /**
-         * The accumulated exp.material rowIds changed by {@code update}s since the last drain, used to drive a targeted
+         * The earliest {@code exp.material.Modified} timestamp from which rows must be re-derived by the next targeted
          * incremental update. Populated by {@link RefreshMaterializedViewRunnable#run()} <b>before</b> the {@code update}
-         * counter is incremented, so any reader that observes the new counter-value is guaranteed to see these rowids.
+         * counter is incremented, so any reader that observes the new counter-value is guaranteed to see this watermark
+         * when it drains the pending state. {@code null} means no targeted update is pending. Min-merged so the watermark
+         * always covers the oldest not-yet-applied change. Because {@code Modified} is written with the database clock
+         * (the constant {@code NowTimestamp} is inlined as {@code CURRENT_TIMESTAMP}), this timestamp is comparable to it
+         * directly, with no web-server-vs-database clock skew.
          */
-        public final Set<Integer> pendingUpdateRowIds = ConcurrentHashMap.newKeySet();
+        public final AtomicReference<Timestamp> pendingUpdateSince = new AtomicReference<>();
         /**
-         * Set when an {@code update} could not supply rowIds (or the pending set crossed {@link #UPDATE_ROWID_THRESHOLD}),
-         * meaning the next read must do a full re-sync rather than a targeted update.
+         * Set when an {@code update} could not supply a watermark timestamp, meaning the next read must do a full re-sync
+         * rather than a targeted update.
          */
         public volatile boolean fullUpdatePending = false;
 
@@ -1264,47 +1256,39 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             rollup = new AtomicLong(l);
         }
 
-        /** Record the rowIds changed by one update (before its counter-increment). null/empty rowIds force a full re-sync. */
-        void recordPendingUpdate(@Nullable Set<Integer> changedRowIds)
+        /**
+         * Record the watermark for one update (before its counter-increment). A null timestamp means the caller could
+         * not capture a change time, forcing a full re-sync; otherwise the watermark is min-merged so it covers the
+         * oldest pending change.
+         */
+        void recordPendingUpdate(@Nullable Timestamp changedSince)
         {
-            if (changedRowIds == null || changedRowIds.isEmpty())
-            {
+            if (changedSince == null)
                 fullUpdatePending = true;
-                pendingUpdateRowIds.clear();
-            }
-            else if (!fullUpdatePending)
-            {
-                pendingUpdateRowIds.addAll(changedRowIds);
-                if (pendingUpdateRowIds.size() > UPDATE_ROWID_THRESHOLD)
-                {
-                    fullUpdatePending = true;
-                    pendingUpdateRowIds.clear();
-                }
-            }
-            // else: a full re-sync is already pending; the individual rowIds are redundant
+            else
+                pendingUpdateSince.accumulateAndGet(changedSince, (cur, next) -> cur == null || next.before(cur) ? next : cur);
         }
 
-        /** The drained pending update state: either a full re-sync or the specific rowIds to target. */
-        record PendingUpdate(boolean full, Set<Integer> rowIds) {}
+        /** The drained pending update state: either a full re-sync or the watermark to target. */
+        record PendingUpdate(boolean full, @Nullable Timestamp since) {}
 
         /**
-         * Atomically take and clear the pending update state. Should be called under the {@code _Materialized} loading lock.
-         * A snapshot of the rowIds is removed (not the live set) so any rowIds added concurrently by a POSTCOMMIT runnable
-         * survive for the next drain.
+         * Atomically take and clear the pending update state. Should be called under the {@code _Materialized} loading
+         * lock. The watermark is read with {@code getAndSet(null)} so a timestamp recorded concurrently by a later
+         * POSTCOMMIT runnable survives for the next drain. A full re-sync clears any pending watermark: the re-sync
+         * already covers every committed row (a recorded watermark only ever corresponds to an already-committed change,
+         * since the POSTCOMMIT runnable runs after commit), so the watermark would be redundant.
          */
         PendingUpdate drainPendingUpdate()
         {
             if (fullUpdatePending)
             {
                 fullUpdatePending = false;
-                pendingUpdateRowIds.clear();
-                return new PendingUpdate(true, Set.of());
+                pendingUpdateSince.set(null);
+                return new PendingUpdate(true, null);
             }
-            if (pendingUpdateRowIds.isEmpty())
-                return new PendingUpdate(false, Set.of());
-            Set<Integer> drained = new HashSet<>(pendingUpdateRowIds);
-            pendingUpdateRowIds.removeAll(drained);
-            return new PendingUpdate(false, drained);
+
+            return new PendingUpdate(false, pendingUpdateSince.getAndSet(null));
         }
     }
 
@@ -1312,32 +1296,32 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     static final Map<String, InvalidationCounters> _invalidationCounters = Collections.synchronizedMap(new HashMap<>());
     static final AtomicBoolean initializedListeners = new AtomicBoolean(false);
 
-    // used by SampleTypeServiceImpl.refreshSampleTypeMaterializedView()
     public static void refreshMaterializedView(final String lsid, SampleTypeServiceImpl.SampleChangeType reason)
     {
         refreshMaterializedView(lsid, reason, null);
     }
 
     /**
-     * @param changedRowIds the exp.material rowIds known to have changed (only meaningful for update); null means
-     *                      the caller could not list the changed rows, forcing a full re-sync on the next read.
+     * @param changedSince a watermark (from the database clock, captured before the update's writes) at or after which
+     *                     the changed {@code exp.material} rows were modified; only meaningful for update. null means
+     *                     the caller could not capture a watermark, forcing a full re-sync on the next read.
      */
-    public static void refreshMaterializedView(final String lsid, SampleTypeServiceImpl.SampleChangeType reason, @Nullable Set<Integer> changedRowIds)
+    public static void refreshMaterializedView(final String lsid, SampleTypeServiceImpl.SampleChangeType reason, @Nullable Timestamp changedSince)
     {
         var scope = ExperimentServiceImpl.getExpSchema().getScope();
-        var runnable = new RefreshMaterializedViewRunnable(lsid, reason, changedRowIds);
+        var runnable = new RefreshMaterializedViewRunnable(lsid, reason, changedSince);
         scope.addCommitTask(runnable, DbScope.CommitTaskOption.POSTCOMMIT);
     }
 
     /**
      * POSTCOMMIT task that turns a committed data change into an invalidation: on a schema change it drops the cached MQH
      * (the SQL itself must be regenerated); otherwise it bumps the matching per-LSID counter, and for {@code update} also
-     * records the changed rowIds for a targeted incremental update.
+     * records the change watermark for a targeted incremental update.
      */
     private record RefreshMaterializedViewRunnable(
         String lsid,
         SampleTypeServiceImpl.SampleChangeType reason,
-        @Nullable Set<Integer> changedRowIds
+        @Nullable Timestamp changedSince
     ) implements Runnable
     {
         @Override
@@ -1360,9 +1344,9 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 case rollup -> counters.rollup.incrementAndGet();
                 case update ->
                 {
-                    // Record the changed rowIds BEFORE bumping the counter: a reader that observes the new counter-value
-                    // is then guaranteed to see the corresponding rowIds when it drains the pending state.
-                    counters.recordPendingUpdate(changedRowIds);
+                    // Record the watermark BEFORE bumping the counter: a reader that observes the new counter-value is
+                    // then guaranteed to see the corresponding watermark when it drains the pending state.
+                    counters.recordPendingUpdate(changedSince);
                     counters.update.incrementAndGet();
                 }
                 case delete -> counters.delete.incrementAndGet();
@@ -1373,9 +1357,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         @Override
         public @NonNull String toString()
         {
-            // Concise: report the rowId count, not the (potentially huge) set, so dedup DEBUG logging stays readable.
-            return "RefreshMaterializedViewRunnable{lsid=" + lsid + ", reason=" + reason +
-                    ", changedRowIds=" + (changedRowIds == null ? "null" : changedRowIds.size() + " rows") + "}";
+            return "RefreshMaterializedViewRunnable{lsid=" + lsid + ", reason=" + reason + ", changedSince=" + changedSince + "}";
         }
     }
 
@@ -1587,13 +1569,12 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         {
             InvalidationCounters counters = getInvalidateCounters(_lsid);
             InvalidationCounters.PendingUpdate pending = counters.drainPendingUpdate();
-            if (!pending.full() && pending.rowIds().isEmpty())
+            if (!pending.full() && pending.since() == null)
                 return;
 
             try
             {
-                // The changed set is capped at UPDATE_ROWID_THRESHOLD, so a targeted update fits in one statement.
-                upsertWithRetry(buildIncrementalUpdateSql(pending.full() ? null : pending.rowIds()));
+                upsertWithRetry(buildIncrementalUpdateSql(pending.full() ? null : pending.since()));
             }
             catch (RuntimeException ex)
             {
@@ -1601,19 +1582,19 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 if (pending.full())
                     counters.fullUpdatePending = true;
                 else
-                    counters.pendingUpdateRowIds.addAll(pending.rowIds());
+                    counters.recordPendingUpdate(pending.since());
                 throw ex;
             }
         }
 
         /**
          * Build one incremental UPDATE that re-derives the materialized columns from their source joins. When
-         * {@code changedRowIds} is null this is a full re-sync over the whole sample type; otherwise it targets the given
-         * rows plus the aliquots of any changed root (via {@code rootmaterialrowid}). The {@code IS DISTINCT FROM}
-         * (PostgreSQL) / {@code EXCEPT}-based (SQL Server) guard skips rows whose values already match, so only genuinely
-         * differing rows are rewritten.
+         * {@code changedSince} is null this is a full re-sync over the whole sample type; otherwise it targets the rows
+         * modified at or after the watermark plus the aliquots of any changed root (via {@code rootmaterialrowid}). The
+         * {@code IS DISTINCT FROM} (PostgreSQL) / {@code EXCEPT}-based (SQL Server) guard skips rows whose values already
+         * match, so only genuinely differing rows are rewritten.
          */
-        SQLFragment buildIncrementalUpdateSql(@Nullable Collection<Integer> changedRowIds)
+        SQLFragment buildIncrementalUpdateSql(@Nullable Timestamp changedSince)
         {
             var d = CoreSchema.getInstance().getSchema().getSqlDialect();
             JoinColumns jc = _joinColumns;
@@ -1631,7 +1612,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 sql.append("\nFROM exp.Material m");
                 appendProvisionedJoins(sql, jc);
                 sql.append("\nWHERE st.rowid = m.rowid AND m.cpastype = ").appendValue(_lsid, d);
-                appendChangedRowIdPredicate(sql, d, changedRowIds);
+                appendModifiedSincePredicate(sql, d, changedSince);
                 sql.append(" AND (");
                 String or = "";
                 for (JoinColumn c : setColumns)
@@ -1648,7 +1629,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 sql.append("\nFROM temp.${NAME} st INNER JOIN exp.Material m ON st.rowid = m.rowid");
                 appendProvisionedJoins(sql, jc);
                 sql.append("\nWHERE m.cpastype = ").appendValue(_lsid, d);
-                appendChangedRowIdPredicate(sql, d, changedRowIds);
+                appendModifiedSincePredicate(sql, d, changedSince);
                 // SQL Server before 2022 has no IS DISTINCT FROM; "SELECT <st cols> EXCEPT SELECT <src cols>" is a portable
                 // null-safe tuple comparison that yields a row iff the tuples differ.
                 sql.append(" AND EXISTS (SELECT ");
@@ -1689,25 +1670,13 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 sql.append(" INNER JOIN ").append(jc.provisioned, "m_aliquot").append(" ON m.RowId = m_aliquot.RowId");
         }
 
-        /**
-         * Restrict to the changed rows. The {@code rootmaterialrowid} clause fans a changed root out to all of its aliquots
-         * (whose root-derived columns must be re-derived); it only matters for changed roots, since an aliquot's rowid is
-         * never another row's root. No-op for a full re-sync (null).
-         * <p>
-         * Passing a null large-IN generator to {@code appendInClauseSqlWithCustomInClauseGenerator} forces bind-parameter
-         * markers (never the temp-table generator), which is required because this runs as a single statement via
-         * {@code upsert()}. The set is bound twice; UPDATE_ROWID_THRESHOLD keeps the total parameter count under SQL
-         * Server's cap (see its javadoc).
-         */
-        private static void appendChangedRowIdPredicate(SQLFragment sql, SqlDialect d, @Nullable Collection<Integer> changedRowIds)
+        private void appendModifiedSincePredicate(SQLFragment sql, SqlDialect d, @Nullable Timestamp changedSince)
         {
-            if (changedRowIds == null)
+            if (changedSince == null)
                 return;
-            sql.append(" AND (m.rowid");
-            d.appendInClauseSqlWithCustomInClauseGenerator(sql, changedRowIds, null);
-            sql.append(" OR m.rootmaterialrowid");
-            d.appendInClauseSqlWithCustomInClauseGenerator(sql, changedRowIds, null);
-            sql.append(")");
+            sql.append(" AND (m.modified >= ?").add(changedSince);
+            sql.append(" OR m.rootmaterialrowid IN (SELECT rowid FROM exp.material WHERE cpastype = ").appendValue(_lsid, d)
+                    .append(" AND modified >= ?").add(changedSince).append("))");
         }
     }
 
@@ -2262,11 +2231,50 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             ExpMaterialTableImpl table = getSamplesTable(st);
             assertCacheMatchesFreshDerivation(table, st.getLSID());
 
-            // Make a real change, then force the full-re-sync branch (as a no-rowId write path would) before reading.
+            // Make a real change, then force the full-re-sync branch (as a no-watermark write path would) before reading.
             updateRows(st, List.of(CaseInsensitiveHashMap.of(RowId.name(), roots.getFirst(), "rootProp", "fullResynced")));
             InvalidationCounters counters = getInvalidateCounters(st.getLSID());
-            counters.pendingUpdateRowIds.clear();
+            counters.pendingUpdateSince.set(null);
             counters.fullUpdatePending = true;
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+        }
+
+        @Test
+        public void testModifiedBoundaryNotSkipped() throws Exception
+        {
+            // The watermark predicate uses >= so a row modified at exactly the watermark is never skipped.
+            ExpSampleType st = createSampleType("IncrUpdBoundary");
+            int root = insertRoots(st, "R1").getFirst();
+
+            ExpMaterialTableImpl table = getSamplesTable(st);
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+
+            // Drive the targeted update with a watermark equal to the row's own Modified, simulating same-tick capture.
+            updateRows(st, List.of(CaseInsensitiveHashMap.of(RowId.name(), root, "rootProp", "boundary")));
+            Timestamp rowModified = new SqlSelector(ExperimentServiceImpl.getExpSchema().getScope(),
+                    new SQLFragment("SELECT modified FROM exp.material WHERE rowid = ?").add(root)).getObject(Timestamp.class);
+            InvalidationCounters counters = getInvalidateCounters(st.getLSID());
+            counters.fullUpdatePending = false;
+            counters.pendingUpdateSince.set(rowModified);
+            counters.update.incrementAndGet();
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+        }
+
+        @Test
+        public void testSequentialUpdates() throws Exception
+        {
+            // Two updates in sequence: each read must apply its own watermark and leave the cache consistent.
+            ExpSampleType st = createSampleType("IncrUpdSequential");
+            int root = insertRoots(st, "R1").getFirst();
+            insertAliquots(st, "R1", 2);
+
+            ExpMaterialTableImpl table = getSamplesTable(st);
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+
+            updateRows(st, List.of(CaseInsensitiveHashMap.of(RowId.name(), root, "rootProp", "first")));
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+
+            updateRows(st, List.of(CaseInsensitiveHashMap.of(RowId.name(), root, "rootProp", "second")));
             assertCacheMatchesFreshDerivation(table, st.getLSID());
         }
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1557,15 +1557,15 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             // SQL Server's datetime type lacks microsecond precision
             Timestamp comparison = d.isSqlServer() ? new Timestamp(changedSince.getTime() - 500) : changedSince;
 
-            SQLFragment src = new SQLFragment()
-                    .append(getViewSourceSql().append(" AND m.modified >= ?").add(comparison))
-                    .append("\nUNION ALL\n")
-                    .append(getViewSourceSql()
-                            .append(" AND m.rootmaterialrowid <> m.rowid")
-                            .append(" AND EXISTS (SELECT 1 FROM exp.material r WHERE r.rowid = m.rootmaterialrowid AND r.cpastype = ").appendValue(_lsid, d)
-                            .append(" AND r.modified >= ?").add(comparison).append(")"));
+            SQLFragment sql = new SQLFragment("WITH wModified AS (\n")
+                    .append("SELECT rowId FROM exp.material expm WHERE expm.modified >= ?\n").add(comparison)
+                    .append(")\n");
 
-            SQLFragment sql = new SQLFragment();
+            SQLFragment src = new SQLFragment()
+                    .append(getViewSourceSql()).append(" AND m.rowId IN (SELECT rowId FROM wModified)\n")
+                    .append("UNION\n")
+                    .append(getViewSourceSql()).append(" AND m.rootmaterialrowid IN (SELECT rowId FROM wModified)\n");
+
             if (d.isPostgreSQL())
             {
                 sql.append("UPDATE temp.${NAME} AS st\nSET ");

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -60,6 +60,7 @@ import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.LoggingDataIterator;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.dataiterator.SimpleTranslator;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.MvColumn;
@@ -162,6 +163,7 @@ import static org.labkey.api.exp.api.SampleTypeDomainKind.AVAILABLE_ALIQUOT_VOLU
 import static org.labkey.api.exp.api.SampleTypeDomainKind.SAMPLE_TYPE_FILE_DIRECTORY_NAME;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.*;
 import static org.labkey.api.util.StringExpressionFactory.AbstractStringExpression.NullValueBehavior.NullResult;
+import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.merge;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.schema;
 
 public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.Column> implements ExpMaterialTable
@@ -1232,20 +1234,13 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         public final AtomicLong update, insert, delete, rollup;
 
         /**
-         * The earliest {@code exp.material.Modified} timestamp from which rows must be re-derived by the next targeted
-         * incremental update. Populated by {@link RefreshMaterializedViewRunnable#run()} <b>before</b> the {@code update}
-         * counter is incremented, so any reader that observes the new counter-value is guaranteed to see this watermark
-         * when it drains the pending state. {@code null} means no targeted update is pending. Min-merged so the watermark
-         * always covers the oldest not-yet-applied change. Because {@code Modified} is written with the database clock
-         * (the constant {@code NowTimestamp} is inlined as {@code CURRENT_TIMESTAMP}), this timestamp is comparable to it
-         * directly, with no web-server-vs-database clock skew.
+         * The earliest {@code exp.material.Modified} timestamp from which existing rows must be re-derived by the next
+         * targeted incremental update. Populated by {@link RefreshMaterializedViewRunnable#run()} <b>before</b> the
+         * {@code update} counter is incremented, so any reader that observes the new counter-value is guaranteed to see
+         * this watermark when it drains the pending state. {@code null} means no targeted update is pending. Min-merged so
+         * the watermark always covers the oldest not-yet-applied change.
          */
         public final AtomicReference<Timestamp> pendingUpdateSince = new AtomicReference<>();
-        /**
-         * Set when an {@code update} could not supply a watermark timestamp, meaning the next read must do a full re-sync
-         * rather than a targeted update.
-         */
-        public volatile boolean fullUpdatePending = false;
 
         InvalidationCounters()
         {
@@ -1256,39 +1251,20 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             rollup = new AtomicLong(l);
         }
 
-        /**
-         * Record the watermark for one update (before its counter-increment). A null timestamp means the caller could
-         * not capture a change time, forcing a full re-sync; otherwise the watermark is min-merged so it covers the
-         * oldest pending change.
-         */
-        void recordPendingUpdate(@Nullable Timestamp changedSince)
+        /** Record the watermark for one update (before its counter-increment), min-merged so it covers the oldest pending change. */
+        void recordPendingUpdate(@NotNull Timestamp changedSince)
         {
-            if (changedSince == null)
-                fullUpdatePending = true;
-            else
-                pendingUpdateSince.accumulateAndGet(changedSince, (cur, next) -> cur == null || next.before(cur) ? next : cur);
+            pendingUpdateSince.accumulateAndGet(changedSince, (cur, next) -> cur == null || next.before(cur) ? next : cur);
         }
 
-        /** The drained pending update state: either a full re-sync or the watermark to target. */
-        record PendingUpdate(boolean full, @Nullable Timestamp since) {}
-
         /**
-         * Atomically take and clear the pending update state. Should be called under the {@code _Materialized} loading
-         * lock. The watermark is read with {@code getAndSet(null)} so a timestamp recorded concurrently by a later
-         * POSTCOMMIT runnable survives for the next drain. A full re-sync clears any pending watermark: the re-sync
-         * already covers every committed row (a recorded watermark only ever corresponds to an already-committed change,
-         * since the POSTCOMMIT runnable runs after commit), so the watermark would be redundant.
+         * Atomically take and clear the pending watermark. Should be called under the {@code _Materialized} loading lock.
+         * Read with {@code getAndSet(null)} so a timestamp recorded concurrently by a later POSTCOMMIT runnable survives
+         * for the next drain. Returns null when no targeted update is pending.
          */
-        PendingUpdate drainPendingUpdate()
+        @Nullable Timestamp drainPendingUpdate()
         {
-            if (fullUpdatePending)
-            {
-                fullUpdatePending = false;
-                pendingUpdateSince.set(null);
-                return new PendingUpdate(true, null);
-            }
-
-            return new PendingUpdate(false, pendingUpdateSince.getAndSet(null));
+            return pendingUpdateSince.getAndSet(null);
         }
     }
 
@@ -1314,9 +1290,10 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     }
 
     /**
-     * POSTCOMMIT task that turns a committed data change into an invalidation: on a schema change it drops the cached MQH
-     * (the SQL itself must be regenerated); otherwise it bumps the matching per-LSID counter, and for {@code update} also
-     * records the change watermark for a targeted incremental update.
+     * POSTCOMMIT task that turns a committed data change into an invalidation: a schema change (or any update/merge that
+     * could not capture a watermark) drops the cached MQH so the next read rebuilds the whole view; otherwise it bumps the
+     * matching per-LSID counter(s), and for {@code update}/{@code merge} also records the change watermark for a targeted
+     * incremental update.
      */
     private record RefreshMaterializedViewRunnable(
         String lsid,
@@ -1342,14 +1319,24 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             {
                 case insert -> counters.insert.incrementAndGet();
                 case rollup -> counters.rollup.incrementAndGet();
-                case update ->
-                {
-                    // Record the watermark BEFORE bumping the counter: a reader that observes the new counter-value is
-                    // then guaranteed to see the corresponding watermark when it drains the pending state.
+                case delete -> counters.delete.incrementAndGet();
+                case update, merge -> {
+                    // An update or merge did not capture a watermark, so it cannot be targeted incrementally; drop the
+                    // cached MQH so the next read rebuilds the whole view. Clear any pending watermark since the
+                    // rebuild supersedes it.
+                    if (changedSince == null)
+                    {
+                        counters.pendingUpdateSince.set(null);
+                        _materializedQueries.remove(lsid);
+                        return;
+                    }
+
                     counters.recordPendingUpdate(changedSince);
                     counters.update.incrementAndGet();
+
+                    if (reason == merge)
+                        counters.insert.incrementAndGet();
                 }
-                case delete -> counters.delete.incrementAndGet();
                 default -> throw new IllegalStateException("Unexpected value: " + reason);
             }
         }
@@ -1558,43 +1545,26 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             upsertWithRetry(incremental);
         }
 
-        /**
-         * Generalized incremental update: re-derive the materialized columns from their source joins for the rows that
-         * changed since the last drain, instead of dropping and fully rebuilding the temp table. Drains the pending state
-         * under the {@code _Materialized} loading lock (held by the caller) and either does a full re-sync or a single
-         * targeted update of the changed rows. On failure the drained work is restored, so nothing is lost before the
-         * caller's handler drops the MQH and rebuilds.
-         */
         void executeIncrementalUpdate()
         {
             InvalidationCounters counters = getInvalidateCounters(_lsid);
-            InvalidationCounters.PendingUpdate pending = counters.drainPendingUpdate();
-            if (!pending.full() && pending.since() == null)
+            Timestamp since = counters.drainPendingUpdate();
+            if (since == null)
                 return;
 
             try
             {
-                upsertWithRetry(buildIncrementalUpdateSql(pending.full() ? null : pending.since()));
+                upsertWithRetry(buildIncrementalUpdateSql(since));
             }
             catch (RuntimeException ex)
             {
-                // Restore the drained work so nothing is lost; the caller's handler will drop the MQH and rebuild cleanly.
-                if (pending.full())
-                    counters.fullUpdatePending = true;
-                else
-                    counters.recordPendingUpdate(pending.since());
+                // Restore the drained watermark so nothing is lost; the caller's handler will drop the MQH and rebuild cleanly.
+                counters.recordPendingUpdate(since);
                 throw ex;
             }
         }
 
-        /**
-         * Build one incremental UPDATE that re-derives the materialized columns from their source joins. When
-         * {@code changedSince} is null this is a full re-sync over the whole sample type; otherwise it targets the rows
-         * modified at or after the watermark plus the aliquots of any changed root (via {@code rootmaterialrowid}). The
-         * {@code IS DISTINCT FROM} (PostgreSQL) / {@code EXCEPT}-based (SQL Server) guard skips rows whose values already
-         * match, so only genuinely differing rows are rewritten.
-         */
-        SQLFragment buildIncrementalUpdateSql(@Nullable Timestamp changedSince)
+        SQLFragment buildIncrementalUpdateSql(@NotNull Timestamp changedSince)
         {
             var d = CoreSchema.getInstance().getSchema().getSqlDialect();
             JoinColumns jc = _joinColumns;
@@ -1670,10 +1640,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 sql.append(" INNER JOIN ").append(jc.provisioned, "m_aliquot").append(" ON m.RowId = m_aliquot.RowId");
         }
 
-        private void appendModifiedSincePredicate(SQLFragment sql, SqlDialect d, @Nullable Timestamp changedSince)
+        private void appendModifiedSincePredicate(SQLFragment sql, SqlDialect d, @NotNull Timestamp changedSince)
         {
-            if (changedSince == null)
-                return;
             sql.append(" AND (m.modified >= ?").add(changedSince);
             sql.append(" OR m.rootmaterialrowid IN (SELECT rowid FROM exp.material WHERE cpastype = ").appendValue(_lsid, d)
                     .append(" AND modified >= ?").add(changedSince).append("))");
@@ -2231,11 +2199,10 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             ExpMaterialTableImpl table = getSamplesTable(st);
             assertCacheMatchesFreshDerivation(table, st.getLSID());
 
-            // Make a real change, then force the full-re-sync branch (as a no-watermark write path would) before reading.
+            // Make a real change, then force the full rebuild path (as a no-watermark update/merge would: drop the MQH)
+            // before reading. The next read must rebuild the whole view from scratch.
             updateRows(st, List.of(CaseInsensitiveHashMap.of(RowId.name(), roots.getFirst(), "rootProp", "fullResynced")));
-            InvalidationCounters counters = getInvalidateCounters(st.getLSID());
-            counters.pendingUpdateSince.set(null);
-            counters.fullUpdatePending = true;
+            _materializedQueries.remove(st.getLSID());
             assertCacheMatchesFreshDerivation(table, st.getLSID());
         }
 
@@ -2254,7 +2221,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             Timestamp rowModified = new SqlSelector(ExperimentServiceImpl.getExpSchema().getScope(),
                     new SQLFragment("SELECT modified FROM exp.material WHERE rowid = ?").add(root)).getObject(Timestamp.class);
             InvalidationCounters counters = getInvalidateCounters(st.getLSID());
-            counters.fullUpdatePending = false;
             counters.pendingUpdateSince.set(rowModified);
             counters.update.incrementAndGet();
             assertCacheMatchesFreshDerivation(table, st.getLSID());
@@ -2275,6 +2241,27 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             assertCacheMatchesFreshDerivation(table, st.getLSID());
 
             updateRows(st, List.of(CaseInsensitiveHashMap.of(RowId.name(), root, "rootProp", "second")));
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+        }
+
+        @Test
+        public void testMergeInsertAndUpdate() throws Exception
+        {
+            // A single merge that both updates existing rows and inserts new ones must leave the cache consistent: the
+            // merge signals both the update path (existing rows, watermark-targeted) and the insert path (new rows).
+            ExpSampleType st = createSampleType("IncrUpdMerge");
+            insertRoots(st, "R1", "R2");
+            insertAliquots(st, "R1", 2);
+
+            ExpMaterialTableImpl table = getSamplesTable(st);
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+
+            // R1/R2 already exist (matched by name -> updated); R3/R4 are new (-> inserted), all in one merge.
+            mergeRows(st, List.of(
+                    CaseInsensitiveHashMap.of("name", "R1", "rootProp", "mergedR1"),
+                    CaseInsensitiveHashMap.of("name", "R2", "rootProp", "mergedR2"),
+                    CaseInsensitiveHashMap.of("name", "R3", "rootProp", "mergedR3"),
+                    CaseInsensitiveHashMap.of("name", "R4", "rootProp", "mergedR4")));
             assertCacheMatchesFreshDerivation(table, st.getLSID());
         }
 
@@ -2342,6 +2329,14 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         {
             BatchValidationException errors = new BatchValidationException();
             getUpdateService(st).updateRows(_user, _c, rows, null, errors, null, null);
+            if (errors.hasErrors())
+                throw errors;
+        }
+
+        private void mergeRows(ExpSampleType st, List<Map<String, Object>> rows) throws Exception
+        {
+            BatchValidationException errors = new BatchValidationException();
+            getUpdateService(st).mergeRows(_user, _c, MapDataIterator.of(rows), errors, null, null);
             if (errors.hasErrors())
                 throw errors;
         }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -21,6 +21,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.util.Precision;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.audit.AuditHandler;
 import org.labkey.api.cache.BlockingCache;
@@ -48,8 +53,10 @@ import org.labkey.api.data.PHI;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.Sort;
+import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.UnionContainerFilter;
+import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.LoggingDataIterator;
@@ -61,6 +68,7 @@ import org.labkey.api.exp.PropertyColumn;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpSampleType;
+import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.api.NameExpressionOptionService;
@@ -77,6 +85,7 @@ import org.labkey.api.exp.query.ExpSampleTypeTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.gwt.client.AuditBehaviorType;
+import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.gwt.client.model.PropertyValidatorType;
 import org.labkey.api.inventory.InventoryService;
 import org.labkey.api.ontology.Quantity;
@@ -89,6 +98,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryException;
 import org.labkey.api.query.QueryForeignKey;
+import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUrls;
@@ -105,11 +115,14 @@ import org.labkey.api.security.permissions.MoveEntitiesPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HeartBeat;
+import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
+import org.labkey.api.util.TestContext;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -131,6 +144,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -165,7 +179,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         amountValidator.setName("SampleAmountNonNegative");
         amountValidator.setExpressionValue("~gte=0");
         amountValidator.setErrorMessage("Amounts must be non-negative.");
-        amountValidator.setColumnNameProvidedData(PROVIDED_DATA_PREFIX + Column.StoredAmount.name());
+        amountValidator.setColumnNameProvidedData(PROVIDED_DATA_PREFIX + StoredAmount.name());
         AMOUNT_RANGE_VALIDATORS.add(amountValidator);
     }
 
@@ -197,7 +211,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         ColumnInfo result = super.resolveColumn(name);
         if (result == null)
         {
-            if ("CpasType".equalsIgnoreCase(name))
+            if (CpasType.name().equalsIgnoreCase(name))
                 result = createColumn(SampleSet.name(), SampleSet);
             else if (Property.name().equalsIgnoreCase(name))
                 result = createPropertyColumn(Property.name());
@@ -210,7 +224,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     @Override
     public ColumnInfo getExpObjectColumn()
     {
-        var ret = wrapColumn("ExpMaterialTableImpl_object_", _rootTable.getColumn("objectid"));
+        var ret = wrapColumn("ExpMaterialTableImpl_object_", _rootTable.getColumn(ObjectId.name()));
         ret.setConceptURI(BuiltInColumnTypes.EXPOBJECTID_CONCEPT_URI);
         return ret;
     }
@@ -353,7 +367,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 Unit typeUnit = getSampleTypeUnit();
                 if (typeUnit != null)
                 {
-                    SampleTypeAmountDisplayColumn columnInfo = new SampleTypeAmountDisplayColumn(this, Column.StoredAmount.name(), Column.Units.name(), label, importAliases, typeUnit);
+                    SampleTypeAmountDisplayColumn columnInfo = new SampleTypeAmountDisplayColumn(this, StoredAmount.name(), Units.name(), label, importAliases, typeUnit);
                     columnInfo.setDisplayColumnFactory(colInfo -> new SampleTypeAmountPrecisionDisplayColumn(colInfo, typeUnit));
                     columnInfo.setDescription("The amount of this sample, in the display unit for the sample type, currently on hand.");
                     columnInfo.setShownInUpdateView(true);
@@ -1212,9 +1226,35 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     }
 
 
+    /**
+     * Once the pending changed-rowid set for a single update grows past this size, a targeted incremental update is no
+     * longer worth it (the changed-rowid IN list grows and the win over a whole-join re-sync shrinks), so we escalate to a
+     * full re-sync instead. Chosen to match the application's bulk-edit cap of 1,000 rows, so a normal single update stays
+     * targeted.
+     * <p>
+     * This value is also bounded by SQL Server's 2,100-bind-parameter limit: the targeted predicate references the changed
+     * set twice ({@code m.rowid IN (...) OR m.rootmaterialrowid IN (...)}), so a targeted statement binds {@code 2*N + 1}
+     * parameters. At 1,000 that is 2,001, safely under the cap. Raising this past ~1,049 would require restructuring the
+     * predicate to avoid using the set twice.
+     */
+    static final int UPDATE_ROWID_THRESHOLD = 1_000;
+
     static class InvalidationCounters
     {
         public final AtomicLong update, insert, delete, rollup;
+
+        /**
+         * The accumulated exp.material rowIds changed by {@code update}s since the last drain, used to drive a targeted
+         * incremental update. Populated by {@link RefreshMaterializedViewRunnable#run()} <b>before</b> the {@code update}
+         * counter is incremented, so any reader that observes the new counter-value is guaranteed to see these rowids.
+         */
+        public final Set<Integer> pendingUpdateRowIds = ConcurrentHashMap.newKeySet();
+        /**
+         * Set when an {@code update} could not supply rowIds (or the pending set crossed {@link #UPDATE_ROWID_THRESHOLD}),
+         * meaning the next read must do a full re-sync rather than a targeted update.
+         */
+        public volatile boolean fullUpdatePending = false;
+
         InvalidationCounters()
         {
             long l = System.currentTimeMillis();
@@ -1222,6 +1262,49 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             insert = new AtomicLong(l);
             delete = new AtomicLong(l);
             rollup = new AtomicLong(l);
+        }
+
+        /** Record the rowIds changed by one update (before its counter-increment). null/empty rowIds force a full re-sync. */
+        void recordPendingUpdate(@Nullable Set<Integer> changedRowIds)
+        {
+            if (changedRowIds == null || changedRowIds.isEmpty())
+            {
+                fullUpdatePending = true;
+                pendingUpdateRowIds.clear();
+            }
+            else if (!fullUpdatePending)
+            {
+                pendingUpdateRowIds.addAll(changedRowIds);
+                if (pendingUpdateRowIds.size() > UPDATE_ROWID_THRESHOLD)
+                {
+                    fullUpdatePending = true;
+                    pendingUpdateRowIds.clear();
+                }
+            }
+            // else: a full re-sync is already pending; the individual rowIds are redundant
+        }
+
+        /** The drained pending update state: either a full re-sync or the specific rowIds to target. */
+        record PendingUpdate(boolean full, Set<Integer> rowIds) {}
+
+        /**
+         * Atomically take and clear the pending update state. Should be called under the {@code _Materialized} loading lock.
+         * A snapshot of the rowIds is removed (not the live set) so any rowIds added concurrently by a POSTCOMMIT runnable
+         * survive for the next drain.
+         */
+        PendingUpdate drainPendingUpdate()
+        {
+            if (fullUpdatePending)
+            {
+                fullUpdatePending = false;
+                pendingUpdateRowIds.clear();
+                return new PendingUpdate(true, Set.of());
+            }
+            if (pendingUpdateRowIds.isEmpty())
+                return new PendingUpdate(false, Set.of());
+            Set<Integer> drained = new HashSet<>(pendingUpdateRowIds);
+            pendingUpdateRowIds.removeAll(drained);
+            return new PendingUpdate(false, drained);
         }
     }
 
@@ -1232,61 +1315,76 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     // used by SampleTypeServiceImpl.refreshSampleTypeMaterializedView()
     public static void refreshMaterializedView(final String lsid, SampleTypeServiceImpl.SampleChangeType reason)
     {
+        refreshMaterializedView(lsid, reason, null);
+    }
+
+    /**
+     * @param changedRowIds the exp.material rowIds known to have changed (only meaningful for update); null means
+     *                      the caller could not list the changed rows, forcing a full re-sync on the next read.
+     */
+    public static void refreshMaterializedView(final String lsid, SampleTypeServiceImpl.SampleChangeType reason, @Nullable Set<Integer> changedRowIds)
+    {
         var scope = ExperimentServiceImpl.getExpSchema().getScope();
-        var runnable = new RefreshMaterializedViewRunnable(lsid, reason);
+        var runnable = new RefreshMaterializedViewRunnable(lsid, reason, changedRowIds);
         scope.addCommitTask(runnable, DbScope.CommitTaskOption.POSTCOMMIT);
     }
 
-    private static class RefreshMaterializedViewRunnable implements Runnable
+    /**
+     * POSTCOMMIT task that turns a committed data change into an invalidation: on a schema change it drops the cached MQH
+     * (the SQL itself must be regenerated); otherwise it bumps the matching per-LSID counter, and for {@code update} also
+     * records the changed rowIds for a targeted incremental update.
+     */
+    private record RefreshMaterializedViewRunnable(
+        String lsid,
+        SampleTypeServiceImpl.SampleChangeType reason,
+        @Nullable Set<Integer> changedRowIds
+    ) implements Runnable
     {
-        private final String _lsid;
-        private final SampleTypeServiceImpl.SampleChangeType _reason;
-
-        public RefreshMaterializedViewRunnable(String lsid, SampleTypeServiceImpl.SampleChangeType reason)
-        {
-            _lsid = lsid;
-            _reason = reason;
-        }
-
         @Override
         public void run()
         {
-            if (_reason == schema)
+            if (reason == schema)
             {
                 /* NOTE: MaterializedQueryHelper can detect data changes and refresh the materialized view using the provided SQL.
                  * It does not handle schema changes where the SQL itself needs to be updated.  In this case, we remove the
                  * MQH from the cache to force the SQL to be regenerated.
                  */
-                _materializedQueries.remove(_lsid);
+                _materializedQueries.remove(lsid);
                 return;
             }
-            var counters = getInvalidateCounters(_lsid);
-            switch (_reason)
+
+            var counters = getInvalidateCounters(lsid);
+            switch (reason)
             {
                 case insert -> counters.insert.incrementAndGet();
                 case rollup -> counters.rollup.incrementAndGet();
-                case update -> counters.update.incrementAndGet();
+                case update ->
+                {
+                    // Record the changed rowIds BEFORE bumping the counter: a reader that observes the new counter-value
+                    // is then guaranteed to see the corresponding rowIds when it drains the pending state.
+                    counters.recordPendingUpdate(changedRowIds);
+                    counters.update.incrementAndGet();
+                }
                 case delete -> counters.delete.incrementAndGet();
-                default -> throw new IllegalStateException("Unexpected value: " + _reason);
+                default -> throw new IllegalStateException("Unexpected value: " + reason);
             }
         }
 
         @Override
-        public boolean equals(Object obj)
+        public @NonNull String toString()
         {
-            return obj instanceof RefreshMaterializedViewRunnable other && _lsid.equals(other._lsid) && _reason.equals(other._reason);
+            // Concise: report the rowId count, not the (potentially huge) set, so dedup DEBUG logging stays readable.
+            return "RefreshMaterializedViewRunnable{lsid=" + lsid + ", reason=" + reason +
+                    ", changedRowIds=" + (changedRowIds == null ? "null" : changedRowIds.size() + " rows") + "}";
         }
     }
 
     private static InvalidationCounters getInvalidateCounters(String lsid)
     {
         if (!initializedListeners.getAndSet(true))
-        {
             CacheManager.addListener(_invalidationCounters::clear);
-        }
-        return _invalidationCounters.computeIfAbsent(lsid, (unused) ->
-                new InvalidationCounters()
-        );
+
+        return _invalidationCounters.computeIfAbsent(lsid, (_) -> new InvalidationCounters());
     }
 
     /* SELECT and JOIN, does not include WHERE, same as getJoinSQL() */
@@ -1304,17 +1402,22 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
              * Maybe have a callback to generate the SQL dynamically, and verify that the sql is unchanged.
              */
             SQLFragment viewSql = getJoinSQL(null).append(" WHERE CpasType = ").appendValue(_ss.getLSID());
+            // Capture the column mapping for incremental updates. Safe to cache: a schema change drops this MQH from the
+            // cache (reason == schema), so a changed column set always rebuilds with a fresh mapping.
+            JoinColumns joinColumns = getJoinColumns(null);
             return (_MaterializedQueryHelper) new _MaterializedQueryHelper.Builder(_ss.getLSID(), "", getExpSchema().getDbSchema().getScope(), viewSql)
+                .joinColumns(joinColumns)
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_rowid ON temp.${NAME} (rowid)")
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_lsid ON temp.${NAME} (lsid)")
                 .addIndex("CREATE INDEX idx_${NAME}_container ON temp.${NAME} (container)")
                 .addIndex("CREATE INDEX idx_${NAME}_root ON temp.${NAME} (rootmaterialrowid)")
-                .addInvalidCheck(() -> String.valueOf(getInvalidateCounters(_ss.getLSID()).update.get()))
+                // NOTE: no addInvalidCheck for the update counter. Updates are now applied incrementally by
+                // executeIncrementalUpdate() (like insert/delete/rollup) rather than triggering a full drop-and-rebuild.
+                // The MQH is still dropped on schema changes and on incremental-update errors (see incrementalUpdateBeforeSelect).
                 .build();
         });
         return new SQLFragment("SELECT * FROM ").append(mqh.getFromSql("_cached_view_"));
     }
-
 
     /**
      * MaterializedQueryHelper has a built-in mechanism for tracking when a temp table needs to be recomputed.
@@ -1323,11 +1426,17 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
      */
     static class _MaterializedQueryHelper extends MaterializedQueryHelper
     {
+        /** Columns that an incremental UPDATE never re-derives */
+        static final Set<String> IMMUTABLE_UPDATE_COLUMNS = new CaseInsensitiveHashSet(RowId.name(), LSID.name(), CpasType.name(), RootMaterialRowId.name());
+
         final String _lsid;
+        /** The column mapping that produced the temp table, used to build the incremental UPDATE SET clauses. */
+        final JoinColumns _joinColumns;
 
         static class Builder extends MaterializedQueryHelper.Builder
         {
             String _lsid;
+            JoinColumns _joinColumns;
 
             public Builder(String lsid, String prefix, DbScope scope, SQLFragment select)
             {
@@ -1335,18 +1444,25 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 this._lsid = lsid;
             }
 
+            public Builder joinColumns(JoinColumns joinColumns)
+            {
+                this._joinColumns = joinColumns;
+                return this;
+            }
+
             @Override
             public _MaterializedQueryHelper build()
             {
-                return new _MaterializedQueryHelper(_lsid, _prefix, _scope, _select, _uptodate, _supplier, _indexes, _max, _isSelectInto);
+                return new _MaterializedQueryHelper(_lsid, _joinColumns, _prefix, _scope, _select, _uptodate, _supplier, _indexes, _max, _isSelectInto);
             }
         }
 
-        _MaterializedQueryHelper(String lsid, String prefix, DbScope scope, SQLFragment select, @Nullable SQLFragment uptodate, Supplier<String> supplier, @Nullable Collection<String> indexes, long maxTimeToCache,
+        _MaterializedQueryHelper(String lsid, JoinColumns joinColumns, String prefix, DbScope scope, SQLFragment select, @Nullable SQLFragment uptodate, Supplier<String> supplier, @Nullable Collection<String> indexes, long maxTimeToCache,
                                         boolean isSelectIntoSql)
         {
             super(prefix, scope, select, uptodate, supplier, indexes, maxTimeToCache, isSelectIntoSql);
             this._lsid = lsid;
+            this._joinColumns = joinColumns;
         }
 
         @Override
@@ -1373,6 +1489,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
                 if (!materialized.incrementalDeleteCheck.stillValid(0))
                     executeIncrementalDelete();
+                if (!materialized.incrementalUpdateCheck.stillValid(0))
+                    executeIncrementalUpdate();
                 if (!materialized.incrementalRollupCheck.stillValid(0))
                     executeIncrementalRollup();
                 if (!materialized.incrementalInsertCheck.stillValid(0))
@@ -1399,7 +1517,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         void upsertWithRetry(SQLFragment sql)
         {
             // not actually read-only, but we don't want to start an explicit transaction
-            _scope.executeWithRetryReadOnly((tx) -> upsert(sql));
+            _scope.executeWithRetryReadOnly((_) -> upsert(sql));
         }
 
         void executeIncrementalInsert()
@@ -1457,6 +1575,140 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             }
             upsertWithRetry(incremental);
         }
+
+        /**
+         * Generalized incremental update: re-derive the materialized columns from their source joins for the rows that
+         * changed since the last drain, instead of dropping and fully rebuilding the temp table. Drains the pending state
+         * under the {@code _Materialized} loading lock (held by the caller) and either does a full re-sync or a single
+         * targeted update of the changed rows. On failure the drained work is restored, so nothing is lost before the
+         * caller's handler drops the MQH and rebuilds.
+         */
+        void executeIncrementalUpdate()
+        {
+            InvalidationCounters counters = getInvalidateCounters(_lsid);
+            InvalidationCounters.PendingUpdate pending = counters.drainPendingUpdate();
+            if (!pending.full() && pending.rowIds().isEmpty())
+                return;
+
+            try
+            {
+                // The changed set is capped at UPDATE_ROWID_THRESHOLD, so a targeted update fits in one statement.
+                upsertWithRetry(buildIncrementalUpdateSql(pending.full() ? null : pending.rowIds()));
+            }
+            catch (RuntimeException ex)
+            {
+                // Restore the drained work so nothing is lost; the caller's handler will drop the MQH and rebuild cleanly.
+                if (pending.full())
+                    counters.fullUpdatePending = true;
+                else
+                    counters.pendingUpdateRowIds.addAll(pending.rowIds());
+                throw ex;
+            }
+        }
+
+        /**
+         * Build one incremental UPDATE that re-derives the materialized columns from their source joins. When
+         * {@code changedRowIds} is null this is a full re-sync over the whole sample type; otherwise it targets the given
+         * rows plus the aliquots of any changed root (via {@code rootmaterialrowid}). The {@code IS DISTINCT FROM}
+         * (PostgreSQL) / {@code EXCEPT}-based (SQL Server) guard skips rows whose values already match, so only genuinely
+         * differing rows are rewritten.
+         */
+        SQLFragment buildIncrementalUpdateSql(@Nullable Collection<Integer> changedRowIds)
+        {
+            var d = CoreSchema.getInstance().getSchema().getSqlDialect();
+            JoinColumns jc = _joinColumns;
+
+            // Re-derive every temp column except the join key and immutable columns
+            List<JoinColumn> setColumns = jc.columns.stream()
+                    .filter(c -> !IMMUTABLE_UPDATE_COLUMNS.contains(c.tempColumnName()))
+                    .toList();
+
+            SQLFragment sql = new SQLFragment();
+            if (d.isPostgreSQL())
+            {
+                sql.append("UPDATE temp.${NAME} AS st\nSET ");
+                appendSetClause(sql, setColumns);
+                sql.append("\nFROM exp.Material m");
+                appendProvisionedJoins(sql, jc);
+                sql.append("\nWHERE st.rowid = m.rowid AND m.cpastype = ").appendValue(_lsid, d);
+                appendChangedRowIdPredicate(sql, d, changedRowIds);
+                sql.append(" AND (");
+                String or = "";
+                for (JoinColumn c : setColumns)
+                {
+                    sql.append(or).append("st.").append(c.tempColumnSql()).append(" IS DISTINCT FROM ").append(c.sourceSql());
+                    or = " OR ";
+                }
+                sql.append(")");
+            }
+            else
+            {
+                sql.append("UPDATE st\nSET ");
+                appendSetClause(sql, setColumns);
+                sql.append("\nFROM temp.${NAME} st INNER JOIN exp.Material m ON st.rowid = m.rowid");
+                appendProvisionedJoins(sql, jc);
+                sql.append("\nWHERE m.cpastype = ").appendValue(_lsid, d);
+                appendChangedRowIdPredicate(sql, d, changedRowIds);
+                // SQL Server before 2022 has no IS DISTINCT FROM; "SELECT <st cols> EXCEPT SELECT <src cols>" is a portable
+                // null-safe tuple comparison that yields a row iff the tuples differ.
+                sql.append(" AND EXISTS (SELECT ");
+                String comma = "";
+                for (JoinColumn c : setColumns)
+                {
+                    sql.append(comma).append("st.").append(c.tempColumnSql());
+                    comma = ", ";
+                }
+                sql.append(" EXCEPT SELECT ");
+                comma = "";
+                for (JoinColumn c : setColumns)
+                {
+                    sql.append(comma).append(c.sourceSql());
+                    comma = ", ";
+                }
+                sql.append(")");
+            }
+            return sql;
+        }
+
+        private static void appendSetClause(SQLFragment sql, List<JoinColumn> setColumns)
+        {
+            String comma = "";
+            for (JoinColumn c : setColumns)
+            {
+                // PostgreSQL and SQL Server both want bare column names on the SET left-hand side.
+                sql.append(comma).append(c.tempColumnSql()).append(" = ").append(c.sourceSql());
+                comma = ", ";
+            }
+        }
+
+        private static void appendProvisionedJoins(SQLFragment sql, JoinColumns jc)
+        {
+            if (jc.hasSampleColumns)
+                sql.append(" INNER JOIN ").append(jc.provisioned, "m_sample").append(" ON m.RootMaterialRowId = m_sample.RowId");
+            if (jc.hasAliquotColumns)
+                sql.append(" INNER JOIN ").append(jc.provisioned, "m_aliquot").append(" ON m.RowId = m_aliquot.RowId");
+        }
+
+        /**
+         * Restrict to the changed rows. The {@code rootmaterialrowid} clause fans a changed root out to all of its aliquots
+         * (whose root-derived columns must be re-derived); it only matters for changed roots, since an aliquot's rowid is
+         * never another row's root. No-op for a full re-sync (null).
+         * <p>
+         * Passing a null large-IN generator to {@code appendInClauseSqlWithCustomInClauseGenerator} forces bind-parameter
+         * markers (never the temp-table generator), which is required because this runs as a single statement via
+         * {@code upsert()}. The set is bound twice; UPDATE_ROWID_THRESHOLD keeps the total parameter count under SQL
+         * Server's cap (see its javadoc).
+         */
+        private static void appendChangedRowIdPredicate(SQLFragment sql, SqlDialect d, @Nullable Collection<Integer> changedRowIds)
+        {
+            if (changedRowIds == null)
+                return;
+            sql.append(" AND (m.rowid");
+            d.appendInClauseSqlWithCustomInClauseGenerator(sql, changedRowIds, null);
+            sql.append(" OR m.rootmaterialrowid");
+            d.appendInClauseSqlWithCustomInClauseGenerator(sql, changedRowIds, null);
+            sql.append(")");
+        }
     }
 
     static class _Materialized extends MaterializedQueryHelper.Materialized
@@ -1464,6 +1716,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         final MaterializedQueryHelper.Invalidator incrementalInsertCheck;
         final MaterializedQueryHelper.Invalidator incrementalRollupCheck;
         final MaterializedQueryHelper.Invalidator incrementalDeleteCheck;
+        final MaterializedQueryHelper.Invalidator incrementalUpdateCheck;
 
         _Materialized(_MaterializedQueryHelper mqh, String tableName, String cacheKey, long created, String sql)
         {
@@ -1472,6 +1725,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             incrementalInsertCheck = new MaterializedQueryHelper.SupplierInvalidator(() -> String.valueOf(counters.insert.get()));
             incrementalRollupCheck = new MaterializedQueryHelper.SupplierInvalidator(() -> String.valueOf(counters.rollup.get()));
             incrementalDeleteCheck = new MaterializedQueryHelper.SupplierInvalidator(() -> String.valueOf(counters.delete.get()));
+            incrementalUpdateCheck = new MaterializedQueryHelper.SupplierInvalidator(() -> String.valueOf(counters.update.get()));
         }
 
         @Override
@@ -1482,6 +1736,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             incrementalInsertCheck.stillValid(now);
             incrementalRollupCheck.stillValid(now);
             incrementalDeleteCheck.stillValid(now);
+            incrementalUpdateCheck.stillValid(now);
         }
 
         Lock getLock()
@@ -1490,38 +1745,68 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
     }
 
+    /**
+     * Which join alias a materialized-view column is sourced from:
+     * <ul>
+     *   <li>{@code m} &ndash; the row's own {@code exp.material} record</li>
+     *   <li>{@code m_sample} &ndash; the <b>root</b> material's provisioned row (root-derived / {@code ParentOnly} columns)</li>
+     *   <li>{@code m_aliquot} &ndash; the row's <b>own</b> provisioned row (aliquot-scoped columns plus {@code genid} / unique-id fields)</li>
+     * </ul>
+     */
+    enum JoinAlias { m, m_sample, m_aliquot }
 
-    /* SELECT and JOIN, does not include WHERE */
-    private SQLFragment getJoinSQL(Set<FieldKey> selectedColumns)
+    /**
+     * One column of the materialized join: the unencoded temp-table column name, the SQL reference to that column, the SQL
+     * expression that produces its value, and which join alias that expression reads from. This is the single source of
+     * truth shared by {@link #getJoinSQL} (which builds the SELECT that creates the temp table) and the incremental
+     * {@code UPDATE} paths (which build the SET clause). Keeping both consumers on this one mapping guarantees the temp
+     * column references and the SET expressions can never drift. {@code tempColumnSql} is the valid SQL reference (e.g., a
+     * quoted identifier) by which the column is named in the temp table; use it bare as an UPDATE SET target, or prefix it
+     * with a table alias (e.g., {@code st.}) to reference it elsewhere. {@code tempColumnName} is the unencoded name, useful
+     * for identifying a specific column (e.g., the {@code rowid} join key).
+     */
+    record JoinColumn(String tempColumnName, SQLFragment tempColumnSql, SQLFragment sourceSql, JoinAlias alias) {}
+
+    /**
+     * The ordered column mapping for the materialized join plus which provisioned joins are actually needed. Mirrors the
+     * {@code hasSampleColumns} / {@code hasAliquotColumns} bookkeeping that {@link #getJoinSQL} previously tracked inline.
+     */
+    static class JoinColumns
     {
-        TableInfo provisioned = null == _ss ? null : _ss.getTinfo();
-        Set<String> provisionedCols = new CaseInsensitiveHashSet(provisioned != null ? provisioned.getColumnNameSet() : Collections.emptySet());
+        final List<JoinColumn> columns = new ArrayList<>();
+        TableInfo provisioned = null;
+        boolean hasSampleColumns = false;   // m_sample join required
+        boolean hasAliquotColumns = false;  // m_aliquot join required
+    }
+
+    /**
+     * Classify every selected column into its temp-table name, source expression, and join alias, preserving exactly the
+     * rules previously inlined in {@link #getJoinSQL}: material columns &rarr; {@code m}; {@code genid} / unique-id fields
+     * &rarr; {@code m_aliquot}; root-derived ({@code ParentOnly} or empty derivation scope) &rarr; {@code m_sample}; all
+     * other provisioned columns &rarr; {@code m_aliquot}; MV-indicator columns are always included.
+     */
+    private JoinColumns getJoinColumns(Set<FieldKey> selectedColumns)
+    {
+        JoinColumns result = new JoinColumns();
+        result.provisioned = null == _ss ? null : _ss.getTinfo();
+        Set<String> provisionedCols = new CaseInsensitiveHashSet(result.provisioned != null ? result.provisioned.getColumnNameSet() : Collections.emptySet());
         provisionedCols.remove(RowId.name());
         provisionedCols.remove(Name.name());
         boolean hasProvisionedColumns = containsProvisionedColumns(selectedColumns, provisionedCols);
 
-        boolean hasSampleColumns = false;
-        boolean hasAliquotColumns = false;
-
         Set<String> materialCols = new CaseInsensitiveHashSet(_rootTable.getColumnNameSet());
         selectedColumns = computeInnerSelectedColumns(selectedColumns);
 
-        SQLFragment sql = new SQLFragment();
-        sql.appendComment("<ExpMaterialTableImpl.getJoinSQL(" + (null == _ss ? "" : _ss.getName()) + ")>", getSqlDialect());
-        sql.append("SELECT ");
-        String comma = "";
         for (String materialCol : materialCols)
         {
             // don't need to generate SQL for columns that aren't selected
             if (ALL_COLUMNS == selectedColumns || selectedColumns.contains(new FieldKey(null, materialCol)))
-            {
-                sql.append(comma).append("m.").appendIdentifier(materialCol);
-                comma = ", ";
-            }
+                result.columns.add(new JoinColumn(materialCol, new SQLFragment().appendIdentifier(materialCol), new SQLFragment("m.").appendIdentifier(materialCol), JoinAlias.m));
         }
-        if (null != provisioned && hasProvisionedColumns)
+
+        if (null != result.provisioned && hasProvisionedColumns)
         {
-            for (ColumnInfo propertyColumn : provisioned.getColumns())
+            for (ColumnInfo propertyColumn : result.provisioned.getColumns())
             {
                 // don't select twice
                 if (
@@ -1535,35 +1820,56 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 // don't need to generate SQL for columns that aren't selected
                 if (ALL_COLUMNS == selectedColumns || selectedColumns.contains(propertyColumn.getFieldKey()) || propertyColumn.isMvIndicatorColumn())
                 {
-                    sql.append(comma);
                     boolean rootField = StringUtils.isEmpty(propertyColumn.getDerivationDataScope())
                             || ExpSchema.DerivationDataScopeType.ParentOnly.name().equalsIgnoreCase(propertyColumn.getDerivationDataScope());
+                    String tempColumnName = propertyColumn.getSelectIdentifier().getId();
+                    SQLFragment tempColumnSql = propertyColumn.getSelectIdentifier().getSql();
                     if ("genid".equalsIgnoreCase(propertyColumn.getColumnName()) || propertyColumn.isUniqueIdField())
                     {
-                        sql.append(propertyColumn.getValueSql("m_aliquot")).append(" AS ").appendIdentifier(propertyColumn.getSelectIdentifier());
-                        hasAliquotColumns = true;
+                        result.columns.add(new JoinColumn(tempColumnName, tempColumnSql, propertyColumn.getValueSql("m_aliquot"), JoinAlias.m_aliquot));
+                        result.hasAliquotColumns = true;
                     }
                     else if (rootField)
                     {
-                        sql.append(propertyColumn.getValueSql("m_sample")).append(" AS ").appendIdentifier(propertyColumn.getSelectIdentifier());
-                        hasSampleColumns = true;
+                        result.columns.add(new JoinColumn(tempColumnName, tempColumnSql, propertyColumn.getValueSql("m_sample"), JoinAlias.m_sample));
+                        result.hasSampleColumns = true;
                     }
                     else
                     {
-                        sql.append(propertyColumn.getValueSql("m_aliquot")).append(" AS ").appendIdentifier(propertyColumn.getSelectIdentifier());
-                        hasAliquotColumns = true;
+                        result.columns.add(new JoinColumn(tempColumnName, tempColumnSql, propertyColumn.getValueSql("m_aliquot"), JoinAlias.m_aliquot));
+                        result.hasAliquotColumns = true;
                     }
-                    comma = ", ";
                 }
             }
         }
 
+        return result;
+    }
+
+    /* SELECT and JOIN, does not include WHERE */
+    private SQLFragment getJoinSQL(Set<FieldKey> selectedColumns)
+    {
+        JoinColumns joinColumns = getJoinColumns(selectedColumns);
+
+        SQLFragment sql = new SQLFragment();
+        sql.appendComment("<ExpMaterialTableImpl.getJoinSQL(" + (null == _ss ? "" : _ss.getName()) + ")>", getSqlDialect());
+        sql.append("SELECT ");
+        String comma = "";
+        for (JoinColumn joinColumn : joinColumns.columns)
+        {
+            sql.append(comma).append(joinColumn.sourceSql());
+            // material columns are selected by name (no alias); provisioned columns are aliased to their temp-table column name
+            if (JoinAlias.m != joinColumn.alias())
+                sql.append(" AS ").append(joinColumn.tempColumnSql());
+            comma = ", ";
+        }
+
         sql.append("\nFROM ");
         sql.append(_rootTable, "m");
-        if (hasSampleColumns)
-            sql.append(" INNER JOIN ").append(provisioned, "m_sample").append(" ON m.RootMaterialRowId = m_sample.RowId");
-        if (hasAliquotColumns)
-            sql.append(" INNER JOIN ").append(provisioned, "m_aliquot").append(" ON m.RowId = m_aliquot.RowId");
+        if (joinColumns.hasSampleColumns)
+            sql.append(" INNER JOIN ").append(joinColumns.provisioned, "m_sample").append(" ON m.RootMaterialRowId = m_sample.RowId");
+        if (joinColumns.hasAliquotColumns)
+            sql.append(" INNER JOIN ").append(joinColumns.provisioned, "m_aliquot").append(" ON m.RowId = m_aliquot.RowId");
 
         sql.appendComment("</ExpMaterialTableImpl.getJoinSQL()>", getSqlDialect());
         return sql;
@@ -1830,7 +2136,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                     url.addParameter("includeColumn", aliasKey);
             }
         }
-        catch (IOException e)
+        catch (IOException ignored)
         {}
         templates.add(Pair.of("Download Template", url.toString()));
         return templates;
@@ -1872,6 +2178,184 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 value = Precision.round(Double.valueOf(value.toString()), scale);
             }
             return value;
+        }
+    }
+
+    @TestWhen(TestWhen.When.BVT)
+    public static class IncrementalUpdateTestCase extends Assert
+    {
+        private static User _user;
+        private static Container _c;
+
+        @BeforeClass
+        public static void setup()
+        {
+            JunitUtil.deleteTestContainer();
+
+            _c = JunitUtil.getTestContainer();
+            _user = TestContext.get().getUser();
+        }
+
+        @AfterClass
+        public static void tearDown()
+        {
+            JunitUtil.deleteTestContainer();
+        }
+
+        @Test
+        public void testTargetedSingleRowUpdate() throws Exception
+        {
+            ExpSampleType st = createSampleType("IncrUpdTargeted");
+            int root = insertRoots(st, "R1").getFirst();
+            int aliquot = insertAliquots(st, "R1", 1).getFirst();
+
+            ExpMaterialTableImpl table = getSamplesTable(st);
+            assertCacheMatchesFreshDerivation(table, st.getLSID()); // baseline materialization
+
+            // Targeted update of one aliquot's aliquot-scoped property.
+            updateRows(st, List.of(CaseInsensitiveHashMap.of(RowId.name(), aliquot, "aliquotProp", "changed")));
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+
+            // And a targeted update of the root's own (non-derived-onto-aliquot) name-adjacent material column path.
+            updateRows(st, List.of(CaseInsensitiveHashMap.of(RowId.name(), root, "rootProp", "rootChanged0")));
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+        }
+
+        @Test
+        public void testBatchUpdate() throws Exception
+        {
+            ExpSampleType st = createSampleType("IncrUpdBatch");
+            List<Integer> roots = insertRoots(st, "R1", "R2", "R3", "R4", "R5");
+
+            ExpMaterialTableImpl table = getSamplesTable(st);
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+
+            List<Map<String, Object>> updates = new ArrayList<>();
+            for (int i = 0; i < roots.size(); i++)
+                updates.add(CaseInsensitiveHashMap.of(RowId.name(), roots.get(i), "rootProp", "batch" + i));
+            updateRows(st, updates);
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+        }
+
+        @Test
+        public void testRootFanoutUpdate() throws Exception
+        {
+            ExpSampleType st = createSampleType("IncrUpdFanout");
+            int root = insertRoots(st, "R1").getFirst();
+            insertAliquots(st, "R1", 25);
+
+            ExpMaterialTableImpl table = getSamplesTable(st);
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+
+            // Editing the root's ParentOnly property must re-derive m_sample.* for every aliquot beneath it.
+            updateRows(st, List.of(CaseInsensitiveHashMap.of(RowId.name(), root, "rootProp", "fannedOut")));
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+        }
+
+        @Test
+        public void testFullResync() throws Exception
+        {
+            ExpSampleType st = createSampleType("IncrUpdFull");
+            List<Integer> roots = insertRoots(st, "R1", "R2", "R3");
+            insertAliquots(st, "R1", 3);
+
+            ExpMaterialTableImpl table = getSamplesTable(st);
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+
+            // Make a real change, then force the full-re-sync branch (as a no-rowId write path would) before reading.
+            updateRows(st, List.of(CaseInsensitiveHashMap.of(RowId.name(), roots.getFirst(), "rootProp", "fullResynced")));
+            InvalidationCounters counters = getInvalidateCounters(st.getLSID());
+            counters.pendingUpdateRowIds.clear();
+            counters.fullUpdatePending = true;
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+        }
+
+        private ExpSampleType createSampleType(String name) throws Exception
+        {
+            List<GWTPropertyDescriptor> props = new ArrayList<>();
+            props.add(new GWTPropertyDescriptor("name", "string"));
+            GWTPropertyDescriptor rootProp = new GWTPropertyDescriptor("rootProp", "string");
+            rootProp.setDerivationDataScope(ExpSchema.DerivationDataScopeType.ParentOnly.name()); // -> m_sample join
+            props.add(rootProp);
+            GWTPropertyDescriptor aliquotProp = new GWTPropertyDescriptor("aliquotProp", "string");
+            aliquotProp.setDerivationDataScope(ExpSchema.DerivationDataScopeType.ChildOnly.name()); // -> m_aliquot join
+            props.add(aliquotProp);
+            return SampleTypeService.get().createSampleType(_c, _user, name, null, props, Collections.emptyList(), -1, -1, -1, -1, null);
+        }
+
+        private ExpMaterialTableImpl getSamplesTable(ExpSampleType st)
+        {
+            return (ExpMaterialTableImpl) QueryService.get().getUserSchema(_user, _c, SamplesSchema.SCHEMA_NAME).getTable(st.getName());
+        }
+
+        private @NotNull QueryUpdateService getUpdateService(ExpSampleType st)
+        {
+            TableInfo table = getSamplesTable(st);
+            QueryUpdateService service = table.getUpdateService();
+            if (service == null)
+                throw new IllegalArgumentException("No QueryUpdateService found for table " + st.getName());
+
+            return service;
+        }
+
+        private List<Integer> insertRoots(ExpSampleType st, String... names) throws Exception
+        {
+            List<Map<String, Object>> rows = new ArrayList<>();
+            for (int i = 0; i < names.length; i++)
+                rows.add(CaseInsensitiveHashMap.of("name", names[i], "rootProp", "root" + i));
+            return insert(st, rows);
+        }
+
+        private List<Integer> insertAliquots(ExpSampleType st, String rootName, int count) throws Exception
+        {
+            List<Map<String, Object>> rows = new ArrayList<>();
+            for (int i = 0; i < count; i++)
+                rows.add(CaseInsensitiveHashMap.of("name", rootName + "-" + i, "AliquotedFrom", rootName, "aliquotProp", "aliquot" + i));
+            return insert(st, rows);
+        }
+
+        private List<Integer> insert(ExpSampleType st, List<Map<String, Object>> rows) throws Exception
+        {
+            BatchValidationException errors = new BatchValidationException();
+            List<Map<String, Object>> inserted = getUpdateService(st).insertRows(_user, _c, rows, errors, null, null);
+            if (errors.hasErrors())
+                throw errors;
+
+            if (inserted == null || inserted.isEmpty())
+                return Collections.emptyList();
+
+            List<Integer> rowIds = new ArrayList<>();
+            for (Map<String, Object> row : inserted)
+                rowIds.add(((Number) row.get(RowId.name())).intValue());
+            return rowIds;
+        }
+
+        private void updateRows(ExpSampleType st, List<Map<String, Object>> rows) throws Exception
+        {
+            BatchValidationException errors = new BatchValidationException();
+            getUpdateService(st).updateRows(_user, _c, rows, null, errors, null, null);
+            if (errors.hasErrors())
+                throw errors;
+        }
+
+        /**
+         * Trigger materialization (and any pending incremental update) as a side effect of {@link #getMaterializedSQL()},
+         * then assert the cached temp table equals a fresh derivation of the join query in both directions.
+         */
+        private void assertCacheMatchesFreshDerivation(ExpMaterialTableImpl table, String lsid)
+        {
+            SQLFragment cached = table.getMaterializedSQL(); // builds/refreshes the temp table via the normal read path
+            SQLFragment fresh = table.getJoinSQL(null).append(" WHERE CpasType = ").appendValue(lsid);
+            DbScope scope = ExperimentServiceImpl.getExpSchema().getScope();
+            assertEquals("Cached rows not found in fresh derivation", 0, countDiff(scope, cached, fresh));
+            assertEquals("Fresh-derivation rows not found in cache", 0, countDiff(scope, fresh, cached));
+        }
+
+        private int countDiff(DbScope scope, SQLFragment a, SQLFragment b)
+        {
+            SQLFragment sql = new SQLFragment("SELECT COUNT(*) FROM (\n").append(a).append("\nEXCEPT\n").append(b).append("\n) diff_");
+            Integer count = new SqlSelector(scope, sql).getObject(Integer.class);
+            return count == null ? 0 : count;
         }
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -865,9 +865,13 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         return ret;
     }
 
-    public void onSamplesChanged(User user, List<Material> materials, SampleTypeServiceImpl.SampleChangeType reason)
+    /**
+     * @param changedRowIds RowIds of samples known to have changed (only meaningful for update); null means
+     *                      the caller could not list the changed rows, forcing a full re-sync on the next read.
+     */
+    public void onSamplesChanged(User user, List<Material> materials, SampleTypeServiceImpl.SampleChangeType reason, @Nullable Set<Integer> changedRowIds)
     {
-        SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(this, reason);
+        SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(this, reason, changedRowIds);
 
         ExpProtocol[] protocols = getProtocols(user);
         if (protocols.length != 0)

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -75,6 +75,7 @@ import org.labkey.api.writer.ContainerUser;
 import org.labkey.experiment.controllers.exp.ExperimentController;
 
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -865,13 +866,9 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         return ret;
     }
 
-    /**
-     * @param changedRowIds RowIds of samples known to have changed (only meaningful for update); null means
-     *                      the caller could not list the changed rows, forcing a full re-sync on the next read.
-     */
-    public void onSamplesChanged(User user, List<Material> materials, SampleTypeServiceImpl.SampleChangeType reason, @Nullable Set<Integer> changedRowIds)
+    public void onSamplesChanged(User user, List<Material> materials, SampleTypeServiceImpl.SampleChangeType reason, @Nullable Timestamp changedSince)
     {
-        SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(this, reason, changedRowIds);
+        SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(this, reason, changedSince);
 
         ExpProtocol[] protocols = getProtocols(user);
         if (protocols.length != 0)
@@ -895,7 +892,6 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
             }
         }
     }
-
 
     @Override
     public void setContainer(Container container)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -135,6 +135,7 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -2407,12 +2408,13 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     /**
-     * @param changedRowIds RowIds of samples known to have changed (only meaningful for update); null means
-     *                      the caller could not list the changed rows, forcing a full re-sync on the next read.
+     * @param changedSince a database-clock watermark captured before the update's writes, at or after which the changed
+     *                     samples were modified (only meaningful for update); null means the caller could not capture a
+     *                     watermark, forcing a full re-sync on the next read.
      */
-    public void refreshSampleTypeMaterializedView(@NotNull ExpSampleType st, SampleChangeType reason, @Nullable Set<Integer> changedRowIds)
+    public void refreshSampleTypeMaterializedView(@NotNull ExpSampleType st, SampleChangeType reason, @Nullable Timestamp changedSince)
     {
-        ExpMaterialTableImpl.refreshMaterializedView(st.getLSID(), reason, changedRowIds);
+        ExpMaterialTableImpl.refreshMaterializedView(st.getLSID(), reason, changedSince);
     }
 
     public static class TestCase extends Assert

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -2403,9 +2403,17 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
     public void refreshSampleTypeMaterializedView(@NotNull ExpSampleType st, SampleChangeType reason)
     {
-        ExpMaterialTableImpl.refreshMaterializedView(st.getLSID(), reason);
+        refreshSampleTypeMaterializedView(st, reason, null);
     }
 
+    /**
+     * @param changedRowIds RowIds of samples known to have changed (only meaningful for update); null means
+     *                      the caller could not list the changed rows, forcing a full re-sync on the next read.
+     */
+    public void refreshSampleTypeMaterializedView(@NotNull ExpSampleType st, SampleChangeType reason, @Nullable Set<Integer> changedRowIds)
+    {
+        ExpMaterialTableImpl.refreshMaterializedView(st.getLSID(), reason, changedRowIds);
+    }
 
     public static class TestCase extends Assert
     {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1206,7 +1206,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 if (hasNameChange)
                     ExperimentService.get().addObjectLegacyName(st.getObjectId(), ExperimentServiceImpl.getNamespacePrefix(ExpSampleType.class), oldSampleTypeName, user);
 
-                transaction.addCommitTask(() -> SampleTypeServiceImpl.get().indexSampleType(st, SearchService.get().defaultTask().getQueue(container, SearchService.PRIORITY.modified)), POSTCOMMIT);
+                transaction.addCommitTask(() -> indexSampleType(st, SearchService.get().defaultTask().getQueue(container, SearchService.PRIORITY.modified)), POSTCOMMIT);
                 transaction.commit();
                 refreshSampleTypeMaterializedView(st, SampleChangeType.schema);
             }
@@ -1972,6 +1972,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         updateCounts.put("sampleAuditEvents", 0);
         Map<Long, List<FileFieldRenameData>> fileMovesBySampleId = new LongHashMap<>();
         ExperimentService expService = ExperimentService.get();
+        Timestamp changedSince = SampleTypeUpdateServiceDI.captureChangedSince();
 
         try (DbScope.Transaction transaction = ensureTransaction())
         {
@@ -1982,7 +1983,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 AbstractQueryUpdateService.addTransactionAuditEvent(transaction, user, auditEvent);
             }
 
-            for (Map.Entry<ExpSampleType, List<ExpMaterial>> entry: sampleTypesMap.entrySet())
+            for (Map.Entry<ExpSampleType, List<ExpMaterial>> entry : sampleTypesMap.entrySet())
             {
                 ExpSampleType sampleType = entry.getKey();
                 SamplesSchema schema = new SamplesSchema(user, sampleType.getContainer());
@@ -2056,10 +2057,10 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 for (ExpSampleType sampleType : sampleTypesMap.keySet())
                 {
                     // force refresh of materialized view
-                    SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(sampleType, SampleChangeType.update);
+                    refreshSampleTypeMaterializedView(sampleType, SampleChangeType.update, changedSince);
                     // update search index for moved samples via indexSampleType() helper, it filters for samples to index
                     // based on the modified date
-                    SampleTypeServiceImpl.get().indexSampleType(sampleType, SearchService.get().defaultTask().getQueue(sampleType.getContainer(), SearchService.PRIORITY.modified));
+                    indexSampleType(sampleType, SearchService.get().defaultTask().getQueue(sampleType.getContainer(), SearchService.PRIORITY.modified));
                 }
             }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -2400,7 +2400,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return getProjectSampleCount(container, counterType == NameGenerator.EntityCounter.rootSampleCount);
     }
 
-    public enum SampleChangeType { insert, update, merge /* insert + update */, delete, rollup /* aliquot count */, schema }
+    public enum SampleChangeType { insert, update, merge, delete, rollup /* aliquot count */, schema }
 
     public void refreshSampleTypeMaterializedView(@NotNull ExpSampleType st, SampleChangeType reason)
     {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -2400,7 +2400,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return getProjectSampleCount(container, counterType == NameGenerator.EntityCounter.rootSampleCount);
     }
 
-    public enum SampleChangeType { insert, update, delete, rollup /* aliquot count */, schema }
+    public enum SampleChangeType { insert, update, merge /* insert + update */, delete, rollup /* aliquot count */, schema }
 
     public void refreshSampleTypeMaterializedView(@NotNull ExpSampleType st, SampleChangeType reason)
     {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -469,19 +469,16 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         context.putConfigParameter(ExperimentService.QueryOptions.GetSampleRecomputeCol, true);
         ArrayList<Map<String, Object>> outputRows = new ArrayList<>();
-        InsertOption io = context.getInsertOption();
-        // Capture the watermark BEFORE the writes for any operation that updates existing rows (update or merge), so it is
-        // a lower bound on every exp.material.Modified the operation sets (ignored for a pure insert).
-        Timestamp changedSince = io.allowUpdate ? captureChangedSince() : null;
+        InsertOption insertOption = context.getInsertOption();
+        Timestamp changedSince = insertOption.allowUpdate ? captureChangedSince() : null;
 
         int ret = super.loadRows(user, container, rows, outputRows, context, extraScriptContext);
         if (ret > 0 && !context.getErrors().hasErrors() && _sampleType != null)
         {
-            boolean isMediaUpdate = _sampleType.isMedia() && io.updateOnly;
-            // updateOnly -> update; insert+update (MERGE/UPSERT/REPLACE) -> merge; pure insert -> insert.
-            SampleTypeServiceImpl.SampleChangeType reason = io.updateOnly ? update : io.allowUpdate ? merge : insert;
+            boolean isMediaUpdate = _sampleType.isMedia() && insertOption.updateOnly;
+            SampleTypeServiceImpl.SampleChangeType reason = insertOption.updateOnly ? update : insertOption.allowUpdate ? merge : insert;
             onSamplesChanged(!isMediaUpdate ? outputRows : null, context.getConfigParameters(), container, reason, changedSince);
-            audit(io.auditAction);
+            audit(insertOption.auditAction);
         }
         return ret;
     }
@@ -490,8 +487,6 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     public int mergeRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
     {
         assert _sampleType != null : "SampleType required for insert/update, but not required for read/delete";
-        // Capture the watermark BEFORE the writes so the merge's update portion can be targeted (the insert portion is
-        // handled by the insert path). A null watermark would route the merge to a full rebuild.
         Timestamp changedSince = captureChangedSince();
         int ret = _importRowsUsingDIB(user, container, rows, null, getDataIteratorContext(errors, InsertOption.MERGE, configParameters), extraScriptContext);
         if (ret > 0 && !errors.hasErrors())

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -46,6 +46,7 @@ import org.labkey.api.data.NameGeneratorState;
 import org.labkey.api.data.RemapCache;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.UpdateableTableInfo;
@@ -116,6 +117,7 @@ import org.labkey.experiment.SampleTypeAuditProvider;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -466,11 +468,13 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         context.putConfigParameter(ExperimentService.QueryOptions.GetSampleRecomputeCol, true);
         ArrayList<Map<String, Object>> outputRows = new ArrayList<>();
+        Timestamp changedSince = context.getInsertOption().allowUpdate ? captureChangedSince() : null;
+
         int ret = super.loadRows(user, container, rows, outputRows, context, extraScriptContext);
         if (ret > 0 && !context.getErrors().hasErrors() && _sampleType != null)
         {
             boolean isMediaUpdate = _sampleType.isMedia() && context.getInsertOption().updateOnly;
-            onSamplesChanged(!isMediaUpdate ? outputRows : null, context.getConfigParameters(), container, context.getInsertOption().allowUpdate ? update : insert);
+            onSamplesChanged(!isMediaUpdate ? outputRows : null, context.getConfigParameters(), container, context.getInsertOption().allowUpdate ? update : insert, changedSince);
             audit(context.getInsertOption().auditAction);
         }
         return ret;
@@ -510,7 +514,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         if (results != null && !results.isEmpty() && !errors.hasErrors())
         {
-            onSamplesChanged(results, configParameters, container, SampleTypeServiceImpl.SampleChangeType.insert);
+            onSamplesChanged(results, configParameters, container, insert);
             audit(QueryService.AuditAction.INSERT);
         }
         return results;
@@ -553,6 +557,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         List<Map<String, Object>> results;
         Map<Enum, Object> finalConfigParameters = configParameters == null ? new HashMap<>() : configParameters;
         recordDataIteratorUsed(finalConfigParameters);
+        Timestamp changedSince = captureChangedSince();
 
         try
         {
@@ -567,7 +572,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         if (results != null && !results.isEmpty() && !errors.hasErrors())
         {
-            onSamplesChanged(!_sampleType.isMedia() ? results : null, configParameters, container, update);
+            onSamplesChanged(!_sampleType.isMedia() ? results : null, configParameters, container, update, changedSince);
             audit(QueryService.AuditAction.UPDATE);
         }
 
@@ -1140,8 +1145,12 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
     private void onSamplesChanged(List<Map<String, Object>> results, Map<Enum, Object> params, Container container, SampleTypeServiceImpl.SampleChangeType reason)
     {
+        onSamplesChanged(results, params, container, reason, null);
+    }
+
+    private void onSamplesChanged(List<Map<String, Object>> results, Map<Enum, Object> params, Container container, SampleTypeServiceImpl.SampleChangeType reason, @Nullable Timestamp changedSince)
+    {
         var tx = getSchema().getDbSchema().getScope().getCurrentTransaction();
-        Set<Integer> changedRowIds = collectChangedRowIds(results, reason);
         Pair<Set<Long>, Set<String>> parentKeys = getSampleParentsForRecalc(results);
         boolean useBackgroundRecalc = false;
         if (parentKeys != null)
@@ -1164,7 +1173,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                 boolean finalUseBackgroundRecalc = useBackgroundRecalc;
                 boolean finalSkipRecalc = skipRecalc;
                 tx.addCommitTask(() -> {
-                    fireSamplesChanged(reason, changedRowIds);
+                    fireSamplesChanged(reason, changedSince);
                     if (finalUseBackgroundRecalc && !finalSkipRecalc)
                         handleRecalc(parentKeys.first, parentKeys.second, true, container);
                 }, DbScope.CommitTaskOption.POSTCOMMIT);
@@ -1174,7 +1183,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         }
         else
         {
-            fireSamplesChanged(reason, changedRowIds);
+            fireSamplesChanged(reason, changedSince);
         }
     }
 
@@ -1206,30 +1215,15 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         }
     }
 
-    private void fireSamplesChanged(SampleTypeServiceImpl.SampleChangeType reason, @Nullable Set<Integer> changedRowIds)
+    private void fireSamplesChanged(SampleTypeServiceImpl.SampleChangeType reason, @Nullable Timestamp changedSince)
     {
         if (_sampleType != null)
-            _sampleType.onSamplesChanged(getUser(), null, reason, changedRowIds);
+            _sampleType.onSamplesChanged(getUser(), null, reason, changedSince);
     }
 
-    /**
-     * Collect the changed rowIds so an update refresh can do a targeted incremental update instead of a full rebuild.
-     */
-    private @Nullable Set<Integer> collectChangedRowIds(List<Map<String, Object>> results, SampleTypeServiceImpl.SampleChangeType reason)
+    private static @Nullable Timestamp captureChangedSince()
     {
-        if (reason != update || results == null || results.isEmpty() || results.size() > ExpMaterialTableImpl.UPDATE_ROWID_THRESHOLD)
-            return null;
-
-        Set<Integer> changedRowIds = new HashSet<>(results.size());
-        for (Map<String, Object> row : results)
-        {
-            Long rowId = getMaterialRowId(row);
-            if (rowId == null)
-                return null; // can't enumerate the full changed set -> fall back to full re-sync
-            changedRowIds.add(rowId.intValue());
-        }
-
-        return changedRowIds;
+        return new SqlSelector(DbScope.getLabKeyScope(), "SELECT CURRENT_TIMESTAMP").getObject(Timestamp.class);
     }
 
     void audit(QueryService.AuditAction auditAction)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -1225,7 +1225,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             _sampleType.onSamplesChanged(getUser(), null, reason, changedSince);
     }
 
-    private static @Nullable Timestamp captureChangedSince()
+    static @Nullable Timestamp captureChangedSince()
     {
         return new SqlSelector(DbScope.getLabKeyScope(), "SELECT CURRENT_TIMESTAMP").getObject(Timestamp.class);
     }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -1141,6 +1141,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     private void onSamplesChanged(List<Map<String, Object>> results, Map<Enum, Object> params, Container container, SampleTypeServiceImpl.SampleChangeType reason)
     {
         var tx = getSchema().getDbSchema().getScope().getCurrentTransaction();
+        Set<Integer> changedRowIds = collectChangedRowIds(results, reason);
         Pair<Set<Long>, Set<String>> parentKeys = getSampleParentsForRecalc(results);
         boolean useBackgroundRecalc = false;
         if (parentKeys != null)
@@ -1163,7 +1164,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                 boolean finalUseBackgroundRecalc = useBackgroundRecalc;
                 boolean finalSkipRecalc = skipRecalc;
                 tx.addCommitTask(() -> {
-                    fireSamplesChanged(reason);
+                    fireSamplesChanged(reason, changedRowIds);
                     if (finalUseBackgroundRecalc && !finalSkipRecalc)
                         handleRecalc(parentKeys.first, parentKeys.second, true, container);
                 }, DbScope.CommitTaskOption.POSTCOMMIT);
@@ -1173,7 +1174,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         }
         else
         {
-            fireSamplesChanged(reason);
+            fireSamplesChanged(reason, changedRowIds);
         }
     }
 
@@ -1205,10 +1206,30 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         }
     }
 
-    private void fireSamplesChanged(SampleTypeServiceImpl.SampleChangeType reason)
+    private void fireSamplesChanged(SampleTypeServiceImpl.SampleChangeType reason, @Nullable Set<Integer> changedRowIds)
     {
         if (_sampleType != null)
-            _sampleType.onSamplesChanged(getUser(), null, reason);
+            _sampleType.onSamplesChanged(getUser(), null, reason, changedRowIds);
+    }
+
+    /**
+     * Collect the changed rowIds so an update refresh can do a targeted incremental update instead of a full rebuild.
+     */
+    private @Nullable Set<Integer> collectChangedRowIds(List<Map<String, Object>> results, SampleTypeServiceImpl.SampleChangeType reason)
+    {
+        if (reason != update || results == null || results.isEmpty() || results.size() > ExpMaterialTableImpl.UPDATE_ROWID_THRESHOLD)
+            return null;
+
+        Set<Integer> changedRowIds = new HashSet<>(results.size());
+        for (Map<String, Object> row : results)
+        {
+            Long rowId = getMaterialRowId(row);
+            if (rowId == null)
+                return null; // can't enumerate the full changed set -> fall back to full re-sync
+            changedRowIds.add(rowId.intValue());
+        }
+
+        return changedRowIds;
     }
 
     void audit(QueryService.AuditAction auditAction)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -151,6 +151,7 @@ import static org.labkey.api.exp.query.ExpMaterialTable.Column.*;
 import static org.labkey.api.util.IntegerUtils.asLong;
 import static org.labkey.experiment.ExpDataIterators.incrementCounts;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.insert;
+import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.merge;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.rollup;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.update;
 
@@ -468,14 +469,19 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         context.putConfigParameter(ExperimentService.QueryOptions.GetSampleRecomputeCol, true);
         ArrayList<Map<String, Object>> outputRows = new ArrayList<>();
-        Timestamp changedSince = context.getInsertOption().allowUpdate ? captureChangedSince() : null;
+        InsertOption io = context.getInsertOption();
+        // Capture the watermark BEFORE the writes for any operation that updates existing rows (update or merge), so it is
+        // a lower bound on every exp.material.Modified the operation sets (ignored for a pure insert).
+        Timestamp changedSince = io.allowUpdate ? captureChangedSince() : null;
 
         int ret = super.loadRows(user, container, rows, outputRows, context, extraScriptContext);
         if (ret > 0 && !context.getErrors().hasErrors() && _sampleType != null)
         {
-            boolean isMediaUpdate = _sampleType.isMedia() && context.getInsertOption().updateOnly;
-            onSamplesChanged(!isMediaUpdate ? outputRows : null, context.getConfigParameters(), container, context.getInsertOption().allowUpdate ? update : insert, changedSince);
-            audit(context.getInsertOption().auditAction);
+            boolean isMediaUpdate = _sampleType.isMedia() && io.updateOnly;
+            // updateOnly -> update; insert+update (MERGE/UPSERT/REPLACE) -> merge; pure insert -> insert.
+            SampleTypeServiceImpl.SampleChangeType reason = io.updateOnly ? update : io.allowUpdate ? merge : insert;
+            onSamplesChanged(!isMediaUpdate ? outputRows : null, context.getConfigParameters(), container, reason, changedSince);
+            audit(io.auditAction);
         }
         return ret;
     }
@@ -484,10 +490,13 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     public int mergeRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
     {
         assert _sampleType != null : "SampleType required for insert/update, but not required for read/delete";
+        // Capture the watermark BEFORE the writes so the merge's update portion can be targeted (the insert portion is
+        // handled by the insert path). A null watermark would route the merge to a full rebuild.
+        Timestamp changedSince = captureChangedSince();
         int ret = _importRowsUsingDIB(user, container, rows, null, getDataIteratorContext(errors, InsertOption.MERGE, configParameters), extraScriptContext);
         if (ret > 0 && !errors.hasErrors())
         {
-            onSamplesChanged(null, configParameters, container, update); // mergeRows not really used, skip wiring recalc
+            onSamplesChanged(null, configParameters, container, merge, changedSince); // mergeRows not really used, skip wiring recalc
             audit(QueryService.AuditAction.MERGE);
         }
         return ret;


### PR DESCRIPTION
#### Rationale
This seeks to address a portion of [#1185](https://github.com/LabKey/internal-issues/issues/1185) by introducing support for incremental update of the materialized view. The rows to update are determined by checking the modified column against a timestamp created when the mutating action is initiated. Additionally, supports incremental insert + update when it is a merge action.

#### Changes
- Add support for incremental update and incremental merge of the materialized view to `ExpMaterialTableImpl` 
- Update on sample change signatures to accept a `changedSince` timestamp parameter
- Unit tests