### PR TITLE
Enable mothership module so its controller can handle requests

### DIFF
--- a/api/src/org/labkey/api/security/permissions/AbstractContainerScopingTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractContainerScopingTest.java
@@ -33,6 +33,7 @@ import org.labkey.api.view.ViewServlet;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -80,8 +81,8 @@ public abstract class AbstractContainerScopingTest extends Assert
         if (enabledModules.length > 0)
         {
             Set<org.labkey.api.module.Module> m = new HashSet<>(c.getActiveModules());
-            m.addAll(Set.of(enabledModules));
-            c.setActiveModules(m);
+            Collections.addAll(m, enabledModules);
+            c.setActiveModules(m, getAdmin());
         }
         _containers.add(c);
         return c;

--- a/api/src/org/labkey/api/security/permissions/AbstractContainerScopingTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractContainerScopingTest.java
@@ -33,8 +33,10 @@ import org.labkey.api.view.ViewServlet;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Base class for "container scoping" (a.k.a. broken-object-level-authorization / BOLA / IDOR) integration tests. These
@@ -71,10 +73,16 @@ public abstract class AbstractContainerScopingTest extends Assert
      * automatic cleanup. Callers pass a short local name (e.g. "A"/"B"/"Source"); the class name is prepended so two
      * test classes can both ask for "A" without colliding.
      */
-    protected Container createContainer(String name)
+    protected Container createContainer(String name, org.labkey.api.module.Module... enabledModules)
     {
         Container junit = JunitUtil.getTestContainer();
         Container c = ContainerManager.ensureContainer(junit.getParsedPath().append(getClass().getSimpleName() + "-" + name, true), getAdmin());
+        if (enabledModules.length > 0)
+        {
+            Set<org.labkey.api.module.Module> m = new HashSet<>(c.getActiveModules());
+            m.addAll(Set.of(enabledModules));
+            c.setActiveModules(m);
+        }
         _containers.add(c);
         return c;
     }

--- a/api/src/org/labkey/api/security/permissions/AbstractContainerScopingTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractContainerScopingTest.java
@@ -19,6 +19,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.module.Module;
 import org.labkey.api.security.MutableSecurityPolicy;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicyManager;
@@ -78,13 +79,19 @@ public abstract class AbstractContainerScopingTest extends Assert
     {
         Container junit = JunitUtil.getTestContainer();
         Container c = ContainerManager.ensureContainer(junit.getParsedPath().append(getClass().getSimpleName() + "-" + name, true), getAdmin());
+        activateModules(c, enabledModules);
+        _containers.add(c);
+        return c;
+    }
+
+    protected Container activateModules(Container c, Module... enabledModules)
+    {
         if (enabledModules.length > 0)
         {
             Set<org.labkey.api.module.Module> m = new HashSet<>(c.getActiveModules());
             Collections.addAll(m, enabledModules);
             c.setActiveModules(m, getAdmin());
         }
-        _containers.add(c);
         return c;
     }
 

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -54,6 +54,7 @@ import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.module.AllowedDuringUpgrade;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
@@ -1887,8 +1888,8 @@ public class MothershipController extends SpringActionController
         public void testUpdateInstallationContainerScoping() throws Exception
         {
             User admin = getAdmin();
-            Container folderA = createContainer("A");
-            Container folderB = createContainer("B");
+            Container folderA = createContainer("A", ModuleLoader.getInstance().getModule(MothershipModule.class));
+            Container folderB = createContainer("B", ModuleLoader.getInstance().getModule(MothershipModule.class));
 
             // An installation row that lives in folder B
             ServerInstallation si = new ServerInstallation();


### PR DESCRIPTION
#### Rationale
In 26.3, modules need to be considered active in a container to process requests.

#### Changes
- Make it convenient to enable modules when creating containers in integration test
- Enable Mothership module before sending it requests

#### Tasks 📍
- [x] Claude Code Review
- ~Manual Testing~
- [x] Test Automation
