### PR TITLE
GitHub Kanban #1946: encoding updates

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -70,6 +70,7 @@ import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.InputBuilder;
@@ -939,7 +940,8 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             }
             else
             {
-                sb.append(label);
+                // GitHub Kanban #1946: encode the label (a DataClass name); the if-branch above already encodes via LinkBuilder.simpleLink.
+                sb.append(PageFlowUtil.filter(label));
             }
 
             sb.append("</span> ");

--- a/issues/src/org/labkey/issue/actions/ChangeSummary.java
+++ b/issues/src/org/labkey/issue/actions/ChangeSummary.java
@@ -168,7 +168,8 @@ public class ChangeSummary
                     summary += " of " + duplicateOf.getIssueId();
             }
 
-            sbHTMLChanges.append("<b>").append(summary);
+            // GitHub Kanban #1946: encode summary, which includes the issue resolution text
+            sbHTMLChanges.append("<b>").append(PageFlowUtil.filter(summary));
             sbHTMLChanges.append("</b><br>\n");
         }
 


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/kanban/issues/1946
Encoding updates for data class search template.
Encoding updates for issue resolution in summary.