### PR TITLE
Endpoint tests: fix setup file paths

### DIFF
--- a/experiment/test/js/jest.config.integration.js
+++ b/experiment/test/js/jest.config.integration.js
@@ -14,8 +14,8 @@ module.exports = {
     },
     moduleFileExtensions: ['js', 'ts', 'tsx'],
     moduleDirectories: ['node_modules'],
-    setupFiles: ['@labkey/test/dist/config/integration.setup.js'],
-    setupFilesAfterEnv: ['@labkey/test/dist/config/integration.setup.afterenv.js'],
+    setupFiles: ['./node_modules/@labkey/test/dist/config/integration.setup.js'],
+    setupFilesAfterEnv: ['./node_modules/@labkey/test/dist/config/integration.setup.afterenv.js'],
     testEnvironment: 'jsdom',
     testPathIgnorePatterns: ['/node_modules/'],
     transform: {


### PR DESCRIPTION
#### Rationale
Module resolution path changes due to most recent package updates require we specify `./node_modules` explicitly for jest setup file paths.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7785
- https://github.com/LabKey/limsModules/pull/2287

#### Changes
- Prefix setup file paths with `./node_modules`