### PR TITLE
Fix field error handling in BeanViewForm

### DIFF
--- a/api/src/org/labkey/api/data/BeanViewForm.java
+++ b/api/src/org/labkey/api/data/BeanViewForm.java
@@ -20,7 +20,10 @@ import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.beanutils.DynaBean;
 import org.apache.commons.beanutils.DynaClass;
+import org.labkey.api.action.BaseViewAction.BeanUtilsPropertyBindingResult;
 import org.labkey.api.action.HasBindParameters;
+import org.labkey.api.action.NullSafeBindException;
+import org.springframework.validation.BindException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -84,6 +87,13 @@ public class BeanViewForm<K> extends TableViewForm implements DynaBean, HasBindP
     {
         ObjectFactory<K> factory = ObjectFactory.Registry.getFactory(_wrappedClass);
         setTypedValues(factory.toMap(bean, null), false);
+    }
+
+    @Override
+    public BindException createErrors()
+    {
+        // Teaches Spring to resolve field names via string lookups instead of getters. e.g., errors.rejectValue().
+        return new NullSafeBindException(new BeanUtilsPropertyBindingResult(this, "form"));
     }
 
     @Override

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -30,7 +30,6 @@ import org.labkey.api.action.HasBindParameters;
 import org.labkey.api.action.NullSafeBindException;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
-import org.labkey.api.ontology.Quantity;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
@@ -897,9 +896,15 @@ public class TableViewForm extends ViewForm implements HasBindParameters
             setValueToBind(pv.getName(), pv.getValue());
         }
 
-        BindException errors = new NullSafeBindException(this, "form");
+        BindException errors = createErrors();
         validateBind(errors);
         return errors;
+    }
+
+    // Construct and return a BindException that's appropriate for this form
+    public BindException createErrors()
+    {
+        return new NullSafeBindException(this, "form");
     }
 }
 

--- a/api/src/org/labkey/api/query/UserSchemaAction.java
+++ b/api/src/org/labkey/api/query/UserSchemaAction.java
@@ -17,7 +17,6 @@ package org.labkey.api.query;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.FormViewAction;
-import org.labkey.api.action.NullSafeBindException;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.attachments.SpringAttachmentFile;
 import org.labkey.api.audit.TransactionAuditProvider;
@@ -79,7 +78,7 @@ public abstract class UserSchemaAction extends FormViewAction<QueryUpdateForm>
         QueryUpdateForm command = new QueryUpdateForm(_table, getViewContext(), null);
         if (command.isBulkUpdate())
             command.setValidateRequired(false);
-        BindException errors = new NullSafeBindException(new BeanUtilsPropertyBindingResult(command, "form"));
+        BindException errors = command.createErrors();
         command.validateBind(errors);
         return errors;
     }

--- a/study/src/org/labkey/study/pipeline/FileAnalysisDatasetTask.java
+++ b/study/src/org/labkey/study/pipeline/FileAnalysisDatasetTask.java
@@ -16,7 +16,6 @@
 package org.labkey.study.pipeline;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.action.BaseViewAction;
 import org.labkey.api.action.NullSafeBindException;
 import org.labkey.api.admin.PipelineJobLoggerGetter;
 import org.labkey.api.assay.transform.DataTransformService;
@@ -114,7 +113,7 @@ public class FileAnalysisDatasetTask extends AbstractDatasetImportTask<FileAnaly
             for (String error : readerErrors)
                 _ctx.getLogger().error(error);
 
-            BindException errors = new NullSafeBindException(new BaseViewAction.BeanUtilsPropertyBindingResult(this, "pipeline"));
+            BindException errors = new NullSafeBindException(this, "pipeline");
             boolean allowDomainUpdates = true;
             if (_ctx.getProperties().containsKey(StudyImportContext.ALLOW_DOMAIN_UPDATES))
                 allowDomainUpdates = Boolean.parseBoolean(_ctx.getProperties().get(StudyImportContext.ALLOW_DOMAIN_UPDATES));


### PR DESCRIPTION
## Rationale
A `TableViewForm` change in the related PR removed the use of `BeanUtilsPropertyBindingResult`, causing field error validation attempts on `BeanViewForm` to throw. `OlapController$ContainerScopingTestCase` started failing as a result. This restores the use of BeanUtilsPropertyBindingResult for BeanViewForm only. It also removes a couple unnecessary uses of this class.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7348

## Tasks 📍
- [x] Claude Code Review
- [x] Code Review
- [x] TeamCity and Merge