### PR TITLE
GitHub Issue 1282: add getSampleNames to reduce memory usage

### DIFF
--- a/api/src/org/labkey/api/workflow/Job.java
+++ b/api/src/org/labkey/api/workflow/Job.java
@@ -312,6 +312,9 @@ public abstract class Job extends CreatedModified implements Identifiable
     @JsonIgnore
     public abstract @NotNull List<? extends ExpMaterial> getSamples();
 
+    @JsonIgnore
+    public abstract @NotNull List<String> getSampleNames();
+
     public void setEntities(List<WorkEntity> entities)
     {
         _entities = entities;

--- a/api/src/org/labkey/api/workflow/WorkEntity.java
+++ b/api/src/org/labkey/api/workflow/WorkEntity.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
-import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.util.GUID;
@@ -76,15 +76,15 @@ public class WorkEntity
             this.setContainerId(new GUID((String) map.get("Container")));
     }
 
-    public WorkEntity(ExpMaterial sample)
+    public WorkEntity(@NotNull Long rowId, @NotNull WorkEntity.EntityType entityType)
     {
-        _entityType = EntityType.Sample;
-        _entityValue = sample.getRowId();
+        _entityType = entityType;
+        _entityValue = rowId;
     }
 
-    public WorkEntity(ExpMaterial sample, WorkType workType, Long workRowId, @Nullable Long actionId)
+    public WorkEntity(@NotNull Long rowId, @NotNull WorkEntity.EntityType entityType, WorkType workType, Long workRowId, @Nullable Long actionId)
     {
-        this(sample);
+        this(rowId, entityType);
         _workType = workType;
         _workRowId = workRowId;
         _actionId = actionId;


### PR DESCRIPTION
## Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7840
- https://github.com/LabKey/limsModules/pull/2328

## Changes
- Re-type the WorkEntity constructors from ExpMaterial to (rowId, EntityType) so work entities can be built from ids without loading sample objects

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->