### PR TITLE
Canceling Pipeline's Setup sends you back to an unstyled page

### DIFF
--- a/pipeline/src/org/labkey/pipeline/status/PipelineQueryView.java
+++ b/pipeline/src/org/labkey/pipeline/status/PipelineQueryView.java
@@ -112,7 +112,7 @@ public class PipelineQueryView extends QueryView
             {
                 ActionButton button = new ActionButton(PipelineController.BrowseAction.class, "Process and Import Data");
                 button.setActionType(ActionButton.Action.LINK);
-                button.setURL(PageFlowUtil.urlProvider(PipelineUrls.class).urlBrowse(getContainer(), getViewContext().getActionURL()));
+                button.setURL(PageFlowUtil.urlProvider(PipelineUrls.class).urlBrowse(getContainer(), _returnUrl == null ? getViewContext().getActionURL() : _returnUrl));
                 bar.add(button);
             }
         }

--- a/pipeline/src/org/labkey/pipeline/status/PipelineQueryView.java
+++ b/pipeline/src/org/labkey/pipeline/status/PipelineQueryView.java
@@ -144,7 +144,7 @@ public class PipelineQueryView extends QueryView
             {
                 ActionButton button = new ActionButton(PipelineController.SetupAction.class, "Setup");
                 button.setActionType(ActionButton.Action.LINK);
-                button.setURL(PipelineController.urlSetup(getContainer(), getViewContext().getActionURL()));
+                button.setURL(PipelineController.urlSetup(getContainer(), _returnUrl == null ? getViewContext().getActionURL() : _returnUrl));
                 bar.add(button);
             }
         }


### PR DESCRIPTION
## Rationale
If you click on the pipeline grid's Setup button after it's refreshed itself via AJAX, cancelling the Setup action takes you "back" to the raw AJAX URL.

## Changes
- Propagate the returnUrl value into the AJAX grid render