### PR TITLE
Upgrade ActiveMQ to 5.19.8

### DIFF
--- a/pipeline/gradle.properties
+++ b/pipeline/gradle.properties
@@ -1,4 +1,4 @@
-activemqVersion=5.19.7
+activemqVersion=5.19.8
 
 geronimoJ2eeConnector15SpecVersion=1.0.1
 


### PR DESCRIPTION
## Rationale

Routine dependency upgrade per the JAR dependency upgrade schedule, picking up the latest ActiveMQ 5.19.x security-hardening release.

## Related Pull Requests

- LabKey/premiumModules#647 (Snowflake JDBC 4.3.1)
- LabKey/testAutomation#3087 (Selenium 4.45.0, Jetty 12.1.10)

## Changes

- Bump `activemqVersion` from 5.19.7 to 5.19.8 in `pipeline/gradle.properties`