### PR TITLE
Initial support for PostgreSQL 19.x

### DIFF
--- a/api/src/org/labkey/api/data/dialect/sqlKeywords.txt
+++ b/api/src/org/labkey/api/data/dialect/sqlKeywords.txt
@@ -253,6 +253,7 @@ des_key_file
 desc
 describe
 descriptor
+destination
 destroy
 destructor
 detach
@@ -294,6 +295,7 @@ dynamic
 dynamic_function
 dynamic_function_code
 each
+edge
 element
 else
 elseif
@@ -400,6 +402,8 @@ goto
 grant
 granted
 grants
+graph
+graph_table
 greatest
 group
 group_replication
@@ -560,6 +564,7 @@ longtext
 loop
 low_priority
 lower
+lsn
 m
 map
 mapping
@@ -672,6 +677,7 @@ nocompress
 nocreatedb
 nocreaterole
 nocreateuser
+node
 nodegroup
 noholdlock
 noinherit
@@ -793,6 +799,7 @@ point
 policy
 polygon
 port
+portion
 position
 position_regex
 postfix
@@ -819,6 +826,8 @@ processlist
 profile
 profiles
 program
+properties
+property
 proxy
 public
 publication
@@ -866,6 +875,7 @@ regr_sxx
 regr_sxy
 regr_syy
 reindex
+relationship
 relative
 relay
 relay_log_file
@@ -877,6 +887,7 @@ reload
 remove
 rename
 reorganize
+repack
 repair
 repeat
 repeatable
@@ -1216,6 +1227,7 @@ varying
 vector
 verbose
 version
+vertex
 view
 views
 virtual

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -148,7 +148,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
 
     public static BasePostgreSqlDialect getLatestSupportedDialect()
     {
-        return new PostgreSql_18_Dialect();
+        return new PostgreSql_19_Dialect();
     }
 
     public static class DialectRetrievalTestCase extends AbstractDialectRetrievalTestCase

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -130,9 +130,9 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
     public Collection<? extends SqlDialect> getDialectsToTest()
     {
         // PostgreSQL dialects are nearly identical, so just test the oldest supported one
-        PostgreSql_13_Dialect conforming = getOldestSupportedDialect();
+        PostgreSql_14_Dialect conforming = getOldestSupportedDialect();
         conforming.setStandardConformingStrings(true);
-        PostgreSql_13_Dialect nonconforming = getOldestSupportedDialect();
+        PostgreSql_14_Dialect nonconforming = getOldestSupportedDialect();
         nonconforming.setStandardConformingStrings(false);
 
         return PageFlowUtil.set(
@@ -141,9 +141,9 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         );
     }
 
-    public static PostgreSql_13_Dialect getOldestSupportedDialect()
+    public static PostgreSql_14_Dialect getOldestSupportedDialect()
     {
-        return new PostgreSql_13_Dialect();
+        return new PostgreSql_14_Dialect();
     }
 
     public static BasePostgreSqlDialect getLatestSupportedDialect()
