### PR TITLE
CASE THEN/ELSE {value expression}

### DIFF
--- a/query/src/org/labkey/query/QueryTestCase.jsp
+++ b/query/src/org/labkey/query/QueryTestCase.jsp
@@ -911,8 +911,10 @@ d,seven,twelve,day,month,date,duration,guid
                 assertFalse(rs.getColumn(1).isHidden());
                 assertEquals("0.00", rs.getColumn(1).getFormat());
             }
-        }
+        },
 
+        // test operators in WHEN expression
+        new SqlTest("SELECT CASE WHEN 1=1 THEN 'a' || 'b' ELSE CASE WHEN (2=2) THEN 'two' ELSE NULL END END")
     );
 
     List<SqlTest> postgres = List.of(

--- a/query/src/org/labkey/query/QueryTestCase.jsp
+++ b/query/src/org/labkey/query/QueryTestCase.jsp
@@ -913,8 +913,8 @@ d,seven,twelve,day,month,date,duration,guid
             }
         },
 
-        // test operators in WHEN expression
-        new SqlTest("SELECT CASE WHEN 1=1 THEN 'a' || 'b' ELSE CASE WHEN (2=2) THEN 'two' ELSE NULL END END")
+        // test operators in THEN expression
+        new SqlTest("SELECT CASE WHEN 1=1 THEN 'a' || 'b' ELSE 'x' || 'y' END")
     );
 
     List<SqlTest> postgres = List.of(

--- a/query/src/org/labkey/query/sql/SqlBase.g
+++ b/query/src/org/labkey/query/sql/SqlBase.g
@@ -729,15 +729,15 @@ caseExpression
 	;
 	
 whenClause
-	: (WHEN^ logicalExpression THEN! unaryExpression)
+	: (WHEN^ logicalExpression THEN! valueExpression)
 	;
 	
 altWhenClause
-	: (WHEN^ unaryExpression THEN! unaryExpression)
+	: (WHEN^ unaryExpression THEN! valueExpression)
 	;
 	
 elseClause
-	: (ELSE^ unaryExpression)
+	: (ELSE^ valueExpression)
 	;
 	
 


### PR DESCRIPTION
## Rationale
There has been a long running issue where some operators in THEN/ELSE expressions have unexpectedly required parentheses. 

## Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

## Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->