### PR TITLE
Place "forgot password" after "password"

### DIFF
--- a/core/resources/views/login.html
+++ b/core/resources/views/login.html
@@ -5,10 +5,10 @@
         <label for="email">Email</label>
         <input id="email" name="email" type="text" class="input-block" autocomplete="off">
         <label for="password">Password</label>
+        <input id="password" name="password" type="password" class="input-block" autocomplete="off">
         <div class="forgot-password-link">
             <a href="login-resetPassword.view">Forgot password</a>
         </div>
-        <input id="password" name="password" type="password" class="input-block" autocomplete="off">
         <input aria-labelledby="remember-label" type="checkbox" name="remember" id="remember" checked >
         <span id="remember-label">Remember my email address</span>
         <div class="termsOfUseSection" hidden>

--- a/core/webapp/login.css
+++ b/core/webapp/login.css
@@ -82,8 +82,9 @@ ul.sso-list > li {
 
 .forgot-password-link {
     text-align: right;
-    width: 284px;
-    display: inline-block;
+    width: 350px;
+    margin-top: -10px;
+    margin-bottom: 10px;
 }
 
 .signing-in-msg {


### PR DESCRIPTION
#### Rationale
Place "forgot password" after <INPUT password> both visually and in the tab-order.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->
