### PR TITLE
Warn about http remoteconnection config

### DIFF
--- a/query/api-src/org/labkey/remoteapi/RemoteConnections.java
+++ b/query/api-src/org/labkey/remoteapi/RemoteConnections.java
@@ -117,11 +117,6 @@ public class RemoteConnections
             return false;
         }
 
-        if (isCleartextHttpUrl(urlObj))
-        {
-            LOG.warn("Remote connection '{}' is configured with a cleartext http:// URL ({}). Credentials will be sent unencrypted. Use https:// instead.", newName, url);
-        }
-
         // validate the user
         try
         {
@@ -161,6 +156,12 @@ public class RemoteConnections
         if (CONNECTION_KIND_QUERY.equals(connectionKind))
             singleConnectionMap.put(RemoteConnections.FIELD_CONTAINER, folderPath);
         singleConnectionMap.save();
+
+        if (isCleartextHttpUrl(urlObj))
+        {
+            LOG.warn("Remote connection '{}' is configured with a cleartext http:// URL ({}). Credentials will be sent unencrypted. Use https:// instead.", newName, url);
+        }
+
         return true;
     }
 

--- a/query/api-src/org/labkey/remoteapi/RemoteConnections.java
+++ b/query/api-src/org/labkey/remoteapi/RemoteConnections.java
@@ -159,7 +159,8 @@ public class RemoteConnections
 
         if (isCleartextHttpUrl(urlObj))
         {
-            LOG.warn("Remote connection '{}' is configured with a cleartext http:// URL ({}). Credentials will be sent unencrypted. Use https:// instead.", newName, url);
+            // Log the host only — interpolating the full URL could leak credentials embedded in userinfo (e.g., http://user:pass@host/).
+            LOG.warn("Remote connection '{}' is configured with a cleartext http:// URL (host: {}). Credentials will be sent unencrypted. Use https:// instead.", newName, urlObj.getHost());
         }
 
         return true;

--- a/query/api-src/org/labkey/remoteapi/RemoteConnections.java
+++ b/query/api-src/org/labkey/remoteapi/RemoteConnections.java
@@ -92,9 +92,10 @@ public class RemoteConnections
         }
 
         // validate the url string and connection
+        URL urlObj;
         try
         {
-            URL urlObj = new URL(url);
+            urlObj = new URL(url);
             URLConnection conn = urlObj.openConnection();
             conn.connect();
         }
@@ -114,6 +115,11 @@ public class RemoteConnections
             LOG.warn("Error connecting to remote connection URL: {}", url, e);
             errors.addError(new LabKeyError("A connection to the entered URL could not be established. " + getBriefMessage(e)));
             return false;
+        }
+
+        if (isCleartextHttpUrl(urlObj))
+        {
+            LOG.warn("Remote connection '{}' is configured with a cleartext http:// URL ({}). Credentials will be sent unencrypted. Use https:// instead.", newName, url);
         }
 
         // validate the user
@@ -162,6 +168,11 @@ public class RemoteConnections
     public static String getBriefMessage(Throwable t)
     {
         return t.getMessage() == null ? t.getClass().getSimpleName() : t.getMessage();
+    }
+
+    public static boolean isCleartextHttpUrl(@NotNull URL url)
+    {
+        return "http".equalsIgnoreCase(url.getProtocol());
     }
 
     public static boolean deleteRemoteConnection(RemoteConnectionForm remoteConnectionForm, Container container)
@@ -345,6 +356,15 @@ public class RemoteConnections
         {
             assertEquals("boom", getBriefMessage(new IOException("boom")));
             assertEquals("IOException", getBriefMessage(new IOException()));
+        }
+
+        @Test
+        public void testIsCleartextHttpUrl() throws MalformedURLException
+        {
+            assertTrue("http:// must be detected as cleartext", isCleartextHttpUrl(new URL("http://example.com/labkey")));
+            assertTrue("scheme match is case-insensitive", isCleartextHttpUrl(new URL("HTTP://example.com/labkey")));
+            assertFalse("https:// is encrypted", isCleartextHttpUrl(new URL("https://example.com/labkey")));
+            assertFalse("HTTPS:// is encrypted", isCleartextHttpUrl(new URL("HTTPS://example.com/labkey")));
         }
     }
 }

