### PR TITLE
Kanban Issue 1924: Additional container scoping updates

### DIFF
--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -2841,13 +2841,14 @@ public class OntologyManager
         return cache.remap(SchemaKey.fromParts(lookup.getSchemaKey()), lookup.getQueryName(), user, lkContainer, ContainerFilter.Type.CurrentPlusProjectAndShared, String.valueOf(value));
     }
 
-    public static List<PropertyUsages> findPropertyUsages(User user, List<Integer> propertyIds, int maxUsageCount)
+    public static List<PropertyUsages> findPropertyUsagesByIds(User user, Container container, List<Integer> propertyIds, int maxUsageCount)
     {
         List<PropertyUsages> ret = new ArrayList<>(propertyIds.size());
         for (int propertyId : propertyIds)
         {
             var pd = getPropertyDescriptor(propertyId);
-            if (pd == null)
+            // Kanban #1924: Get property descriptors for the current container only
+            if (pd == null || !pd.getContainer().equals(container))
                 throw new IllegalArgumentException("property not found: " + propertyId);
 
             ret.add(findPropertyUsages(user, pd, maxUsageCount));

--- a/api/src/org/labkey/api/study/publish/AbstractPublishConfirmAction.java
+++ b/api/src/org/labkey/api/study/publish/AbstractPublishConfirmAction.java
@@ -42,6 +42,7 @@ import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.RedirectException;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.VBox;
 import org.labkey.api.view.template.ClientDependency;
 import org.springframework.validation.BindException;
@@ -106,6 +107,10 @@ public abstract class AbstractPublishConfirmAction<FORM extends PublishConfirmFo
             if (_targetStudy == null)
             {
                 errors.reject(SpringActionController.ERROR_MSG, "Could not find target study");
+            }
+            else if (!_targetStudy.hasPermission(getUser(), InsertPermission.class))
+            {
+                throw new UnauthorizedException("You do not have permission to insert into the target study");
             }
         }
 

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1767,12 +1767,12 @@ public class AssayController extends SpringActionController
             ExpProtocol protocol = service.getExpProtocol(form.getProtocolId());
             if (protocol == null)
                 throw new NotFoundException("Protocol with id " + form.getProtocolId() + " not found.");
-            AssayProvider provider = AssayService.get().getProvider(protocol);
-            if (provider == null)
-                throw new NotFoundException("No provider found for protocol " + form.getProtocolId());
             // Kanban #1924: Assure permission in the protocol's container, which may be different than the current container
             if (!protocol.getContainer().hasPermission(getUser(), ReadPermission.class))
                 throw new UnauthorizedException("User does not have permission to read protocol " + protocol.getName());
+            AssayProvider provider = AssayService.get().getProvider(protocol);
+            if (provider == null)
+                throw new NotFoundException("No provider found for protocol " + form.getProtocolId());
             AssaySchema schema = provider.createProtocolSchema(getUser(), getContainer(), protocol, null);
             TableInfo tableInfo = schema.getTableOrThrow(AssayProtocolSchema.DATA_TABLE_NAME, ContainerFilter.getUnsafeEverythingFilter());
 

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1457,6 +1457,9 @@ public class AssayController extends SpringActionController
                 ExpRun expRun = ExperimentService.get().getExpRun(NumberUtils.toInt(run));
                 if (expRun != null)
                 {
+                    // Kanban #1924 assure permissions to the run's container, which might be different from the current container
+                    if (!expRun.getContainer().hasPermission(getUser(), AssayReadPermission.class))
+                        throw new UnauthorizedException("User does not have " + AssayReadPermission.class.getSimpleName() + " for run " + run);
                     response.put("success", true);
                     DataState state = AssayQCService.getProvider().getQCState(expRun.getProtocol(), expRun.getRowId());
                     if (state != null)
@@ -1762,9 +1765,14 @@ public class AssayController extends SpringActionController
 
             ExperimentService service = ExperimentService.get();
             ExpProtocol protocol = service.getExpProtocol(form.getProtocolId());
+            if (protocol == null)
+                throw new NotFoundException("Protocol with id " + form.getProtocolId() + " not found.");
             AssayProvider provider = AssayService.get().getProvider(protocol);
             if (provider == null)
                 throw new NotFoundException("No provider found for protocol " + form.getProtocolId());
+            // Kanban #1924: Assure permission in the protocol's container, which may be different than the current container
+            if (!protocol.getContainer().hasPermission(getUser(), ReadPermission.class))
+                throw new UnauthorizedException("User does not have permission to read protocol " + protocol.getName());
             AssaySchema schema = provider.createProtocolSchema(getUser(), getContainer(), protocol, null);
             TableInfo tableInfo = schema.getTableOrThrow(AssayProtocolSchema.DATA_TABLE_NAME, ContainerFilter.getUnsafeEverythingFilter());
 

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -403,6 +403,9 @@ public class CoreController extends SpringActionController
 
                 if (!obj.getContainer().equals(getContainer()))
                 {
+                    // Kanban #1924: Assure permission in the object's container
+                    if (!obj.getContainer().hasPermission(getUser(), ReadPermission.class))
+                        throw new UnauthorizedException();
                     ActionURL correctedURL = getViewContext().getActionURL().clone();
                     Container objectContainer = obj.getContainer();
                     if (objectContainer == null)
@@ -1768,6 +1771,11 @@ public class CoreController extends SpringActionController
         {
             // Provide information about container, specifically an array of child tab folders that were deleted
             Container container = form.getContainerPath() != null ? ContainerManager.getForPath(form.getContainerPath()) : getContainer();
+            if (container == null)
+                throw new NotFoundException("No container found for path: " + form.getContainerPath());
+            // Kanban #1924: Assure permission to the container
+            if (!container.hasPermission(getUser(), ReadPermission.class))
+                throw new UnauthorizedException("You do not have permission to view the container information.");
             JSONArray deletedFolders = new JSONArray();
             for (FolderTab folderTab : container.getDeletedTabFolders(form.getNewFolderType()))
             {

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -2636,6 +2636,10 @@ public class UserController extends SpringActionController
             if (null == group)
                 throw new NotFoundException("Cannot find group with id " + groupId);
 
+            // Kanban #1924: Assure permission in the group's container
+            Container groupContainer =  ContainerManager.getForId(group.getContainer());
+            if (null != groupContainer && !groupContainer.hasPermission(getUser(), ReadPermission.class))
+                throw new UnauthorizedException("You do not have permission to see information about the group '" + group.getName() + "'");
             response.put("groupId", group.getUserId());
             response.put("groupName", group.getName());
             response.put("groupCaption", SecurityManager.getDisambiguatedGroupName(group));

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -737,7 +737,8 @@ public class ExperimentController extends SpringActionController
                 JSONArray runIds = json.getJSONArray("runIds");
                 for (int i = 0; i < runIds.length(); i++)
                 {
-                    ExpRunImpl run = ExperimentServiceImpl.get().getExpRun(runIds.getInt(i));
+                    // Kanban #1924: Make sure the run belongs to the current container.
+                    ExpRunImpl run = ExperimentServiceImpl.get().getExpRun(runIds.getInt(i), getContainer());
                     if (run != null)
                     {
                         runs.add(run);
@@ -7961,7 +7962,13 @@ public class ExperimentController extends SpringActionController
                 {
                     ExpSampleType sampleType = SampleTypeService.get().getSampleType(form.getRowId());
                     if (sampleType != null)
+                    {
+                        // Kanban #1924: Assure permission in the sample type's container
+                        if (!sampleType.getContainer().hasPermission(getUser(), ReadPermission.class))
+                            throw new UnauthorizedException("You do not have permission to read this sample type.");
                         value = sampleType.getCurrentGenId();
+                    }
+
                 }
                 else
                 {
@@ -7973,7 +7980,12 @@ public class ExperimentController extends SpringActionController
             {
                 ExpDataClass dataClass = ExperimentService.get().getDataClass(form.getRowId());
                 if (dataClass != null)
+                {
+                    // Kanban #1924: assure permission in the data class's container
+                    if (!dataClass.getContainer().hasPermission(getUser(), ReadPermission.class))
+                        throw new UnauthorizedException("You do not have permission to read this data class.");
                     value = dataClass.getCurrentGenId();
+                }
             }
 
             ApiSimpleResponse resp = new ApiSimpleResponse();

--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -2067,7 +2067,7 @@ public class PropertyController extends SpringActionController
             List<OntologyManager.PropertyUsages> usages = null;
             if (form.getPropertyIds() != null)
             {
-                usages = OntologyManager.findPropertyUsages(getUser(), form.getPropertyIds(), form.maxUsageCount);
+                usages = OntologyManager.findPropertyUsagesByIds(getUser(), getContainer(), form.getPropertyIds(), form.maxUsageCount);
             }
             else if (form.getPropertyURIs() != null)
             {


### PR DESCRIPTION
#### Rationale
Small refactors to help introduce better container scoping checks 

#### Related PRs
- https://github.com/LabKey/premiumModules/pull/612
- https://github.com/LabKey/testAutomation/pull/3046

#### Changes
- Update `OntologyManager.findPropertyUsages` when given ids to match the behavior when given URIs (that is, to exclude the descriptors not from the given container) 
- Updates container checks in 
  - AssayController::GetQCStateAction 
  - CoreController::DownloadFileLinkAction
  - CoreController::GetContainerInfoAction
  - ExperimentController::CreateHiddenRunGroupAction
  - ExperimentController::GetEntitySequenceAction
  - PropertyController::PropertyUsagesAction


