### PR TITLE
Skip batch trigger if we have prior errors.

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -889,6 +889,8 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         }
 
         // Fire triggers, if any, and also throw if there are any errors
+        if (errors.hasErrors())
+            throw errors;
         getQueryTable().fireBatchTrigger(container, user, TableInfo.TriggerType.UPDATE, false, errors, extraScriptContext);
         afterInsertUpdate(null==result?0:result.size(), errors, true);
 


### PR DESCRIPTION
## Rationale
related issue : https://github.com/LabKey/internal-issues/issues/1261

Don't execute the trigger scripts if the update accumulates any errors during the row by row update.