### PR TITLE
Eliminate X-Frame-Options setting

### DIFF
--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -55,7 +55,6 @@ public class AuthFilter implements Filter
     private static final Object FIRST_REQUEST_LOCK = new Object();
 
     public static final String STRICT_TRANSPORT_SECURITY_HEADER_NAME = "Strict-Transport-Security";
-    public static final String X_FRAME_OPTIONS_HEADER_NAME = "X-Frame-Options";
     public static final String X_CONTENT_TYPE_OPTIONS_HEADER_NAME = "X-Content-Type-Options";
     public static final String REFERRER_POLICY_HEADER_NAME = "Referrer-Policy";
     public static final String SERVER_HEADER_NAME = "Server";
@@ -87,8 +86,6 @@ public class AuthFilter implements Filter
 
         if (ModuleLoader.getInstance().isStartupComplete())
         {
-            if (!"ALLOW".equals(AppProps.getInstance().getXFrameOption()))
-                resp.setHeader(X_FRAME_OPTIONS_HEADER_NAME, AppProps.getInstance().getXFrameOption());
             resp.setHeader(X_CONTENT_TYPE_OPTIONS_HEADER_NAME, "nosniff");
             resp.setHeader(REFERRER_POLICY_HEADER_NAME, "origin-when-cross-origin" );
 

--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -211,11 +211,6 @@ public interface AppProps
 
     // configurable http security settings
 
-    /**
-     * @return "SAMEORIGIN" or "DENY" or "ALLOW"
-     */
-    String getXFrameOption();
-
     String getStaticFilesPrefix();
 
     boolean isWebfilesRootEnabled();

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -554,13 +554,6 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
         return lookupBooleanValue(allowSessionKeys, false);
     }
 
-    @Override
-    public String getXFrameOption()
-    {
-        return lookupStringValue(XFrameOption, "SAMEORIGIN");
-    }
-
-
     private static final String not_init = "";
     private String staticFilesPrefix = not_init;
 

--- a/api/src/org/labkey/api/settings/SiteSettingsProperties.java
+++ b/api/src/org/labkey/api/settings/SiteSettingsProperties.java
@@ -178,14 +178,6 @@ public enum SiteSettingsProperties implements StartupProperty, SafeToRenderEnum
             writeable.setAdminOnlyMessage(value);
         }
     },
-    XFrameOption("Controls whether or not a browser may render a server page in a <frame> , <iframe> or <object>. Valid values: [SAMEORIGIN, ALLOW]")
-    {
-        @Override
-        public void setValue(WriteableAppProps writeable, String value)
-        {
-            writeable.setXFrameOption(value);
-        }
-    },
     navAccessOpen("Always include inaccessible parent folders in project menu when child folder is accessible")
     {
         @Override

--- a/api/src/org/labkey/api/settings/WriteableAppProps.java
+++ b/api/src/org/labkey/api/settings/WriteableAppProps.java
@@ -225,11 +225,6 @@ public class WriteableAppProps extends AppPropsImpl
         storeBooleanValue(allowSessionKeys, b);
     }
 
-    public void setXFrameOption(String option)
-    {
-        storeStringValue(XFrameOption, option);
-    }
-
     public void setExternalRedirectHosts(@NotNull Collection<String> externalRedirectHosts)
     {
         setAllowList(externalRedirectHostURLs, externalRedirectHosts);

--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -833,7 +833,6 @@ public class ExceptionUtil
                         ContentSecurityPolicyFilter.ContentSecurityPolicyType.Enforce.getHeaderName(),
                         ContentSecurityPolicyFilter.ContentSecurityPolicyType.Report.getHeaderName(),
                         AuthFilter.STRICT_TRANSPORT_SECURITY_HEADER_NAME,
-                        AuthFilter.X_FRAME_OPTIONS_HEADER_NAME,
                         AuthFilter.X_CONTENT_TYPE_OPTIONS_HEADER_NAME,
                         AuthFilter.REFERRER_POLICY_HEADER_NAME,
                         AuthFilter.SERVER_HEADER_NAME))
