### PR TITLE
Give more helpful feedback when remote connection fails

### DIFF
--- a/query/api-src/org/labkey/remoteapi/RemoteConnections.java
+++ b/query/api-src/org/labkey/remoteapi/RemoteConnections.java
@@ -16,14 +16,17 @@
 package org.labkey.remoteapi;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.action.LabKeyError;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.PropertyManager.WritablePropertyMap;
 import org.labkey.api.security.ValidEmail;
+import org.labkey.api.util.logging.LogHelper;
 import org.springframework.validation.BindException;
 
+import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -36,6 +39,8 @@ import java.util.Map;
  */
 public class RemoteConnections
 {
+    private static final Logger LOG = LogHelper.getLogger(RemoteConnections.class, "Remote server connection management for ETLs");
+
     public static String REMOTE_QUERY_CONNECTIONS_CATEGORY = "remote-connections";
     public static String REMOTE_FILE_CONNECTIONS_CATEGORY = "remote-file-connections";
     public static String FIELD_URL = "URL";
@@ -91,9 +96,16 @@ public class RemoteConnections
             errors.addError(new LabKeyError("The entered URL is not valid."));
             return false;
         }
+        catch (SSLException e)
+        {
+            LOG.warn("TLS error connecting to remote connection URL: {}", url, e);
+            errors.addError(new LabKeyError("A secure (TLS) connection to the entered URL could not be established. This is often caused by an untrusted, self-signed, or expired certificate. " + e));
+            return false;
+        }
         catch (IOException e)
         {
-            errors.addError(new LabKeyError("A connection to the entered URL could not be established."));
+            LOG.warn("Error connecting to remote connection URL: {}", url, e);
+            errors.addError(new LabKeyError("A connection to the entered URL could not be established. " + e));
             return false;
         }
 

--- a/query/api-src/org/labkey/remoteapi/RemoteConnections.java
+++ b/query/api-src/org/labkey/remoteapi/RemoteConnections.java
@@ -30,6 +30,7 @@ import org.springframework.validation.BindException;
 
 import javax.net.ssl.SSLException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -324,6 +325,11 @@ public class RemoteConnections
                     try (Socket client = socket.accept())
                     {
                         client.getOutputStream().write("This is not a TLS handshake".getBytes(StandardCharsets.UTF_8));
+                        client.getOutputStream().flush();
+                        // Drain the client's handshake bytes until it disconnects
+                        InputStream in = client.getInputStream();
+                        byte[] buffer = new byte[1024];
+                        while (in.read(buffer) != -1) { /* keep draining */ }
                     }
                     catch (IOException ignored) {}
                 }, "RemoteConnections.TestCase non-TLS responder");

--- a/query/api-src/org/labkey/remoteapi/RemoteConnections.java
+++ b/query/api-src/org/labkey/remoteapi/RemoteConnections.java
@@ -18,6 +18,8 @@ package org.labkey.remoteapi;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
 import org.labkey.api.action.LabKeyError;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.PropertyManager;
@@ -29,9 +31,13 @@ import org.springframework.validation.BindException;
 import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * User: gktaylor
@@ -99,13 +105,13 @@ public class RemoteConnections
         catch (SSLException e)
         {
             LOG.warn("TLS error connecting to remote connection URL: {}", url, e);
-            errors.addError(new LabKeyError("A secure (TLS) connection to the entered URL could not be established. This is often caused by an untrusted, self-signed, or expired certificate. " + e));
+            errors.addError(new LabKeyError("A secure (TLS) connection to the entered URL could not be established. This is often caused by an untrusted, self-signed, or expired certificate. " + getBriefMessage(e)));
             return false;
         }
         catch (IOException e)
         {
             LOG.warn("Error connecting to remote connection URL: {}", url, e);
-            errors.addError(new LabKeyError("A connection to the entered URL could not be established. " + e));
+            errors.addError(new LabKeyError("A connection to the entered URL could not be established. " + getBriefMessage(e)));
             return false;
         }
 
@@ -149,6 +155,12 @@ public class RemoteConnections
             singleConnectionMap.put(RemoteConnections.FIELD_CONTAINER, folderPath);
         singleConnectionMap.save();
         return true;
+    }
+
+    /** @return a brief, user-facing description of the failure, suitable for appending to an error message. Full details should be logged separately. */
+    public static String getBriefMessage(Throwable t)
+    {
+        return t.getMessage() == null ? t.getClass().getSimpleName() : t.getMessage();
     }
 
     public static boolean deleteRemoteConnection(RemoteConnectionForm remoteConnectionForm, Container container)