--- a/query/src/org/labkey/query/view/createRemoteConnection.jsp
+++ b/query/src/org/labkey/query/view/createRemoteConnection.jsp
@@ -49,7 +49,7 @@
 <labkey:form name="editConnection" action="<%=QueryController.RemoteQueryConnectionUrls.urlSaveRemoteConnection(c) %>" method="post" layout="horizontal">
     <labkey:input type="text" label="Connection Name *" name="newConnectionName" id="newConnectionName" size="50" value="<%=nameToShow%>" isRequired="true"/>
     <labkey:input type="text" label="Server URL *" name="url" id="url" size="50" value="<%=url%>" forceSmallContext="true"
-                  contextContent="Enter the server URL, including the protocol and any context path. Use https:// so credentials are encrypted in transit; for example, https://example.labkey.com/labkey. http:// is accepted but sends the configured user and password in cleartext."
+                  contextContent="Enter the server URL, including the protocol and any context path. As an example, https:://localhost:8080/labkey would be a valid name."
                   isRequired="true"/>
     <labkey:input type="text" label="User *" name="userEmail" id="userEmail" size="50" value="<%=userEmail%>" isRequired="true"/>
     <labkey:input type="password" label="Password *" name="password" id="password" size="50" isRequired="true"/>

--- a/query/src/org/labkey/query/view/createRemoteConnection.jsp
+++ b/query/src/org/labkey/query/view/createRemoteConnection.jsp
@@ -46,6 +46,7 @@
         }
         catch (MalformedURLException ignored)
         {
+            // Malformed URLs are surfaced by server-side validation in createOrEditRemoteConnection; suppress here.
         }
     }
 %>

--- a/query/src/org/labkey/query/view/createRemoteConnection.jsp
+++ b/query/src/org/labkey/query/view/createRemoteConnection.jsp
@@ -35,14 +35,21 @@
     String connectionKind = remoteConnectionForm.getConnectionKind();
     boolean editConnection = StringUtils.isNotEmpty(name);
     String nameToShow = editConnection ? name : remoteConnectionForm.getNewConnectionName();
+    boolean usingCleartextHttp = url != null && url.toLowerCase().startsWith("http://");
 %>
 <p><%=h(RemoteConnections.MANAGEMENT_PAGE_INSTRUCTIONS)%></p>
 <labkey:errors/>
+<% if (usingCleartextHttp) { %>
+<p class="labkey-error">
+    Warning: this connection uses an http:// URL. The configured user and password will be sent to the remote
+    server in cleartext on every ETL run. Use https:// so credentials are encrypted in transit.
+</p>
+<% } %>
 <br>
 <labkey:form name="editConnection" action="<%=QueryController.RemoteQueryConnectionUrls.urlSaveRemoteConnection(c) %>" method="post" layout="horizontal">
     <labkey:input type="text" label="Connection Name *" name="newConnectionName" id="newConnectionName" size="50" value="<%=nameToShow%>" isRequired="true"/>
     <labkey:input type="text" label="Server URL *" name="url" id="url" size="50" value="<%=url%>" forceSmallContext="true"
-                  contextContent="Enter in the server URL. Include both the protocol (http:// or https://) and a context path if necessary. As an example, http://localhost:8080/labkey would be a valid name."
+                  contextContent="Enter the server URL, including the protocol and any context path. Use https:// so credentials are encrypted in transit; for example, https://example.labkey.com/labkey. http:// is accepted but sends the configured user and password in cleartext."
                   isRequired="true"/>
     <labkey:input type="text" label="User *" name="userEmail" id="userEmail" size="50" value="<%=userEmail%>" isRequired="true"/>
     <labkey:input type="password" label="Password *" name="password" id="password" size="50" isRequired="true"/>

--- a/query/src/org/labkey/query/view/createRemoteConnection.jsp
+++ b/query/src/org/labkey/query/view/createRemoteConnection.jsp
@@ -22,6 +22,8 @@
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.query.controllers.QueryController" %>
 <%@ page import="org.labkey.remoteapi.RemoteConnections" %>
+<%@ page import="java.net.MalformedURLException" %>
+<%@ page import="java.net.URL" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -35,12 +37,22 @@
     String connectionKind = remoteConnectionForm.getConnectionKind();
     boolean editConnection = StringUtils.isNotEmpty(name);
     String nameToShow = editConnection ? name : remoteConnectionForm.getNewConnectionName();