@@ -1106,7 +1105,6 @@ public class ExceptionUtil
             else
             {
                 pageConfig.setTemplate(originalConfig.getTemplate());
-                pageConfig.setFrameOption(originalConfig.getFrameOption());
             }
 
             HttpView<?> errorView = null;

--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -152,7 +152,6 @@ public class PageConfig
     private TrueFalse _showHeader = TrueFalse.Default;
     private List<NavTree> _navTrail;
     private AppBar _appBar;
-    private FrameOption _frameOption = FrameOption.ALLOW;
     private boolean _trackingScript = true;
     private String _canonicalLink = null;
     private boolean _includePostParameters = false;
@@ -503,21 +502,6 @@ public class PageConfig
             }
         }
         return sb.getHtmlString();
-    }
-
-    public enum FrameOption
-    {
-        ALLOW, SAMEORIGIN, DENY
-    }
-    
-    public void setFrameOption(FrameOption option)
-    {
-        _frameOption = option;
-    }
-
-    public FrameOption getFrameOption()
-    {
-        return null==_frameOption?FrameOption.ALLOW:_frameOption;
     }
 
     public void setAllowTrackingScript(TrueFalse opt)

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -96,9 +96,6 @@ public class ContentSecurityPolicyFilter implements Filter
     // ensurePolicyExpression().
     private volatile StringExpression _policyExpression;
 
-    // Initialized on first request and reset when allowed sources change
-    private volatile boolean _shouldSetXFrameOptionsHeader = false;
-
     public enum ContentSecurityPolicyType
     {
         Report("Content-Security-Policy-Report-Only"), Enforce("Content-Security-Policy");
@@ -223,8 +220,6 @@ public class ContentSecurityPolicyFilter implements Filter
                 }
 
                 resp.setHeader(getType().getHeaderName(), csp);
-                if (_shouldSetXFrameOptionsHeader)
-                    resp.setHeader(X_FRAME_OPTIONS_HEADER_NAME,"SAMEORIGIN");
             }
         }
         chain.doFilter(request, response);
@@ -281,8 +276,6 @@ public class ContentSecurityPolicyFilter implements Filter
                 var substitutedPolicy = StringExpressionFactory.create(getStashedTemplate(), false, NullValueBehavior.KeepSubstitution)
                     .eval(SUBSTITUTION_MAP);
                 expression = _policyExpression = StringExpressionFactory.create(substitutedPolicy, false, NullValueBehavior.ReplaceNullAndMissingWithBlank);
-                // If frame-ancestors 'self' (no customization) is present in the CSP then we'll add X-Frame-Options: SAMEORIGIN for old browsers
-                _shouldSetXFrameOptionsHeader = getType() == ContentSecurityPolicyType.Enforce && substitutedPolicy.contains("frame-ancestors 'self'  ;");
             }
         }
 

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -89,12 +89,15 @@ public class ContentSecurityPolicyFilter implements Filter
     // This is effectively @NotNull since it's set to non-null values in init() and never changed
     private String _stashedTemplate = null;
 
-    // We can't set this statically because the class is referenced before URLProviders are available
+    // We can't set this statically because this class is referenced before URLProviders are available
     private final String _reportingEndpointsHeaderValue = "csp-report=\"" + PageFlowUtil.urlProvider(AdminUrls.class).getCspReportToURL().getLocalURIString() + "\"";
 
     // Initialized on first request and reset when allowed sources change. Don't reference this directly; always use
     // ensurePolicyExpression().
     private volatile StringExpression _policyExpression;
+
+    // Initialized on first request and reset when allowed sources change
+    private volatile boolean _shouldSetXFrameOptionsHeader = false;
 
     public enum ContentSecurityPolicyType
     {
@@ -203,6 +206,8 @@ public class ContentSecurityPolicyFilter implements Filter
         }
     }
 
+    private static final String X_FRAME_OPTIONS_HEADER_NAME = "X-Frame-Options";
+
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
     {
@@ -218,6 +223,8 @@ public class ContentSecurityPolicyFilter implements Filter
                 }
 
                 resp.setHeader(getType().getHeaderName(), csp);
