### PR TITLE
Project admins should be able to view user details from the project user page

### DIFF
--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -1587,11 +1587,10 @@ public class UserController extends SpringActionController
             if (schema == null)
                 throw new NotFoundException(CoreQuerySchema.NAME + " schema");
 
-            // use getTable(forWrite=true) because we hack on this TableInfo
-            // TODO don't hack on the TableInfo, shouldn't the schema check canSeeUserDetails() and has AdminPermission?
-            TableInfo table = schema.getTable(CoreQuerySchema.SITE_USERS_TABLE_NAME, null, true, true);
+            String tableName = isUserManager ? CoreQuerySchema.SITE_USERS_TABLE_NAME : CoreQuerySchema.USERS_TABLE_NAME;
+            TableInfo table = schema.getTable(tableName, null, true, true);
             if (table == null)
-                throw new NotFoundException(CoreQuerySchema.SITE_USERS_TABLE_NAME + " table");
+                throw new NotFoundException(tableName + " table");
             else if (table instanceof AbstractTableInfo)
             {
                 // conditionally remove the email and groups columns only for this view


### PR DESCRIPTION
## Rationale
We were always using the site users table for the details action which only permits viewing your own record unless you are a user manager. I thought about just always using the user table for this view but the site user table includes the expired column if the auth configuration supports login expiration limits.