-    boolean usingCleartextHttp = url != null && url.toLowerCase().startsWith("http://");
+    boolean usingCleartextHttp = false;
+    if (url != null)
+    {
+        try
+        {
+            usingCleartextHttp = RemoteConnections.isCleartextHttpUrl(new URL(url));
+        }
+        catch (MalformedURLException ignored)
+        {
+        }
+    }
 %>
 <p><%=h(RemoteConnections.MANAGEMENT_PAGE_INSTRUCTIONS)%></p>
 <labkey:errors/>
 <% if (usingCleartextHttp) { %>
-<p class="labkey-error">
+<p class="labkey-warning-messages">
     Warning: this connection uses an http:// URL. The configured user and password will be sent to the remote
     server in cleartext on every ETL run. Use https:// so credentials are encrypted in transit.
 </p>
@@ -49,7 +61,7 @@
 <labkey:form name="editConnection" action="<%=QueryController.RemoteQueryConnectionUrls.urlSaveRemoteConnection(c) %>" method="post" layout="horizontal">
     <labkey:input type="text" label="Connection Name *" name="newConnectionName" id="newConnectionName" size="50" value="<%=nameToShow%>" isRequired="true"/>
     <labkey:input type="text" label="Server URL *" name="url" id="url" size="50" value="<%=url%>" forceSmallContext="true"
-                  contextContent="Enter the server URL, including the protocol and any context path. As an example, https:://localhost:8080/labkey would be a valid name."
+                  contextContent="Enter the server URL, including the protocol and any context path. As an example, https://localhost:8080/labkey would be a valid name."
                   isRequired="true"/>
     <labkey:input type="text" label="User *" name="userEmail" id="userEmail" size="50" value="<%=userEmail%>" isRequired="true"/>
     <labkey:input type="password" label="Password *" name="password" id="password" size="50" isRequired="true"/>

--- a/query/src/org/labkey/query/view/manageRemoteConnections.jsp
+++ b/query/src/org/labkey/query/view/manageRemoteConnections.jsp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.security.permissions.AdminOperationsPermission" %>
 <%@ page import="org.labkey.api.settings.AppProps" %>
@@ -22,6 +23,10 @@
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.query.controllers.QueryController.RemoteQueryConnectionUrls" %>
 <%@ page import="org.labkey.remoteapi.RemoteConnections" %>
+<%@ page import="java.net.MalformedURLException" %>
+<%@ page import="java.net.URL" %>
+<%@ page import="java.util.ArrayList" %>
+<%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -29,11 +34,41 @@
 <%
     Container c = getContainer();
     boolean hasAdminOpsPerm = c.hasPermission(getUser(), AdminOperationsPermission.class);
+
+    Map<String, String> connectionMap = ((JspView<Map<String,String>>) HttpView.currentView()).getModelBean();
+
+    List<String> cleartextConnections = new ArrayList<>();
+    if (connectionMap != null)
+    {
+        for (String connectionName : connectionMap.values())
+        {
+            Map<String, String> props = RemoteConnections.getRemoteConnection(
+                    RemoteConnections.REMOTE_QUERY_CONNECTIONS_CATEGORY, connectionName, c);
+            String connUrl = props.get(RemoteConnections.FIELD_URL);
+            if (connUrl != null)
+            {
+                try
+                {
+                    if (RemoteConnections.isCleartextHttpUrl(new URL(connUrl)))
+                        cleartextConnections.add(connectionName);
+                }
+                catch (MalformedURLException ignored)
+                {
+                    // Malformed URLs are surfaced by server-side validation in createOrEditRemoteConnection; suppress here.
+                }
+            }
+        }
+    }
 %>
+
+<% if (!cleartextConnections.isEmpty()) { %>
+<p class="labkey-warning-messages">
+    Warning: one or more remote connections use a cleartext http:// URL: <%=h(StringUtils.join(cleartextConnections, ", "))%>. Credentials are sent unencrypted on every ETL run.
+</p>
+<% } %>
 
 <br>
 <%
-    Map<String, String> connectionMap = ((JspView<Map<String,String>>) HttpView.currentView()).getModelBean();
     if (connectionMap == null)
     { %>
         <p style="color: red">EncryptionKey has not been specified in <%= h(AppProps.getInstance().getWebappConfigurationFilename()) %>, or its value no longer matches key previously in use.</p>


### PR DESCRIPTION
#### Rationale
A04-6. Add warnings about cleartext http:// remote connection.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
  - log a WARN naming the connection and the host that's cleartext
  - update help text / example to use https instead of http
  - Show warning listing any connections whose stored URL is cleartext.

#### Tasks 📍
- [x] Claude Code Review
- [x] Manual Testing @labkey-adam 
- [x] Merge