+                if (_shouldSetXFrameOptionsHeader)
+                    resp.setHeader(X_FRAME_OPTIONS_HEADER_NAME,"SAMEORIGIN");
             }
         }
         chain.doFilter(request, response);
@@ -274,6 +281,8 @@ public class ContentSecurityPolicyFilter implements Filter
                 var substitutedPolicy = StringExpressionFactory.create(getStashedTemplate(), false, NullValueBehavior.KeepSubstitution)
                     .eval(SUBSTITUTION_MAP);
                 expression = _policyExpression = StringExpressionFactory.create(substitutedPolicy, false, NullValueBehavior.ReplaceNullAndMissingWithBlank);
+                // If frame-ancestors 'self' (no customization) is present in the CSP then we'll add X-Frame-Options: SAMEORIGIN for old browsers
+                _shouldSetXFrameOptionsHeader = getType() == ContentSecurityPolicyType.Enforce && substitutedPolicy.contains("frame-ancestors 'self'  ;");
             }
         }
 

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -542,8 +542,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             "search to find the other select values.", false, true);
         OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(SQLFragment.FEATUREFLAG_DISABLE_STRICT_CHECKS, "Disable SQLFragment strict checks",
             "Disables strict SQL generation safeguards in SQLFragment.appendIdentifier and QueryPivot value emission", false, true, FeatureType.Deprecated));
-        OptionalFeatureService.get().addExperimentalFeatureFlag(LoginController.FEATUREFLAG_DISABLE_LOGIN_XFRAME, "Disable Login X-FRAME-OPTIONS=DENY",
-            "By default LabKey disables all framing of login related actions. Disabling this feature will revert to using the standard site settings.", false, true);
         OptionalFeatureService.get().addExperimentalFeatureFlag(PageTemplate.EXPERIMENTAL_SHORT_CIRCUIT_ROBOTS,
             "Short-circuit robots",
             "Save resources by not rendering pages marked as 'noindex' for robots. This is experimental as not all robots are search engines.",

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1471,13 +1471,6 @@ public class AdminController extends SpringActionController
                 }
             }
 
-            String frameOption = StringUtils.trimToEmpty(form.getXFrameOption());
-            if (!frameOption.equals("DENY") && !frameOption.equals("SAMEORIGIN") && !frameOption.equals("ALLOW"))
-            {
-                errors.reject(ERROR_MSG, "XFrameOption must equal DENY, or SAMEORIGIN, or ALLOW");
-                return false;
-            }
-            props.setXFrameOption(frameOption);
             props.setIncludeServerHttpHeader(form.isIncludeServerHttpHeader());
 
             props.setTermsOfUseFrequencySeconds(form.getTermsOfUseFrequencySeconds());
@@ -2402,7 +2395,6 @@ public class AdminController extends SpringActionController
         private boolean _allowSessionKeys;
         private boolean _navAccessOpen;
 
-        private String _XFrameOption;
         private boolean _includeServerHttpHeader;
         private int _termsOfUseFrequencySeconds;
 
@@ -2614,16 +2606,6 @@ public class AdminController extends SpringActionController
         public void setAllowSessionKeys(boolean allowSessionKeys)
         {
             _allowSessionKeys = allowSessionKeys;
-        }
-
-        public String getXFrameOption()
-        {
-            return _XFrameOption;
-        }
-
-        public void setXFrameOption(String XFrameOption)
-        {
-            _XFrameOption = XFrameOption;
         }
 
         public boolean isIncludeServerHttpHeader()

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -464,15 +464,6 @@ Click the Save button at any time to accept the current settings and continue.</
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
-    <td class="labkey-form-label"><label for="<%=XFrameOption%>">X-Frame-Options</label></td>
-    <td><select name="<%=XFrameOption%>" id="<%=XFrameOption%>">
-        <% String option = appProps.getXFrameOption(); %>
-        <%-- BREAKS GWT <option value="DENY" <%=selectedEq("DENY",option)%>>DENY</option> --%>
-        <option value="SAMEORIGIN" <%=selectedEq("SAMEORIGIN",option)%>>SAMEORIGIN</option>
-        <option value="ALLOW" <%=selectedEq("ALLOW",option)%>>Allow</option></select></td>
-</tr>
-<tr><td colspan=3 class=labkey-title-area-line></td></tr>
-<tr>
     <td class="labkey-form-label"><label for="<%=includeServerHttpHeader%>">Include a <code>Server</code> HTTP header in responses</label></td>
     <td><labkey:checkbox id="<%=includeServerHttpHeader.name()%>" name="<%=includeServerHttpHeader.name()%>" checked="<%=AppProps.getInstance().isIncludeServerHttpHeader()%>" value="true"/></td>
 </tr>

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -321,7 +321,7 @@ Click the Save button at any time to accept the current settings and continue.</
 </tr>
 
 <tr>
