### PR TITLE
Fix tsconfig.test.json path for integration tests

### DIFF
--- a/experiment/test/js/jest.config.integration.js
+++ b/experiment/test/js/jest.config.integration.js
@@ -22,7 +22,7 @@ module.exports = {
         '^.+\\.tsx?$': [
             'ts-jest',
             {
-                tsconfig: 'node_modules/@labkey/build/webpack/tsconfig.test.json',
+                tsconfig: 'node_modules/@labkey/build/configs/tsconfig.test.json',
             }
         ]
     },


### PR DESCRIPTION
## Rationale
The jest.config.integration.js file is pointing to the old webpack tsconfig path.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7873
- https://github.com/LabKey/limsModules/pull/2353

## Changes
- experiment: Fix path to tsconfig.test.json in jest.config.integration.js file

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->