### PR TITLE
Update ActiveMQ to 5.19.8 for OWASP CVE remediation

### DIFF
--- a/pipeline/gradle.properties
+++ b/pipeline/gradle.properties
@@ -1,4 +1,4 @@
-activemqVersion=5.19.7
+activemqVersion=5.19.8
 
 geronimoJ2eeConnector15SpecVersion=1.0.1
 


### PR DESCRIPTION
#### Rationale

LabKey Server's OWASP Dependency Check build is failing on develop; ActiveMQ 5.19.7 accounts for nine of those findings. Bumping to 5.19.8 clears all nine.

#### Related Pull Requests

- LabKey/server#1437 - companion server-root OWASP remediation (Tomcat, HttpCore5, Jackson)

#### Changes

- Bump ActiveMQ 5.19.7 -> 5.19.8: CVE-2026-49877 (HIGH 8.1) plus CVE-2026-49432, CVE-2026-49434, CVE-2026-50734, CVE-2026-50750, CVE-2026-53916, CVE-2026-53917, CVE-2026-54475, CVE-2026-52760
