### PR TITLE
ErrorHandler: don't imply page not found for configuration errors

### DIFF
--- a/core/src/client/ErrorHandler/ErrorHandler.test.tsx
+++ b/core/src/client/ErrorHandler/ErrorHandler.test.tsx
@@ -5,8 +5,7 @@
  */
 import React from 'react';
 import { userEvent } from '@testing-library/user-event';
-import { renderWithAppContext } from '@labkey/components'
-import { getServerContext } from '@labkey/api';
+import { renderWithAppContext } from '@labkey/components';
 
 import { ErrorHandlerImpl } from './ErrorHandler';
 import { ErrorDetails, ErrorType } from './model';
@@ -19,13 +18,13 @@ describe('ErrorHandlerImpl', () => {
             message: 'This is a not found exception',
         };
         renderWithAppContext(<ErrorHandlerImpl context={{ errorDetails }} />);
-        expect(document.querySelector('.labkey-error-heading').innerHTML.includes(errorDetails.message)).toBeTruthy();
+        expect(document.querySelector('.labkey-error-heading').textContent.includes(errorDetails.message)).toBeTruthy();
         expect(document.querySelectorAll('.error-details-container')).toHaveLength(0);
 
         await userEvent.click(document.querySelectorAll('.error-page-button')[2]);
         const question = document.querySelector('.error-details-container');
-        expect(question.innerHTML.includes('What went wrong?')).toBeTruthy();
-        expect(question.innerHTML.includes('Incorrect URL:')).toBeTruthy();
+        expect(question.textContent.includes('What went wrong?')).toBeTruthy();
+        expect(question.textContent.includes('Incorrect URL:')).toBeTruthy();
     });
 
     test('Configuration exception', async () => {
@@ -33,14 +32,19 @@ describe('ErrorHandlerImpl', () => {
             errorType: ErrorType.configuration,
             message: 'This is a configuration exception',
         };
-        const subheading = 'The requested page cannot be found.';
         renderWithAppContext(<ErrorHandlerImpl context={{ errorDetails }} />);
-        expect(document.querySelector('.labkey-error-subheading').innerHTML.includes(subheading)).toBeTruthy();
+        expect(document.querySelector('.labkey-error-subheading').textContent).toEqual(
+            'This is a configuration exception.'
+        );
         expect(document.querySelectorAll('.error-details-container')).toHaveLength(0);
 
         await userEvent.click(document.querySelectorAll('.error-page-button')[2]);
-        expect(document.querySelector('.labkey-error-details-question').innerHTML.includes('What went wrong?')).toBeTruthy();
-        expect(document.querySelector('div.labkey-error-details').innerHTML.includes('Server Configuration Errors')).toBeTruthy();
+        expect(
+            document.querySelector('.labkey-error-details-question').textContent.includes('What went wrong?')
+        ).toBeTruthy();
+        expect(
+            document.querySelector('div.labkey-error-details').textContent.includes('Server Configuration Errors')
+        ).toBeTruthy();
     });
 
     test('Permission exception', async () => {
@@ -56,14 +60,19 @@ describe('ErrorHandlerImpl', () => {
             serverContext: {
                 impersonatingUser: { displayName: impersonatedUser },
                 user: { displayName: realUser, isSignedIn: true } as any,
-            }
+            },
         });
-        expect(document.querySelector('.labkey-error-subheading').innerHTML.includes(errorDetails.message)).toBeTruthy();
+        expect(
+            document.querySelector('.labkey-error-subheading').textContent.includes(errorDetails.message)
+        ).toBeTruthy();
         expect(document.querySelectorAll('.error-details-container')).toHaveLength(0);
 
         await userEvent.click(document.querySelectorAll('.error-page-button')[2]);
-        const question = document.querySelector('.error-details-container');
-        expect(document.querySelector('.labkey-error-details-question').innerHTML.startsWith('What is a permission error?')).toBeTruthy();
+        expect(
+            document
+                .querySelector('.labkey-error-details-question')
+                .textContent.startsWith('What is a permission error?')
+        ).toBeTruthy();
 
         // FIXME: the following cases are commented out because nearly the entire ErrorHandler component uses
         //  non-component functions to render the contents, which prevents the code from being able to properly use the
@@ -79,7 +88,9 @@ describe('ErrorHandlerImpl', () => {
             message: 'This is a execution exception',
         };
         renderWithAppContext(<ErrorHandlerImpl context={{ errorDetails }} />);
-        expect(document.querySelector('.labkey-error-subheading').innerHTML.includes(errorDetails.message)).toBeTruthy();
+        expect(
+            document.querySelector('.labkey-error-subheading').textContent.includes(errorDetails.message)
+        ).toBeTruthy();
         expect(document.querySelectorAll('.error-details-container')).toHaveLength(0);
 
         await userEvent.click(document.querySelectorAll('.error-page-button')[2]);

--- a/core/src/client/ErrorHandler/ErrorType.tsx
+++ b/core/src/client/ErrorHandler/ErrorType.tsx
@@ -176,7 +176,6 @@ const PERMISSION_DETAILS = (errorDetails: ErrorDetails) => (
 const CONFIGURATION_HEADING = () => 'Oops! A server configuration error has occurred.';
 const CONFIGURATION_SUBHEADING = (errorMessage?: string) => (
     <>
-        {'The requested page cannot be found. '}
         {errorMessage !== undefined
             ? errorMessage.endsWith('.')
                 ? errorMessage


### PR DESCRIPTION
#### Rationale
For some reason our error page was implying that a page could not be found when a configuration error was being thrown.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2260
- https://github.com/LabKey/platform/pull/7759
- https://github.com/LabKey/testAutomation/pull/3049

#### Changes
- ErrorHandler: Don't render "The requested page cannot be found." for configuration errors

#### Tasks 📍
- [x] Claude Code Review
- [x] Manual Testing
    - The easiest way to test this is with an http URL set for your puppeteer host e.g. http://puppeteer.example.com
- [x] Test Automation (see testAutomation PR)
- [x] Verify Fix

