### PR TITLE
1238: Optional feature flag for AI in products

### DIFF
--- a/api/src/org/labkey/api/mcp/AbstractAgentAction.java
+++ b/api/src/org/labkey/api/mcp/AbstractAgentAction.java
@@ -85,9 +85,18 @@ public abstract class AbstractAgentAction<F extends PromptForm> extends ReadOnly
     @Override
     public void validateForm(F form, Errors errors)
     {
+        if (!McpService.get().isAIFeaturesEnabled())
+        {
+            errors.reject(ERROR_GENERIC, "Agent actions are not available.");
+            return;
+        }
+
         String prompt = form.getPrompt();
         if (prompt != null && prompt.length() > MAX_PROMPT_CHAR_LENGTH)
+        {
             errors.rejectValue("prompt", ERROR_GENERIC, "Prompt cannot exceed " + MAX_PROMPT_CHAR_LENGTH + " characters.");
+            return;
+        }
 
         // Only honor a client-supplied conversationId if this agent previously issued this session that
         // id. Otherwise, generate a fresh one. This prevents a same-session caller from splicing into

--- a/api/src/org/labkey/api/mcp/McpService.java
+++ b/api/src/org/labkey/api/mcp/McpService.java
@@ -150,6 +150,12 @@ public interface McpService extends ToolCallbackProvider
 
     boolean isReady();
 
+    // Convenience for in-product AI features: the AI feature flag is on AND the service has started.
+    default boolean isAIFeaturesReady()
+    {
+        return isAIFeaturesEnabled() && isReady();
+    }
+
     // Register MCPs in Module.startup()
     default void register(McpImpl mcp)
     {

--- a/api/src/org/labkey/api/mcp/McpService.java
+++ b/api/src/org/labkey/api/mcp/McpService.java
@@ -99,6 +99,7 @@ public interface McpService extends ToolCallbackProvider
 
     Logger LOG = LogHelper.getLogger(McpService.class, "MCP registration exceptions");
     String ENABLE_MCP_SERVER_FLAG = "enableMcpServer";
+    String ENABLE_AI_FEATURES = "enableAIFeatures";
 
     // Interface for MCP classes that we will "ingest" using Spring annotations. Provides a few helper methods.
     interface McpImpl
@@ -143,6 +144,11 @@ public interface McpService extends ToolCallbackProvider
     default boolean isEnabled()
     {
         return OptionalFeatureService.get().isFeatureEnabled(ENABLE_MCP_SERVER_FLAG);
+    }
+
+    default boolean isAIFeaturesEnabled()
+    {
+        return OptionalFeatureService.get().isFeatureEnabled(ENABLE_AI_FEATURES);
     }
 
     boolean isReady();

--- a/api/src/org/labkey/api/mcp/McpService.java
+++ b/api/src/org/labkey/api/mcp/McpService.java
@@ -121,9 +121,6 @@ public interface McpService extends ToolCallbackProvider
         // Every MCP resource should call this on every invocation
         default void incrementResourceRequestCount(String resource)
         {
-            if (!get().isEnabled())
-                throw new RuntimeException("The MCP server is not enabled for external requests. Consider toggling the optional feature flag.");
-
             get().incrementResourceRequestCount(resource);
         }
     }

--- a/api/src/org/labkey/api/mcp/NoopMcpService.java
+++ b/api/src/org/labkey/api/mcp/NoopMcpService.java
@@ -43,6 +43,12 @@ class NoopMcpService implements McpService
     }
 
     @Override