@@ -255,5 +267,78 @@ public class RemoteConnections
     private static String makeRemoteConnectionKey(String connectionCategory, String name)
     {
         return connectionCategory + ":" + name;
+    }
+
+    public static class TestCase extends Assert
+    {
+        /** All URL validation failures return before touching the property store, so no container is needed */
+        private BindException validate(String url)
+        {
+            RemoteConnectionForm form = new RemoteConnectionForm();
+            form.setNewConnectionName("RemoteConnectionsTestCase");
+            form.setUrl(url);
+            form.setUserEmail("remoteconnections_testcase@validation.test");
+            form.setPassword("password");
+            // A file connection doesn't require a folder path
+            form.setConnectionKind(CONNECTION_KIND_FILE);
+
+            BindException errors = new BindException(form, "form");
+            assertFalse("Expected validation to fail for URL: " + url, createOrEditRemoteConnection(form, null, errors));
+            assertEquals("Expected a single validation error for URL: " + url, 1, errors.getErrorCount());
+            return errors;
+        }
+
+        private void assertErrorStartsWith(BindException errors, String expectedPrefix)
+        {
+            String message = errors.getAllErrors().get(0).getDefaultMessage();
+            assertNotNull("Expected an error message", message);
+            assertTrue("Expected error message to start with '" + expectedPrefix + "' but was: " + message, message.startsWith(expectedPrefix));
+        }
+
+        @Test
+        public void testMalformedUrl()
+        {
+            assertErrorStartsWith(validate("hptt://localhost/bogus"), "The entered URL is not valid.");
+        }
+
+        @Test
+        public void testConnectionRefused() throws IOException
+        {
+            // Bind an ephemeral port, then release it so nothing is listening when we connect
+            int port;
+            try (ServerSocket socket = new ServerSocket(0))
+            {
+                port = socket.getLocalPort();
+            }
+            assertErrorStartsWith(validate("http://localhost:" + port + "/"), "A connection to the entered URL could not be established.");
+        }
+
+        @Test
+        public void testTlsFailure() throws Exception
+        {
+            // Answer the TLS handshake with plain text, which fails the https client connection with an SSLException
+            try (ServerSocket socket = new ServerSocket(0))
+            {
+                Thread responder = new Thread(() ->
+                {
+                    try (Socket client = socket.accept())
+                    {
+                        client.getOutputStream().write("This is not a TLS handshake".getBytes(StandardCharsets.UTF_8));
+                    }
+                    catch (IOException ignored) {}
+                }, "RemoteConnections.TestCase non-TLS responder");
+                responder.start();
+
+                assertErrorStartsWith(validate("https://localhost:" + socket.getLocalPort() + "/"), "A secure (TLS) connection to the entered URL could not be established.");
+                responder.join(TimeUnit.SECONDS.toMillis(10));
+            }
+        }
+
+        @Test
+        public void testGetBriefMessage()
+        {
+            assertEquals("boom", getBriefMessage(new IOException("boom")));
+            assertEquals("IOException", getBriefMessage(new IOException()));
+        }
     }
 }

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -127,6 +127,7 @@ import org.labkey.query.sql.SqlParser;
 import org.labkey.query.view.InheritedQueryDataViewProvider;
 import org.labkey.query.view.QueryDataViewProvider;
 import org.labkey.query.view.QueryWebPartFactory;
+import org.labkey.remoteapi.RemoteConnections;
 import org.labkey.remoteapi.SelectRowsStreamHack;
 
 import java.util.ArrayList;
@@ -390,6 +391,7 @@ public class QueryModule extends DefaultModule
             Method.TestCase.class,
             QNode.TestCase.class,
             Query.TestCase.class,
+            RemoteConnections.TestCase.class,
             ReportsController.SerializationTest.class,
             SqlParser.SqlParserTestCase.class,
             TableWriter.TestCase.class

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -307,6 +307,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
 
+import javax.net.ssl.SSLException;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -541,8 +542,18 @@ public class QueryController extends SpringActionController
             }
             catch (Exception e)
             {
-                errors.addError(new LabKeyError("The listed credentials for this remote connection failed to connect."));
-                return new JspView<>("/org/labkey/query/view/testRemoteConnectionsFailure.jsp", remoteConnectionForm);
+                LOG.warn("Failed to connect for remote connection '{}' to {}", name, url, e);
+                // SelectRowsStreamHack wraps the underlying failure in a RuntimeException; unwrap to categorize it
+                Throwable cause = ExceptionUtil.unwrapException(e);
+                String message;
+                if (cause instanceof SSLException)
+                    message = "A secure (TLS) connection to the remote server could not be established. This is often caused by an untrusted, self-signed, or expired certificate. ";
+                else if (cause instanceof IOException)
+                    message = "A connection to the remote server could not be established. ";
+                else
+                    message = "The listed credentials for this remote connection failed to connect. ";
+                errors.addError(new LabKeyError(message + RemoteConnections.getBriefMessage(cause)));
+                return new JspView<>("/org/labkey/query/view/testRemoteConnectionsFailure.jsp", remoteConnectionForm, errors);
             }
 
             return new JspView<>("/org/labkey/query/view/testRemoteConnectionsSuccess.jsp", remoteConnectionForm);

--- a/query/src/org/labkey/query/view/testRemoteConnectionsFailure.jsp
+++ b/query/src/org/labkey/query/view/testRemoteConnectionsFailure.jsp
@@ -21,4 +21,5 @@
 <p>
     The connection using the supplied credentials was <a style="color: red; font-size: 200%">not successful</a>.
 </p>
+<labkey:errors/>
 <%=link("manage remote connections", QueryController.RemoteQueryConnectionUrls.urlManageRemoteConnection(getContainer()))%>


### PR DESCRIPTION
#### Rationale
We give very opaque error feedback if an attempted ETL remote connection fails.

#### Changes
- Differentiate between IO and TLS problems
- Log full exception

#### Tasks 📍
- [x] Claude Code Review
- ~Manual Testing~
- [x] Test Automation
