### PR TITLE
Fix TypeError when toggling edit mode before Data Views grid loads

### DIFF
--- a/query/webapp/dataview/DataViewsPanel.js
+++ b/query/webapp/dataview/DataViewsPanel.js
@@ -705,7 +705,7 @@ Ext4.define('LABKEY.ext4.DataViewsPanel', {
                 },
                 scope : this
             },
-            hidden   : !this.manageView,
+            hidden   : !this.editMode,
             scope    : this
         },{
             xtype    : 'fatreecolumn',
@@ -1050,14 +1050,20 @@ Ext4.define('LABKEY.ext4.DataViewsPanel', {
 
     onEnableEditMode : function() {
         this.editMode = true;
-        this._getEditColumn().show();
+        var editColumn = this._getEditColumn();
+        if (editColumn) {
+            editColumn.show();
+        }
         this.refreshViewStore();
         this.applySearchFilter();
     },
 
     onDisableEditMode : function() {
         this.editMode = false;
-        this._getEditColumn().hide();
+        var editColumn = this._getEditColumn();
+        if (editColumn) {
+            editColumn.hide();
+        }
         this.refreshViewStore();
         this.applySearchFilter();
     },


### PR DESCRIPTION
## Rationale
Toggling "Edit" on the Data Views webpart before its grid finishes its async configuration load throws `TypeError: can't access property "show", this._getEditColumn() is undefined`, because `onEnableEditMode`/`onDisableEditMode` call `.show()`/`.hide()` on the edit column before it exists. This happens in practice when a page (e.g. `project-begin.view`) calls `enableEdit()` from an `Ext.onReady` handler, which reliably wins the race against the panel's own config request.

Prompted by this error on TeamCity:
```
TypeError: can't access property "show", this._getEditColumn() is undefined
  onEnableEditMode (http://localhost:8111/labkey/dataview/DataViewsPanel.js:1053:14)
  fire (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:9824:49)
  continueFireEvent (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:11215:47)
  fireEventArgs (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:11193:26)
  monitor/prototype.fireEventArgs (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:41550:37)
  fireEvent (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:11179:25)
  edit (http://localhost:8111/labkey/dataview/DataViewsPanel.js:1047:18)
  enableEdit (http://localhost:8111/labkey/StudyVerifyProject/My%20Study%20Data%20Views/project-begin.view:470:32)
  createSingle/< (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:9869:28)
  fire (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:9824:49)
  Ext.EventManager</readyEvent.fire (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:10058:52)
  fireReadyEvent (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:10136:28)
  onDocumentReady (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:10154:34)
  fn (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:6664:25)
  onReady (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:6669:20)
  Ext.EventManager</Ext.onReady (http://localhost:8111/labkey/ext-4.2.1/ext-all-sandbox-debug.js:10934:20)
  editDataViews (http://localhost:8111/labkey/StudyVerifyProject/My%20Study%20Data%20Views/project-begin.view:473:14)
  h10 (http://localhost:8111/labkey/StudyVerifyProject/My%20Study%20Data%20Views/project-begin.view:1268:14)
```

## Related Pull Requests
None.

## Changes
- Null-guard the edit column lookup in `onEnableEditMode`/`onDisableEditMode` before calling `.show()`/`.hide()`.
- Source the edit column's initial `hidden` state from `this.editMode` instead of the constructor-time `this.manageView` snapshot, so the column renders with the correct visibility once it's created after a mode toggle occurred first.
