### PR TITLE
GitHub Issue 1117: sample type and dataclass foreign keys

### DIFF
--- a/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
@@ -101,15 +101,6 @@ public class AssayResultDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<PropertyStorageSpec.ForeignKey> getPropertyForeignKeys(Container container)
-    {
-        return new HashSet<>(Arrays.asList(
-            new PropertyStorageSpec.ForeignKey(SpecialColumn.CreatedBy.name(), "core", "users", "userid", null, false),
-            new PropertyStorageSpec.ForeignKey(SpecialColumn.ModifiedBy.name(), "core", "users", "userid", null, false)
-        ));
-    }
-
-    @Override
     public DbScope getScope()
     {
         return getSchema().getScope();

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -95,6 +95,7 @@ import org.labkey.api.exp.api.ExpProtocolInputCriteria;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.SampleTypeDomainKind;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainKind;
@@ -122,6 +123,7 @@ import org.labkey.api.util.logging.LogHelper;
 import org.labkey.experiment.api.AliasInsertHelper;
 import org.labkey.experiment.api.Data;
 import org.labkey.experiment.api.DataClass;
+import org.labkey.experiment.api.DataClassDomainKind;
 import org.labkey.experiment.api.DataInput;
 import org.labkey.experiment.api.ExpDataClassImpl;
 import org.labkey.experiment.api.ExpDataImpl;
@@ -895,7 +897,7 @@ public class XarReader extends AbstractXarImporter
         try
         {
             DomainKind<?> kind = domain.getDomainKind();
-            if (kind != null)
+            if (kind instanceof SampleTypeDomainKind || kind instanceof DataClassDomainKind)
                 domain.setPropertyForeignKeys(kind.getPropertyForeignKeys(getContainer())); // GitHub Issue 1117
 
             domain.save(getUser());

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -95,10 +95,8 @@ import org.labkey.api.exp.api.ExpProtocolInputCriteria;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
-import org.labkey.api.exp.api.SampleTypeDomainKind;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.Domain;
-import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.query.ExpMaterialTable;
@@ -123,7 +121,6 @@ import org.labkey.api.util.logging.LogHelper;
 import org.labkey.experiment.api.AliasInsertHelper;
 import org.labkey.experiment.api.Data;
 import org.labkey.experiment.api.DataClass;
-import org.labkey.experiment.api.DataClassDomainKind;
 import org.labkey.experiment.api.DataInput;
 import org.labkey.experiment.api.ExpDataClassImpl;
 import org.labkey.experiment.api.ExpDataImpl;
@@ -896,10 +893,6 @@ public class XarReader extends AbstractXarImporter
 
         try
         {
-            DomainKind<?> kind = domain.getDomainKind();
-            if (kind instanceof SampleTypeDomainKind || kind instanceof DataClassDomainKind)
-                domain.setPropertyForeignKeys(kind.getPropertyForeignKeys(getContainer())); // GitHub Issue 1117
-
             domain.save(getUser());
             DefaultValueService.get().setDefaultValues(domain.getContainer(), newDefaultValues);
         }

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -97,7 +97,6 @@ import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.Domain;
-import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.query.ExpMaterialTable;
@@ -894,10 +893,6 @@ public class XarReader extends AbstractXarImporter
 
         try
         {
-            DomainKind<?> kind = domain.getDomainKind();
-            if (kind != null)
-                domain.setPropertyForeignKeys(kind.getPropertyForeignKeys(getContainer())); // GitHub Issue 1117
-
             domain.save(getUser());
             DefaultValueService.get().setDefaultValues(domain.getContainer(), newDefaultValues);
         }

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -97,6 +97,7 @@ import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.query.ExpMaterialTable;
@@ -893,6 +894,10 @@ public class XarReader extends AbstractXarImporter
 
         try
         {
+            DomainKind<?> kind = domain.getDomainKind();
+            if (kind != null)
+                domain.setPropertyForeignKeys(kind.getPropertyForeignKeys(getContainer())); // GitHub Issue 1117
+
             domain.save(getUser());
             DefaultValueService.get().setDefaultValues(domain.getContainer(), newDefaultValues);
         }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8074,8 +8074,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         {
             OntologyManager.ensureObject(c, lsid.toString());
 
-            if (kind != null)
-                domain.setPropertyForeignKeys(kind.getPropertyForeignKeys(c));
             domain.save(u, options == null ? null : options.getAuditRecordMap(), calculatedFields);
             impl.save(u);
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8074,6 +8074,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         {
             OntologyManager.ensureObject(c, lsid.toString());
 
+            if (kind != null)
+                domain.setPropertyForeignKeys(kind.getPropertyForeignKeys(c));
             domain.save(u, options == null ? null : options.getAuditRecordMap(), calculatedFields);
             impl.save(u);
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -836,7 +836,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         DomainKind<?> kind = domain.getDomainKind();
         if (kind != null)
             domain.setDisabledSystemFields(kind.getDisabledSystemFields(disabledSystemField));
-
         Set<String> reservedNames = kind.getReservedPropertyNames(domain, u);
         Set<String> reservedPrefixes = kind.getReservedPropertyNamePrefixes();
         Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(Collectors.toSet());

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -835,7 +835,10 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         Domain domain = PropertyService.get().createDomain(c, lsid, name, templateInfo);
         DomainKind<?> kind = domain.getDomainKind();
         if (kind != null)
+        {
             domain.setDisabledSystemFields(kind.getDisabledSystemFields(disabledSystemField));
+            domain.setPropertyForeignKeys(kind.getPropertyForeignKeys(c)); // GitHub Issue 1117
+        }
 
         Set<String> reservedNames = kind.getReservedPropertyNames(domain, u);
         Set<String> reservedPrefixes = kind.getReservedPropertyNamePrefixes();

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -835,10 +835,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         Domain domain = PropertyService.get().createDomain(c, lsid, name, templateInfo);
         DomainKind<?> kind = domain.getDomainKind();
         if (kind != null)
-        {
             domain.setDisabledSystemFields(kind.getDisabledSystemFields(disabledSystemField));
-            domain.setPropertyForeignKeys(kind.getPropertyForeignKeys(c)); // GitHub Issue 1117
-        }
 
         Set<String> reservedNames = kind.getReservedPropertyNames(domain, u);
         Set<String> reservedPrefixes = kind.getReservedPropertyNamePrefixes();

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -835,7 +835,11 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         Domain domain = PropertyService.get().createDomain(c, lsid, name, templateInfo);
         DomainKind<?> kind = domain.getDomainKind();
         if (kind != null)
+        {
             domain.setDisabledSystemFields(kind.getDisabledSystemFields(disabledSystemField));
+            domain.setPropertyForeignKeys(kind.getPropertyForeignKeys(c)); // GitHub Issue 1117
+        }
+
         Set<String> reservedNames = kind.getReservedPropertyNames(domain, u);
         Set<String> reservedPrefixes = kind.getReservedPropertyNamePrefixes();
         Set<String> lowerReservedNames = reservedNames.stream().map(String::toLowerCase).collect(Collectors.toSet());

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -213,10 +213,16 @@ public class StorageProvisionerImpl implements StorageProvisioner
             indices.addAll(domain.getPropertyIndices());
             change.setIndexedColumns(domain, indices);
 
-            // GitHub Issue 1117
-            Set<PropertyStorageSpec.ForeignKey> foreignKeys = new LinkedHashSet<>(kind.getPropertyForeignKeys(domain.getContainer()));
-            foreignKeys.addAll(domain.getPropertyForeignKeys());
-            change.setForeignKeys(foreignKeys);
+            /*
+             * TODO:
+             * GitHub Issue 1117: Consider the generic fix below fore develop. See https://github.com/LabKey/platform/pull/7804
+             * Tests may need updates and domains FKs (for example, issues) maybe need to adjusted.
+             *
+             * Set<PropertyStorageSpec.ForeignKey> foreignKeys = new LinkedHashSet<>(kind.getPropertyForeignKeys(domain.getContainer()));
+             * foreignKeys.addAll(domain.getPropertyForeignKeys());
+             * change.setForeignKeys(foreignKeys);
+             */
+            change.setForeignKeys(domain.getPropertyForeignKeys());
 
             try
             {

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -215,7 +215,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
 
             /*
              * TODO:
-             * GitHub Issue 1117: Consider the generic fix below fore develop. See https://github.com/LabKey/platform/pull/7804
+             * GitHub Issue 1117: Consider the generic fix below for develop. See https://github.com/LabKey/platform/pull/7804
              * Tests may need updates and domains FKs (for example, issues) maybe need to adjusted.
              *
              * Set<PropertyStorageSpec.ForeignKey> foreignKeys = new LinkedHashSet<>(kind.getPropertyForeignKeys(domain.getContainer()));

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -213,10 +213,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
             indices.addAll(domain.getPropertyIndices());
             change.setIndexedColumns(domain, indices);
 
-            // GitHub Issue 1117
-            Set<PropertyStorageSpec.ForeignKey> foreignKeys = new LinkedHashSet<>(kind.getPropertyForeignKeys(domain.getContainer()));
-            foreignKeys.addAll(domain.getPropertyForeignKeys());
-            change.setForeignKeys(foreignKeys);
+            change.setForeignKeys(domain.getPropertyForeignKeys());
 
             try
             {

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -213,7 +213,10 @@ public class StorageProvisionerImpl implements StorageProvisioner
             indices.addAll(domain.getPropertyIndices());
             change.setIndexedColumns(domain, indices);
 
-            change.setForeignKeys(domain.getPropertyForeignKeys());
+            // GitHub Issue 1117
+            Set<PropertyStorageSpec.ForeignKey> foreignKeys = new LinkedHashSet<>(kind.getPropertyForeignKeys(domain.getContainer()));
+            foreignKeys.addAll(domain.getPropertyForeignKeys());
+            change.setForeignKeys(foreignKeys);
 
             try
             {


### PR DESCRIPTION
## Rationale
**DO NOT MERGE, TARGET 26.7**
ForeignKeys defined on DomainKind are not enforced in `StorageProvisionerImpl._create` and it's up to each caller to explicitly copy domainKind FK to domain, when creating the domain. Such change is risky as FK conditions are not always met, such as when importing [assay](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_Bvt/4071955?expandedTest=build%3A%28id%3A4071953%29%2Cid%3A2000000446) xar. This PR instead scope the fix to just sample types and dataclasses, during domain creation and folder import actions.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7804
- https://github.com/LabKey/testAutomation/pull/3084

## Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->