@@ -158,17 +158,17 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
         {
             final String connectionUrl = "jdbc:postgresql:";
 
-            // < 13.0 should result in bad version number exception
-            badVersion("PostgreSQL", 0.0, 13.0, null, connectionUrl);
+            // < 14.0 should result in bad version number exception
+            badVersion("PostgreSQL", 0.0, 14.0, null, connectionUrl);
 
             // Test good versions
-            good("PostgreSQL", 13.0, 14.0, "", connectionUrl, null, PostgreSql_13_Dialect.class);
             good("PostgreSQL", 14.0, 15.0, "", connectionUrl, null, PostgreSql_14_Dialect.class);
             good("PostgreSQL", 15.0, 16.0, "", connectionUrl, null, PostgreSql_15_Dialect.class);
             good("PostgreSQL", 16.0, 17.0, "", connectionUrl, null, PostgreSql_16_Dialect.class);
             good("PostgreSQL", 17.0, 18.0, "", connectionUrl, null, PostgreSql_17_Dialect.class);
             good("PostgreSQL", 18.0, 19.0, "", connectionUrl, null, PostgreSql_18_Dialect.class);
-            good("PostgreSQL", 19.0, 20.0, "", connectionUrl, null, PostgreSql_18_Dialect.class);
+            good("PostgreSQL", 19.0, 20.0, "", connectionUrl, null, PostgreSql_19_Dialect.class);
+            good("PostgreSQL", 20.0, 21.0, "", connectionUrl, null, PostgreSql_19_Dialect.class);
         }
     }
 

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -33,22 +33,22 @@ import static org.labkey.core.dialect.PostgreSql92Dialect.PRODUCT_NAME;
 public enum PostgreSqlVersion
 {
     POSTGRESQL_UNSUPPORTED(-1, true, false, null),
-    POSTGRESQL_13(130, true, true, PostgreSql_13_Dialect::new),
     POSTGRESQL_14(140, false, true, PostgreSql_14_Dialect::new),
     POSTGRESQL_15(150, false, true, PostgreSql_15_Dialect::new),
     POSTGRESQL_16(160, false, true, PostgreSql_16_Dialect::new),
     POSTGRESQL_17(170, false, true, PostgreSql_17_Dialect::new),
     POSTGRESQL_18(180, false, true, PostgreSql_18_Dialect::new),
-    POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_18_Dialect::new);
+    POSTGRESQL_19(190, false, false, PostgreSql_19_Dialect::new),
+    POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_19_Dialect::new);
 
     public static final String RECOMMENDED = PRODUCT_NAME + " 18.x is the recommended version.";
 
     private final int _version;
     private final boolean _deprecated;
     private final boolean _tested;
-    private final Supplier<? extends PostgreSql_13_Dialect> _dialectFactory;
+    private final Supplier<? extends PostgreSql_14_Dialect> _dialectFactory;
 
-    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql_13_Dialect> dialectFactory)
+    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql_14_Dialect> dialectFactory)
     {
         _version = version;
         _deprecated = deprecated;
@@ -67,7 +67,7 @@ public enum PostgreSqlVersion
         return _tested;
     }
 
-    public PostgreSql_13_Dialect getDialect()
+    public PostgreSql_14_Dialect getDialect()
     {
         return _dialectFactory.get();
     }
@@ -102,17 +102,17 @@ public enum PostgreSqlVersion
         public void test()
         {
             // Good
-            test(130, POSTGRESQL_13);
             test(140, POSTGRESQL_14);
             test(150, POSTGRESQL_15);
             test(160, POSTGRESQL_16);
             test(170, POSTGRESQL_17);
             test(180, POSTGRESQL_18);
+            test(190, POSTGRESQL_19);
 
             // Future
-            test(190, POSTGRESQL_FUTURE);
             test(200, POSTGRESQL_FUTURE);
             test(210, POSTGRESQL_FUTURE);
+            test(220, POSTGRESQL_FUTURE);
 
             // Bad
             test(83, POSTGRESQL_UNSUPPORTED);
@@ -131,6 +131,7 @@ public enum PostgreSqlVersion
             test(100, POSTGRESQL_UNSUPPORTED);
             test(110, POSTGRESQL_UNSUPPORTED);
             test(120, POSTGRESQL_UNSUPPORTED);
+            test(130, POSTGRESQL_UNSUPPORTED);
         }
 
         private void test(int version, PostgreSqlVersion expectedVersion)

--- a/core/src/org/labkey/core/dialect/PostgreSql_19_Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql_19_Dialect.java
@@ -1,0 +1,5 @@
+package org.labkey.core.dialect;
+
+public class PostgreSql_19_Dialect extends PostgreSql_18_Dialect
+{
+}


### PR DESCRIPTION
#### Rationale
It's time to start testing PostgreSQL 19.x, which is in Beta 1

Also, remove all support for PostgreSQL 13.x, which reached end of life on November 13, 2025

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7241

#### Tasks 📍
- [x] Claude Code Review
- [x] Code Review @labkey-nicka 
- [x] Switch "Old Dependencies postgres" suite to PostgreSQL 14.x @labkey-tchad 
- ~Manual Testing~ Initial support for an early beta: no need for manual testing
- ~Test Automation~ Existing unit tests for versions, keywords, smoke test are sufficient