### PR TITLE
Better fix for reentrancy issue

### DIFF
--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -1258,6 +1258,8 @@ public abstract class SpringActionController implements Controller, HasViewConte
         ViewContext vc = HttpView.currentContext();
         boolean readonly = false;
 
+        // Action classes listed below have a single code path that responds to GET and POST, so check for mutating SQL
+        // regardless of the current method
         if (
             ReadOnlyApiAction.class.isAssignableFrom(actionClass) ||
             SimpleAction.class.isAssignableFrom(actionClass) ||
@@ -1272,19 +1274,24 @@ public abstract class SpringActionController implements Controller, HasViewConte
             if (null != vc && "GET".equals(vc.getRequest().getMethod()))
             {
                 readonly = true;
-                if (!FormViewAction.class.isAssignableFrom(actionClass) && AppProps.getInstance().isDevMode())
+                // Action classes listed below have different code paths for GET vs. POST. Treat them as read-only when
+                // current method is GET.
+                if (AppProps.getInstance().isDevMode() && !(
+                    ConfirmAction.class.isAssignableFrom(actionClass) ||
+                    FormViewAction.class.isAssignableFrom(actionClass)
+                ))
                     _log.warn("Action {} accepted GET unexpectedly... might need to update checkForMutatingSql()", actionClass.getName());
             }
         }
 
         if (readonly)
         {
-            // Note: This defers the mutating SQL parsing & detection until after the quick checks above
+            // Supplier allows the quick checks above us to short-circuit the mutating SQL parsing & detection work
             String mutatingSql = mutatingSqlSupplier.get();
             if (mutatingSql != null)
             {
                 // Checking late in the game to ensure OptionalFeatureService has been initialized and to avoid
-                // reentrancy when querying this optional feature when it's not already cached.
+                // reentrancy when querying this optional feature flag's value when it's not already cached.
                 if (OptionalFeatureService.get().isFeatureEnabled(ALLOW_MUTATING_SQL_VIA_GET))
                     return;
 

--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -1252,15 +1252,18 @@ public abstract class SpringActionController implements Controller, HasViewConte
         Class<?> actionClass = getActionForThread();
         if (null == actionClass)
             return;
+        if (actionClass.getName().contains("JunitController"))
+            return;
 
         ViewContext vc = HttpView.currentContext();
         boolean readonly = false;
 
-        if (ReadOnlyApiAction.class.isAssignableFrom(actionClass))
-        {
-            readonly = true;
-        }
-        else if (SimpleRedirectAction.class.isAssignableFrom(actionClass) || SimpleViewAction.class.isAssignableFrom(actionClass))
+        if (
+            ReadOnlyApiAction.class.isAssignableFrom(actionClass) ||
+            SimpleAction.class.isAssignableFrom(actionClass) ||
+            SimpleRedirectAction.class.isAssignableFrom(actionClass) ||
+            SimpleViewAction.class.isAssignableFrom(actionClass)
+        )
         {
             readonly = true;
         }
@@ -1276,17 +1279,15 @@ public abstract class SpringActionController implements Controller, HasViewConte
 
         if (readonly)
         {
-            if (actionClass.getName().contains("JunitController"))
-                return;
-
-            // Checking this late in the game to ensure OptionalFeatureService has been initialized.
-            if (!ModuleLoader.getInstance().isStartupComplete() || OptionalFeatureService.get().isFeatureEnabled(ALLOW_MUTATING_SQL_VIA_GET))
-                return;
-
             // Note: This defers the mutating SQL parsing & detection until after the quick checks above
             String mutatingSql = mutatingSqlSupplier.get();
             if (mutatingSql != null)
             {
+                // Checking late in the game to ensure OptionalFeatureService has been initialized and to avoid
+                // reentrancy when querying this optional feature when it's not already cached.
+                if (OptionalFeatureService.get().isFeatureEnabled(ALLOW_MUTATING_SQL_VIA_GET))
+                    return;
+
                 boolean verbose = _log.isDebugEnabled() || mutatingActionsWarned.add(actionClass.getName());
                 String message = "MUTATING SQL executed as part of handling action: " +
                         (null == vc ? "" : vc.getRequest().getMethod()) + " " +

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1518,7 +1518,7 @@ public class AdminController extends SpringActionController
         private int _seconds;
     }
 
-    // For SiteWideTermsOfUseTest
+    // For SiteWideTermsOfUseTest - must be invoked in root, as with CustomizeSiteAction
     @AdminConsoleAction(AdminOperationsPermission.class)
     public static class SetTermsOfUseFrequencyAction extends MutatingApiAction<TermsFrequency>
     {


### PR DESCRIPTION
## Rationale
We evaluate every query for mutating SQL, unless a specific deprecated feature flag is set. If not already cached, we need to query the feature flag property map. This can result in reentrancy and a stack overflow.

Previous fix eliminated most reentrancy cases, but detecting mutating SQL before checking the flag avoids checking the flag in the read case.

Also, designate `SimpleAction` as read-only, `ConfirmAction` as read-only when using GET, and make the action checks more readable.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7794