### PR TITLE
Target ES2023 in @labkey/api

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.45.2"
+        "@labkey/components": "7.46.0"
       },
       "devDependencies": {
         "@labkey/build": "9.1.5",
@@ -3742,9 +3742,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.51.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.5.tgz",
-      "integrity": "sha512-F7qo6roSBTqeh68Z4yWwel/AAWvt620SSVdCQauKBYjHRJao/Z29gOKWEQ7lWy0E66avDwBOVzpBZq8syhvP0g==",
+      "version": "1.52.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.52.0.tgz",
+      "integrity": "sha512-jpx4bmrJBNoNCS0oJ0PktkbljY27/9f1ZMKx0i2IGjyFPmK0KrQLWp11QiAwu4Yf0KzZ0NUYe1GdBMfpoH5Y8A==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3786,13 +3786,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.45.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.45.2.tgz",
-      "integrity": "sha512-o/U7wotLaaoqXFhUFTxzgGeU1OVOwq16PBzCF/Ti/+Z8WW3OxAsAUCK/YqQMLkGu5sgH+ZOHoxa6tO3+NjipBw==",
+      "version": "7.46.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.46.0.tgz",
+      "integrity": "sha512-PBkHm5vYtlbxf9B9nm5g7hqVPbj/FQY3eVPbwiXfMD5qGTotfyiyuzkq9ODSygcCNt9Hku3Qh+Z0maqsGw4rew==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.51.5",
+        "@labkey/api": "1.52.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "eslint --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.45.2"
+    "@labkey/components": "7.46.0"
   },
   "devDependencies": {
     "@labkey/build": "9.1.5",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.45.4",
+        "@labkey/components": "7.46.0",
         "@labkey/themes": "1.9.4"
       },
       "devDependencies": {
@@ -3745,9 +3745,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.51.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.5.tgz",
-      "integrity": "sha512-F7qo6roSBTqeh68Z4yWwel/AAWvt620SSVdCQauKBYjHRJao/Z29gOKWEQ7lWy0E66avDwBOVzpBZq8syhvP0g==",
+      "version": "1.52.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.52.0.tgz",
+      "integrity": "sha512-jpx4bmrJBNoNCS0oJ0PktkbljY27/9f1ZMKx0i2IGjyFPmK0KrQLWp11QiAwu4Yf0KzZ0NUYe1GdBMfpoH5Y8A==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3789,13 +3789,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.45.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.45.4.tgz",
-      "integrity": "sha512-X/iP75JtN4xXcRdH8jdyAV8pwDOfeqYqeJO8kU424eLuYJJhVAy0hI4Vw1erIwrix5y6brylHkmMiBts4RXJ/Q==",
+      "version": "7.46.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.46.0.tgz",
+      "integrity": "sha512-PBkHm5vYtlbxf9B9nm5g7hqVPbj/FQY3eVPbwiXfMD5qGTotfyiyuzkq9ODSygcCNt9Hku3Qh+Z0maqsGw4rew==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.51.5",
+        "@labkey/api": "1.52.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/core/package.json
+++ b/core/package.json
@@ -20,7 +20,7 @@
     "lint-branch-fix": "node lint.diff.mjs --currentBranch --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.45.4",
+    "@labkey/components": "7.46.0",
     "@labkey/themes": "1.9.4"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.45.2"
+        "@labkey/components": "7.46.0"
       },
       "devDependencies": {
         "@labkey/build": "9.1.5",
@@ -3754,9 +3754,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.51.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.5.tgz",
-      "integrity": "sha512-F7qo6roSBTqeh68Z4yWwel/AAWvt620SSVdCQauKBYjHRJao/Z29gOKWEQ7lWy0E66avDwBOVzpBZq8syhvP0g==",
+      "version": "1.52.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.52.0.tgz",
+      "integrity": "sha512-jpx4bmrJBNoNCS0oJ0PktkbljY27/9f1ZMKx0i2IGjyFPmK0KrQLWp11QiAwu4Yf0KzZ0NUYe1GdBMfpoH5Y8A==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3798,13 +3798,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.45.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.45.2.tgz",
-      "integrity": "sha512-o/U7wotLaaoqXFhUFTxzgGeU1OVOwq16PBzCF/Ti/+Z8WW3OxAsAUCK/YqQMLkGu5sgH+ZOHoxa6tO3+NjipBw==",
+      "version": "7.46.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.46.0.tgz",
+      "integrity": "sha512-PBkHm5vYtlbxf9B9nm5g7hqVPbj/FQY3eVPbwiXfMD5qGTotfyiyuzkq9ODSygcCNt9Hku3Qh+Z0maqsGw4rew==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.51.5",
+        "@labkey/api": "1.52.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.45.2"
+    "@labkey/components": "7.46.0"
   },
   "devDependencies": {
     "@labkey/build": "9.1.5",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.45.2"
+        "@labkey/components": "7.46.0"
       },
       "devDependencies": {
         "@labkey/build": "9.1.5",
@@ -2835,9 +2835,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.51.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.51.5.tgz",
-      "integrity": "sha512-F7qo6roSBTqeh68Z4yWwel/AAWvt620SSVdCQauKBYjHRJao/Z29gOKWEQ7lWy0E66avDwBOVzpBZq8syhvP0g==",
+      "version": "1.52.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.52.0.tgz",
+      "integrity": "sha512-jpx4bmrJBNoNCS0oJ0PktkbljY27/9f1ZMKx0i2IGjyFPmK0KrQLWp11QiAwu4Yf0KzZ0NUYe1GdBMfpoH5Y8A==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2879,13 +2879,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.45.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.45.2.tgz",
-      "integrity": "sha512-o/U7wotLaaoqXFhUFTxzgGeU1OVOwq16PBzCF/Ti/+Z8WW3OxAsAUCK/YqQMLkGu5sgH+ZOHoxa6tO3+NjipBw==",
+      "version": "7.46.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.46.0.tgz",
+      "integrity": "sha512-PBkHm5vYtlbxf9B9nm5g7hqVPbj/FQY3eVPbwiXfMD5qGTotfyiyuzkq9ODSygcCNt9Hku3Qh+Z0maqsGw4rew==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.51.5",
+        "@labkey/api": "1.52.0",
         "@testing-library/dom": "~10.4.1",
         "@testing-library/jest-dom": "~6.9.1",
         "@testing-library/react": "~16.3.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "7.45.2"
+    "@labkey/components": "7.46.0"
   },
   "devDependencies": {
     "@labkey/build": "9.1.5",


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-api-js/pull/219 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/219
- https://github.com/LabKey/labkey-ui-components/pull/2029
- https://github.com/LabKey/labkey-ui-premium/pull/982
- https://github.com/LabKey/limsModules/pull/2315
- https://github.com/LabKey/platform/pull/7813

#### Changes
- Bump `@labkey` packages
