### PR TITLE
In CPUTimer make the update method public

### DIFF
--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -115,7 +115,7 @@ public class CPUTimer
         return true;
     }
 
-    protected void _update(long elapsed)
+    public void _update(long elapsed)
     {
         _cumulative += elapsed;
         _min = Math.min(_min, elapsed);

--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -109,13 +109,13 @@ public class CPUTimer
     public boolean save()
     {
         if (_stop > _start)
-            _update(_stop - _start);
+            update(_stop - _start);
         _start = 0;
         _stop = 0;
         return true;
     }
 
-    public void _update(long elapsed)
+    public void update(long elapsed)
     {
         _cumulative += elapsed;
         _min = Math.min(_min, elapsed);
@@ -134,7 +134,7 @@ public class CPUTimer
         {
             synchronized (accumulator)
             {
-                accumulator._update(_stop-_start);
+                accumulator.update(_stop-_start);
             }
         }
         _start = 0;

--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -115,6 +115,11 @@ public class CPUTimer
         return true;
     }
 
+    /**
+     * Manually set the elapse time for a timer. Could be used to set the timer to a predefined "max-high" value.
+     *
+     * @param elapsed time in nanoseconds.
+     */
     public void update(long elapsed)
     {
         _cumulative += elapsed;

--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -116,7 +116,7 @@ public class CPUTimer
     }
 
     /**
-     * Manually set the elapse time for a timer. Could be used to set the timer to a predefined "max-high" value.
+     * Manually set the elapsed time for a timer. Could be used to set the timer to a predefined "max-high" value.
      *
      * @param elapsed time in nanoseconds.
      */


### PR DESCRIPTION
## Rationale
Making the update method public in CPUTimer. Can be useful for various scenarios, like if a pef test hits a predefined max allowed time.

## Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2266

## Changes
- Make update method public.