+    public boolean isAIFeaturesEnabled()
+    {
+        return false;
+    }
+
+    @Override
     public boolean isReady()
     {
         return false;

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2265,8 +2265,7 @@ public class PageFlowUtil
         if (AppProps.getInstance().isOptionalFeatureEnabled(NotificationMenuView.EXPERIMENTAL_NOTIFICATION_MENU) && user != null)
             json.put("notifications", Map.of("unreadCount", NotificationService.get().getUnreadNotificationCountByUser(null, user.getUserId())));
 
-        if (McpService.get().isAIFeaturesEnabled())
-            json.put("mcpReady", McpService.get().isReady());
+        json.put("mcpReady", McpService.get().isAIFeaturesReady());
 
         JSONObject defaultHeaders = new JSONObject();
         defaultHeaders.put("X-ONUNAUTHORIZED", "UNAUTHORIZED");

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2265,7 +2265,7 @@ public class PageFlowUtil
         if (AppProps.getInstance().isOptionalFeatureEnabled(NotificationMenuView.EXPERIMENTAL_NOTIFICATION_MENU) && user != null)
             json.put("notifications", Map.of("unreadCount", NotificationService.get().getUnreadNotificationCountByUser(null, user.getUserId())));
 
-        if (McpService.get().isEnabled())
+        if (McpService.get().isAIFeaturesEnabled())
             json.put("mcpReady", McpService.get().isReady());
 
         JSONObject defaultHeaders = new JSONObject();

--- a/core/src/org/labkey/core/admin/sql/SqlScriptController.java
+++ b/core/src/org/labkey/core/admin/sql/SqlScriptController.java
@@ -1122,7 +1122,7 @@ public class SqlScriptController extends SpringActionController
         protected void renderButtons(SqlScript script, PrintWriter out)
         {
             out.println(PageFlowUtil.button("Reorder Script").href(getScriptURL(ReorderScriptAction.class, script)));
-            if (McpService.get().isReady())
+            if (McpService.get().isAIFeaturesReady())
             {
                 out.println(
                     PageFlowUtil.button("Clean Up Script")
@@ -1259,7 +1259,7 @@ public class SqlScriptController extends SpringActionController
         protected ModelAndView getScriptView(SqlScript script)
         {
             McpService mcpService = McpService.get();
-            if (mcpService.isReady())
+            if (mcpService.isAIFeaturesReady())
             {
                 String prompt = getPrompt(DbScope.getLabKeyScope().getSqlDialect(), script);
                 HttpSession session = getViewContext().getSession();

--- a/devtools/src/org/labkey/devtools/TestController.java
+++ b/devtools/src/org/labkey/devtools/TestController.java
@@ -1285,7 +1285,7 @@ public class TestController extends SpringActionController
         @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            if (null == McpService.get() || !McpService.get().isReady())
+            if (null == McpService.get() || !McpService.get().isAIFeaturesReady())
                 return HtmlView.of("Service is not ready yet.");
             getPageConfig().setTemplate(PageConfig.Template.Dialog);
             return new JspView<>("/org/labkey/devtools/view/chat.jsp");

--- a/devtools/src/org/labkey/devtools/view/chat.jsp
+++ b/devtools/src/org/labkey/devtools/view/chat.jsp
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.labkey.api.util.DOM" %>
-<%@ page import="java.util.stream.Stream" %>
-<%@ page import="static org.labkey.api.util.DOM.*" %>
-<%@ page import="static org.labkey.api.util.DOM.Attribute.*" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <style type="text/css">
@@ -30,7 +26,7 @@
       border-radius: 15px;
       border : solid 1px darkgray;
       display: flex;
-      align-items: center; */
+      align-items: center;
       box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     }
 

--- a/query/src/org/labkey/query/view/sourceQuery.jsp
+++ b/query/src/org/labkey/query/view/sourceQuery.jsp
@@ -52,7 +52,7 @@
     boolean canEdit = queryDef.canEdit(getUser());
     boolean canEditMetadata = queryDef.canEditMetadata(getUser());
     boolean canDelete = queryDef.canDelete(getUser());
-    boolean isChatReady = canEdit && McpService.get().isReady();
+    boolean isChatReady = canEdit && McpService.get().isAIFeaturesEnabled() && McpService.get().isReady();
 %>
 <style type="text/css">
 

--- a/query/src/org/labkey/query/view/sourceQuery.jsp
+++ b/query/src/org/labkey/query/view/sourceQuery.jsp
@@ -52,7 +52,7 @@
     boolean canEdit = queryDef.canEdit(getUser());
     boolean canEditMetadata = queryDef.canEditMetadata(getUser());
     boolean canDelete = queryDef.canDelete(getUser());
-    boolean isChatReady = canEdit && McpService.get().isAIFeaturesEnabled() && McpService.get().isReady();
+    boolean isChatReady = canEdit && McpService.get().isAIFeaturesReady();
 %>
 <style type="text/css">
 


### PR DESCRIPTION
## Rationale
This addresses feature request [#1238](https://github.com/LabKey/internal-issues/issues/1238) by adding an optional feature flag that gates AI feature usage.

## Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/646

## Changes
- Defined `McpService.isAIFeaturesEnabled()` backed by feature flag
- Reject requests for `AbtractAgentAction` when feature flag is disabled
- Remove `isEnabled()` check that is too restrictive which caused internal tool requests to fail when MCP feature flag is disabled
- Update `sourceQuery.jsp` to respect feature flag.