### PR TITLE
AbstractAgentAction: statically resolve issued conversationIds

### DIFF
--- a/api/src/org/labkey/api/mcp/AbstractAgentAction.java
+++ b/api/src/org/labkey/api/mcp/AbstractAgentAction.java
@@ -189,15 +189,20 @@ public abstract class AbstractAgentAction<F extends PromptForm> extends ReadOnly
 
     private Set<GUID> getIssuedConversationIds(HttpSession session)
     {
-        return SessionHelper.getAttribute(session, getIssuedConversationIdsKey(), () ->
-                Collections.synchronizedSet(Collections.newSetFromMap(
-                        new LinkedHashMap<>(16, 0.75f, false)
-                        {
-                            @Override
-                            protected boolean removeEldestEntry(Map.Entry<GUID, Boolean> eldest)
-                            {
-                                return size() > MAX_ISSUED_CONVERSATION_IDS;
-                            }
-                        })));
+        return SessionHelper.getAttribute(session, getIssuedConversationIdsKey(), AbstractAgentAction::newIssuedConversationIdSet);
+    }
+
+    private static Set<GUID> newIssuedConversationIdSet()
+    {
+        return Collections.synchronizedSet(Collections.newSetFromMap(
+            new LinkedHashMap<>(16, 0.75f, false)
+            {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<GUID, Boolean> eldest)
+                {
+                    return size() > MAX_ISSUED_CONVERSATION_IDS;
+                }
+            }
+        ));
     }
 }


### PR DESCRIPTION
#### Rationale
The `AbstractAgentAction` ends up holding onto a `ViewContext` via the session until the session is expired. This was caused by an anonymous subclass declared in an instance context in the backing `LinkedHashMap`.

#### Related Pull Requests
- #7665

#### Changes
- Make set creation `static` to avoid indefinitely holding onto the first action instance and its associated view context
