### PR TITLE
Issue #980: Deprecate the UI for deriving samples in LKS

### DIFF
--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -46,6 +46,7 @@ public interface AppProps
     String SCOPE_OPTIONAL_FEATURE = "ExperimentalFeature"; // Startup property prefix for all optional features; "Experimental" for historical reasons.
     String EXPERIMENTAL_NO_GUESTS = "disableGuestAccount";
     String EXPERIMENTAL_BLOCKER = "blockMaliciousClients";
+    String DEPRECATED_DERIVE_SAMPLES_NOT_IN_APP = "deriveSamplesNotInApp";
     String EXPERIMENTAL_RESOLVE_PROPERTY_URI_COLUMNS = "resolve-property-uri-columns";
     String ADMIN_PROVIDED_ALLOWED_EXTERNAL_RESOURCES = "allowedExternalResources";
     String QUANTITY_COLUMN_SUFFIX_TESTING = "quantityColumnSuffixTesting";

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -96,6 +96,7 @@ import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.settings.OptionalFeatureFlag;
 import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.util.GUID;
@@ -264,6 +265,13 @@ public class ExperimentModule extends SpringModule
         ExperimentService.get().registerNameExpressionType("aliquots", "exp", "MaterialSource", "aliquotnameexpression");
         ExperimentService.get().registerNameExpressionType("dataclass", "exp", "DataClass", "nameexpression");
 
+        OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(
+                AppProps.DEPRECATED_DERIVE_SAMPLES_NOT_IN_APP,
+                "Show Derive Samples button in LabKey Server UI",
+                "Shows the Derive Samples button in samples grids in the LabKey Server UI. This option will be removed in LabKey Server 26.11",
+                false,
+                false,
+                OptionalFeatureService.FeatureType.Deprecated));
         OptionalFeatureService.get().addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_RESOLVE_PROPERTY_URI_COLUMNS, "Resolve property URIs as columns on experiment tables",
             "If a column is not found on an experiment table, attempt to resolve the column name as a Property URI and add it as a property column", false, true);
         if (CoreSchema.getInstance().getSqlDialect().isSqlServer())

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -267,8 +267,8 @@ public class ExperimentModule extends SpringModule
 
         OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(
                 AppProps.DEPRECATED_DERIVE_SAMPLES_NOT_IN_APP,
-                "Show Derive Sample buttons and links in LabKey Server UI",
-                "Shows the Derive Samples button in samples grids and a link from the sample lineage page in the LabKey Server UI. This option will be removed in LabKey Server 26.11",
+                "Derive Samples in LabKey Server UI",
+                "Enables the UI for deriving samples in LabKey Server UI from either the samples grids or a sample lineage page. This option will be removed in LabKey Server 26.11",
                 false,
                 false,
                 OptionalFeatureService.FeatureType.Deprecated));

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -267,8 +267,8 @@ public class ExperimentModule extends SpringModule
 
         OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(
                 AppProps.DEPRECATED_DERIVE_SAMPLES_NOT_IN_APP,
-                "Show Derive Samples button in LabKey Server UI",
-                "Shows the Derive Samples button in samples grids in the LabKey Server UI. This option will be removed in LabKey Server 26.11",
+                "Show Derive Sample buttons and links in LabKey Server UI",
+                "Shows the Derive Samples button in samples grids and a link from the sample lineage page in the LabKey Server UI. This option will be removed in LabKey Server 26.11",
                 false,
                 false,
                 OptionalFeatureService.FeatureType.Deprecated));

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -205,6 +205,7 @@ import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.ConceptURIProperties;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.sql.LabKeySql;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.StudyService;
@@ -1107,7 +1108,8 @@ public class ExperimentController extends SpringActionController
                 protected void populateButtonBar(DataView view, ButtonBar bar)
                 {
                     super.populateButtonBar(view, bar);
-                    bar.add(SampleTypeContentsView.getDeriveSamplesButton(getContainer(),null));
+                    if (OptionalFeatureService.get().isFeatureEnabled(AppProps.DEPRECATED_DERIVE_SAMPLES_NOT_IN_APP))
+                        bar.add(SampleTypeContentsView.getDeriveSamplesButton(getContainer(),null));
                 }
             };
             view.setShowDetailsColumn(false);
@@ -1247,7 +1249,7 @@ public class ExperimentController extends SpringActionController
                 }
             }
 
-            if (getContainer().hasPermission(getUser(), InsertPermission.class))
+            if (getContainer().hasPermission(getUser(), InsertPermission.class) && OptionalFeatureService.get().isFeatureEnabled(AppProps.DEPRECATED_DERIVE_SAMPLES_NOT_IN_APP))
             {
                 ActionURL deriveURL = new ActionURL(DeriveSamplesChooseTargetAction.class, getContainer());
                 deriveURL.addParameter("rowIds", _material.getRowId());

--- a/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
@@ -33,6 +33,8 @@ import org.labkey.api.query.QueryAction;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.settings.AppProps;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.study.StudyUrls;
 import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.util.PageFlowUtil;
@@ -215,7 +217,8 @@ public class SampleTypeContentsView extends QueryView
     {
         super.populateButtonBar(view, bar);
 
-        bar.add(getDeriveSamplesButton(getContainer(), _source.getRowId()));
+        if (OptionalFeatureService.get().isFeatureEnabled(AppProps.DEPRECATED_DERIVE_SAMPLES_NOT_IN_APP))
+            bar.add(getDeriveSamplesButton(getContainer(), _source.getRowId()));
 
         ActionButton linkToStudyButton = getLinkToStudyButton(view);
         if (linkToStudyButton != null)


### PR DESCRIPTION
#### Rationale
Issue [980](https://github.com/LabKey/internal-issues/issues/980): The derivation UI in our apps is far superior to the one in LKS, so we will be removing the LKS interface in 26.11 after deprecating it in 26.7.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/3052

#### Changes
- Add a deprecated feature flag 
- Update tests to enable deprecated feature when needing to interact

