### PR TITLE
Share permission lists across core roles

### DIFF
--- a/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 /**
- * A step down from site admins, app admins have broad access but don't get to control native resources on the server.
+ * A step-down from site admins, app admins have broad access but don't get to control native resources on the server.
  */
 public class ApplicationAdminRole extends AbstractRootContainerRole implements AdminRoleListener
 {

--- a/api/src/org/labkey/api/security/roles/AuthorRole.java
+++ b/api/src/org/labkey/api/security/roles/AuthorRole.java
@@ -18,32 +18,27 @@ package org.labkey.api.security.roles;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.reports.permissions.ShareReportPermission;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.permissions.AssayReadPermission;
-import org.labkey.api.security.permissions.DataClassReadPermission;
 import org.labkey.api.security.permissions.InsertPermission;
-import org.labkey.api.security.permissions.MediaReadPermission;
-import org.labkey.api.security.permissions.NotebookReadPermission;
-import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.security.permissions.ReadSomePermission;
+import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.study.Dataset;
 
-/*
- * User: Dave
- * Date: Apr 27, 2009
- */
+import java.util.Collection;
+import java.util.stream.Stream;
+
 public class AuthorRole extends AbstractRole
 {
+    static final Collection<Class<? extends Permission>> PERMISSIONS = Stream.concat(
+        ReaderRole.PERMISSIONS.stream(),
+        Stream.of(
+            InsertPermission.class,
+            ShareReportPermission.class
+        )
+    ).toList();
+
     public AuthorRole()
     {
         super("Author", "Authors may read and add some information. They can also update and delete some information they added.",
-                ReadPermission.class,
-                ReadSomePermission.class,
-                AssayReadPermission.class,
-                DataClassReadPermission.class,
-                MediaReadPermission.class,
-                NotebookReadPermission.class,
-                InsertPermission.class,
-                ShareReportPermission.class
+            PERMISSIONS
         );
     }
 

--- a/api/src/org/labkey/api/security/roles/EditorRole.java
+++ b/api/src/org/labkey/api/security/roles/EditorRole.java
@@ -15,70 +15,25 @@
  */
 package org.labkey.api.security.roles;
 
-import org.labkey.api.lists.permissions.ManagePicklistsPermission;
-import org.labkey.api.pipeline.PipeRoot;
-import org.labkey.api.reports.permissions.EditSharedReportPermission;
-import org.labkey.api.reports.permissions.ShareReportPermission;
-import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.permissions.AssayReadPermission;
-import org.labkey.api.security.permissions.DataClassReadPermission;
 import org.labkey.api.security.permissions.DeletePermission;
-import org.labkey.api.security.permissions.EditSharedViewPermission;
-import org.labkey.api.security.permissions.InsertPermission;
-import org.labkey.api.security.permissions.MediaReadPermission;
-import org.labkey.api.security.permissions.MoveEntitiesPermission;
-import org.labkey.api.security.permissions.NotebookReadPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.security.permissions.ReadSomePermission;
 import org.labkey.api.security.permissions.SampleWorkflowDeletePermission;
-import org.labkey.api.security.permissions.SampleWorkflowJobPermission;
-import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.study.Dataset;
-import org.labkey.api.study.Study;
-import org.labkey.api.study.permissions.SharedParticipantGroupPermission;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Stream;
 
-/*
-* User: Dave
-* Date: Apr 27, 2009
-* Time: 1:22:17 PM
-*/
-public class EditorRole extends AbstractRole
+public class EditorRole extends EditorWithoutDeleteRole
 {
-    protected static Collection<Class<? extends Permission>> BASE_EDITOR_PERMISSIONS = Arrays.asList(
-            ReadPermission.class,
-            ReadSomePermission.class,
-            AssayReadPermission.class,
-            DataClassReadPermission.class,
-            MediaReadPermission.class,
-            NotebookReadPermission.class,
-            InsertPermission.class,
-            MoveEntitiesPermission.class,
-            UpdatePermission.class,
-            EditSharedViewPermission.class,
-            ShareReportPermission.class,
-            EditSharedReportPermission.class,
-            SharedParticipantGroupPermission.class,
-            ManagePicklistsPermission.class,
-            SampleWorkflowJobPermission.class
-    );
+    protected static Collection<Class<? extends Permission>> PERMISSIONS = Stream.concat(
+        EditorWithoutDeleteRole.PERMISSIONS.stream(),
+        Stream.of(
+            DeletePermission.class,
+            SampleWorkflowDeletePermission.class
+        )
+    ).toList();
 
     public EditorRole()
     {
-        this("Editor", "Editors may read, add, update and delete information.", BASE_EDITOR_PERMISSIONS, Arrays.asList(DeletePermission.class, SampleWorkflowDeletePermission.class));
-    }
-
-    public EditorRole(String name, String description, Collection<Class<? extends Permission>>... permCollections)
-    {
-        super(name, description, permCollections);
-    }
-
-    @Override
-    public boolean isApplicable(SecurableResource resource)
-    {
-        return super.isApplicable(resource) || resource instanceof PipeRoot || resource instanceof Study || resource instanceof Dataset;
+        super("Editor", "Editors may read, add, update and delete information.", PERMISSIONS);
     }
 }

--- a/api/src/org/labkey/api/security/roles/EditorWithoutDeleteRole.java
+++ b/api/src/org/labkey/api/security/roles/EditorWithoutDeleteRole.java
@@ -15,10 +15,50 @@
  */
 package org.labkey.api.security.roles;
 
-public class EditorWithoutDeleteRole extends EditorRole
+import org.labkey.api.lists.permissions.ManagePicklistsPermission;
+import org.labkey.api.pipeline.PipeRoot;
+import org.labkey.api.reports.permissions.EditSharedReportPermission;
+import org.labkey.api.security.SecurableResource;
+import org.labkey.api.security.permissions.EditSharedViewPermission;
+import org.labkey.api.security.permissions.MoveEntitiesPermission;
+import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.SampleWorkflowJobPermission;
+import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.study.Dataset;
+import org.labkey.api.study.Study;
+import org.labkey.api.study.permissions.SharedParticipantGroupPermission;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+public class EditorWithoutDeleteRole extends AbstractRole
 {
+    protected static Collection<Class<? extends Permission>> PERMISSIONS = Stream.concat(
+        AuthorRole.PERMISSIONS.stream(),
+        Stream.of(
+            EditSharedReportPermission.class,
+            EditSharedViewPermission.class,
+            ManagePicklistsPermission.class,
+            MoveEntitiesPermission.class,
+            SampleWorkflowJobPermission.class,
+            SharedParticipantGroupPermission.class,
+            UpdatePermission.class
+        )
+    ).toList();
+
     public EditorWithoutDeleteRole()
     {
-        super("Editor without Delete", "Editors in this role may read, add, and update information but not delete.", BASE_EDITOR_PERMISSIONS);
+        super("Editor without Delete", "Editors in this role may read, add, and update information but not delete.", PERMISSIONS);
+    }
+
+    protected EditorWithoutDeleteRole(String name, String description, Iterable<Class<? extends Permission>>... permCollections)
+    {
+        super(name, description, permCollections);
+    }
+
+    @Override
+    public boolean isApplicable(SecurableResource resource)
+    {
+        return super.isApplicable(resource) || resource instanceof PipeRoot || resource instanceof Study || resource instanceof Dataset;
     }
 }

--- a/api/src/org/labkey/api/security/roles/ReaderRole.java
+++ b/api/src/org/labkey/api/security/roles/ReaderRole.java
@@ -23,32 +23,28 @@ import org.labkey.api.security.permissions.MediaReadPermission;
 import org.labkey.api.security.permissions.NotebookReadPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.security.permissions.ReadSomePermission;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
-/*
-* User: Dave
-* Date: Apr 27, 2009
-* Time: 1:22:04 PM
-*/
 public class ReaderRole extends AbstractRole
 {
+    static final Collection<Class<? extends Permission>> PERMISSIONS = Stream.concat(
+        RestrictedReaderRole.PERMISSIONS.stream(),
+        Stream.of(
+            AssayReadPermission.class,
+            DataClassReadPermission.class,
+            MediaReadPermission.class,
+            NotebookReadPermission.class,
+            ReadPermission.class
+        )
+    ).toList();
+
     public ReaderRole()
     {
         super("Reader", "Readers may read information but may not change anything.",
-                ReadPermission.class,
-                ReadSomePermission.class,
-                AssayReadPermission.class,
-                DataClassReadPermission.class,
-                NotebookReadPermission.class,
-                MediaReadPermission.class
+            PERMISSIONS
         );
-    }
-
-    public ReaderRole(String name, String description, Collection<Class<? extends Permission>>... permCollections)
-    {
-        super(name, description, permCollections);
     }
 
     @Override

--- a/api/src/org/labkey/api/security/roles/RestrictedReaderRole.java
+++ b/api/src/org/labkey/api/security/roles/RestrictedReaderRole.java
@@ -16,8 +16,12 @@
 package org.labkey.api.security.roles;
 
 import org.labkey.api.security.SecurableResource;
+import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadSomePermission;
 import org.labkey.api.study.Study;
+
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Used exclusively in dataset security, as a marker in the study policy to indicate a group has per-dataset permissions.
@@ -25,10 +29,14 @@ import org.labkey.api.study.Study;
  */
 public class RestrictedReaderRole extends AbstractRole
 {
+    static final Collection<Class<? extends Permission>> PERMISSIONS = List.of(
+        ReadSomePermission.class
+    );
+
     public RestrictedReaderRole()
     {
         super("Restricted Reader", "Restricted Readers may read some information, but not all.",
-                ReadSomePermission.class);
+            PERMISSIONS);
     }
 
     @Override


### PR DESCRIPTION
## Rationale
Core roles (RestrictedReaderRole -> ReaderRole -> AuthorRole -> EditorWithoutDeleteRole -> EditorRole), share common permissions but their actual permission lists are duplicated in each class. This can easily lead to mistakes. A better approach is for the roles to share permission lists, each role adding just the permissions it needs to add. This is similar to the way we build the permission lists for admin roles.

## Tasks
- [x] Dev
- [x] Claude Code
- Essentially no functional change and existing automated testing should be sufficient to verify correctness