### PR TITLE
ModuleEditorService.getModuleRoot()

### DIFF
--- a/api/src/org/labkey/api/moduleeditor/api/ModuleEditorService.java
+++ b/api/src/org/labkey/api/moduleeditor/api/ModuleEditorService.java
@@ -66,4 +66,11 @@ public interface ModuleEditorService
             return null;
         return FileUtil.appendPath(resources, path);
     }
+
+    // used by ModuleResourceProvider@AllModuleResourcesRoot() (_webdav/@modules) which wants to soo
+    // the whole module source directory (e.g. when using SourcePath)
+    default File getModuleRoot(Module module, @Nullable List<String> messages)
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
## Rationale
Make ModuleEditorService.getUpdatableResourcesRoot() return the path used to resolve module resources.  getModuleRoot() returns the module source root (potentially parent of getUpdatableResourcesRoot())

## Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

## Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->

## Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

## Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->