### PR TITLE
Sample Volume Scalability -Storage Action optimization

### DIFF
--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -104,7 +104,7 @@ public abstract class SqlDialect
 {
     public static final String GENERIC_ERROR_MESSAGE = "The database experienced an unexpected problem. Please check your input and try again.";
     public static final String CUSTOM_UNIQUE_ERROR_MESSAGE = "Constraint violation: cannot insert duplicate value for column";
-    public static final int TEMP_TABLE_GENERATOR_MIN_SIZE = 1000;
+    public static final int TEMP_TABLE_GENERATOR_MIN_SIZE = 1001; // 1001 so that lists up to the App UI selection limit of 1000 use the consistent inline path; temp tables are used only for larger lists.
 
     protected static final Logger LOG = LogHelper.getLogger(SqlDialect.class, "Database warnings and errors");
     protected static final int MAX_VARCHAR_SIZE = 4000;  //Any length over this will be set to nvarchar(max)/text


### PR DESCRIPTION
#### Rationale
Selection size for grid actions are generally limited to 1000 rows. At exact 1000 rows selection, a temp.inclause is built and used for querying the selected data. This cause query execution plan to be different when row selection is 1000 vs 1-999. To allow consistent behavior for app actions, this PR increases the TEMP_TABLE_GENERATOR_MIN_SIZE to 1001.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/964
- https://github.com/LabKey/platform/pull/7730
- https://github.com/LabKey/limsModules/pull/2241

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->