-    <td colspan=2>Configure Security (<%=bean.getSiteSettingsHelpLink("security")%>)</td>
+    <td colspan=2>Security settings (<%=bean.getSiteSettingsHelpLink("security")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -332,10 +332,14 @@ Click the Save button at any time to accept the current settings and continue.</
     <td class="labkey-form-label"><label for="<%=sslPort%>">HTTPS port number (specified in <%= h(AppProps.getInstance().getWebappConfigurationFilename()) %>)</label></td>
     <td><input type="text" name="<%=sslPort%>" id="<%=sslPort%>" value="<%=appProps.getSSLPort()%>" size="6"></td>
 </tr>
-
+<tr>
+    <td class="labkey-form-label"><label for="<%=includeServerHttpHeader%>">Include a <code>Server</code> HTTP header in responses</label></td>
+    <td><labkey:checkbox id="<%=includeServerHttpHeader.name()%>" name="<%=includeServerHttpHeader.name()%>" checked="<%=AppProps.getInstance().isIncludeServerHttpHeader()%>" value="true"/></td>
+</tr>
 <tr>
     <td>&nbsp;</td>
 </tr>
+
 <tr>
     <td colspan=2>Configure API Keys (<%=bean.getSiteSettingsHelpLink("apiKey")%>)</td>
 </tr>
@@ -376,10 +380,10 @@ Click the Save button at any time to accept the current settings and continue.</
     <td class="labkey-form-label"><label for="<%=allowSessionKeys%>">Let users create session keys</label></td>
     <td><labkey:checkbox id="<%=allowSessionKeys.name()%>" name="<%=allowSessionKeys.name()%>" checked="<%=appProps.isAllowSessionKeys()%>" value="true"/></td>
 </tr>
-
 <tr>
     <td>&nbsp;</td>
 </tr>
+
 <tr>
     <td colspan=2>Customize terms-of-use frequency (<%=bean.getSiteSettingsHelpLink("terms")%>)</td>
 </tr>
@@ -411,10 +415,10 @@ Click the Save button at any time to accept the current settings and continue.</
     %>
     </td>
 </tr>
-
 <tr>
     <td>&nbsp;</td>
 </tr>
+
 <tr>
     <td colspan=2>Configure pipeline settings (<%=bean.getSiteSettingsHelpLink("pipeline")%>)</td>
 </tr>
@@ -444,7 +448,7 @@ Click the Save button at any time to accept the current settings and continue.</
     <td>&nbsp;</td>
 </tr>
 <tr>
-    <td colspan=2>Put web site in administrative mode (<%=bean.getSiteSettingsHelpLink("adminonly")%>)</td>
+    <td colspan=2>Put website in administrative mode (<%=bean.getSiteSettingsHelpLink("adminonly")%>)</td>
 </tr>
 <tr><td colspan=3 class=labkey-title-area-line></td></tr>
 <tr>
@@ -455,21 +459,10 @@ Click the Save button at any time to accept the current settings and continue.</
     <td class="labkey-form-label" style="vertical-align: top"><label for="<%=adminOnlyMessage%>">Message to users when site is in admin-only mode<br/>(Wiki formatting allowed)</label></td>
     <td><textarea id="<%=adminOnlyMessage%>" name="<%=adminOnlyMessage%>" cols="60" rows="3"><%= h(appProps.getAdminOnlyMessage()) %></textarea></td>
 </tr>
+<tr>
+    <td>&nbsp;</td>
+</tr>
 
-<tr>
-    <td>&nbsp;</td>
-</tr>
-<tr>
-    <td colspan=2>HTTP security settings (<%=bean.getSiteSettingsHelpLink("http")%>)</td>
-</tr>
-<tr><td colspan=3 class=labkey-title-area-line></td></tr>
-<tr>
-    <td class="labkey-form-label"><label for="<%=includeServerHttpHeader%>">Include a <code>Server</code> HTTP header in responses</label></td>
-    <td><labkey:checkbox id="<%=includeServerHttpHeader.name()%>" name="<%=includeServerHttpHeader.name()%>" checked="<%=AppProps.getInstance().isIncludeServerHttpHeader()%>" value="true"/></td>
-</tr>
-<tr>
-    <td>&nbsp;</td>
-</tr>
 <tr>
     <td colspan=2>Customize navigation options (<%=bean.getSiteSettingsHelpLink("nav")%>)</td>
 </tr>

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -148,22 +148,12 @@ import static org.labkey.api.security.AuthenticationManager.SELF_SERVICE_EMAIL_C
 
 public class LoginController extends SpringActionController
 {
-    public static final String FEATUREFLAG_DISABLE_LOGIN_XFRAME = "disable-login-xframe-options";
     private static final Logger _log = LogHelper.getLogger(LoginController.class, "User registration and authentication failures");
     private static final ActionResolver _actionResolver = new DefaultActionResolver(LoginController.class);
 
     public LoginController()
     {
         setActionResolver(_actionResolver);
-    }
-
-    @Override
-    public PageConfig defaultPageConfig()
-    {
-        PageConfig ret = super.defaultPageConfig();
-        if (!AppProps.getInstance().isOptionalFeatureEnabled(FEATUREFLAG_DISABLE_LOGIN_XFRAME))
-            ret.setFrameOption(PageConfig.FrameOption.DENY);
-        return ret;
     }
 
     @Override

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -187,15 +187,6 @@ public class UserController extends SpringActionController
         setActionResolver(_actionResolver);
     }
 
-    @Override
-    public PageConfig defaultPageConfig()
-    {
-        PageConfig ret = super.defaultPageConfig();
-        if (!AppProps.getInstance().isOptionalFeatureEnabled(LoginController.FEATUREFLAG_DISABLE_LOGIN_XFRAME))
-            ret.setFrameOption(PageConfig.FrameOption.DENY);
-        return ret;
-    }
-
     public static class UserUrlsImpl implements UserUrls
     {
         @Override

--- a/core/src/org/labkey/core/view/template/bootstrap/pageTemplate.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/pageTemplate.jsp
@@ -35,9 +35,6 @@
     ActionURL url = getActionURL();
     ViewContext context = getViewContext();
 
-    if (model.getFrameOption() != PageConfig.FrameOption.ALLOW)
-        response.setHeader("X-FRAME-OPTIONS", model.getFrameOption().name());
-
     boolean isExplicitNoIndex = null != url && "1".equals(url.getParameter(ActionURL.Param._noindex.name()));
     if (isExplicitNoIndex)
         model.setRobotsNone();


### PR DESCRIPTION
## Rationale
The `frame-ancestors` directive of our standard CSP is the modern way to control what other sites can "frame" a LabKey deployment (none, by default). The `X-Frame-Options` header is effectively obsolete, ignored by any browser that supports `frame-ancestors`. [All major browsers have supported `frame-ancestors` for 10 years](https://caniuse.com/?search=frame-ancestors+) and hence ignore `X-Frame-Options`.

## Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/3094

## User Education
- Bullet in the Release Notes that we've removed the obsolete `X-Frame-Options` header setting in Site Settings in favor of the `frame-ancestors` directive in the standard CSP. If necessary, this (and all other CSP directives) can be customized on the "Allowed External Resource Hosts" administration page.
- This page should be updated: https://www.labkey.org/Documentation/wiki-page.view?name=configAdmin&referrer=inPage#http. I eliminated the "HTTP Security Settings" section since it's down to one item and merged the remaining `Server` header setting into the "Security settings" section. (Note that the Ext3 mentions should be removed from this page as well, https://github.com/LabKey/internal-issues/issues/1177)