### PR TITLE
Minor clean ups

### DIFF
--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -345,7 +345,7 @@ public abstract class JspBase extends JspContext implements HasViewContext
     }
 
 
-    private static final HtmlString SELECTED = HtmlString.of(" selected");
+    private static final HtmlString SELECTED = h(" selected");
 
     /** Returns " selected" (if true) or "" (false) */
     public HtmlString selected(boolean selected)
@@ -359,14 +359,7 @@ public abstract class JspBase extends JspContext implements HasViewContext
         return selected(Objects.equals(a,b));
     }
 
-    /** Returns " selected" (if a.equals(b)) */
-    public HtmlString selectedEq(Object a, Object b)
-    {
-        return selected(null==a ? null==b : a.equals(b));
-    }
-
-
-    private static final HtmlString DISABLED = HtmlString.of(" disabled");
+    private static final HtmlString DISABLED = h(" disabled");
 
     /** Returns " disabled" (if true) or "" (false) */
     public HtmlString disabled(boolean disabled)
@@ -374,7 +367,7 @@ public abstract class JspBase extends JspContext implements HasViewContext
         return disabled ? DISABLED : EMPTY_STRING;
     }
 
-    private static final HtmlString READ_ONLY = HtmlString.of(" readonly");
+    private static final HtmlString READ_ONLY = h(" readonly");
 
     /** Returns " readonly" (if true) or "" (false) */
     public HtmlString readonly(boolean readOnly)
@@ -383,8 +376,8 @@ public abstract class JspBase extends JspContext implements HasViewContext
     }
 
 
-    private static final HtmlString ALTERNATE_ROW = HtmlString.of("labkey-alternate-row");
-    private static final HtmlString ROW = HtmlString.of("labkey-row");
+    private static final HtmlString ALTERNATE_ROW = h("labkey-alternate-row");
+    private static final HtmlString ROW = h("labkey-row");
 
     // Returns "labkey-alternate-row" (true) or "labkey-row" (false)
     public HtmlString getShadeRowClass(boolean shade)
@@ -580,25 +573,25 @@ public abstract class JspBase extends JspContext implements HasViewContext
     // Format date using the container-configured date format and HTML filter the result
     public HtmlString formatDate(Date date)
     {
-        return HtmlString.of(null == date ? "" : DateUtil.formatDate(getContainer(), date));
+        return h(null == date ? "" : DateUtil.formatDate(getContainer(), date));
     }
 
     // Format LocalDate using the container-configured date format and HTML filter the result
     public HtmlString formatDate(LocalDate date)
     {
-        return HtmlString.of(null == date ? "" : DateUtil.formatDate(getContainer(), date));
+        return h(null == date ? "" : DateUtil.formatDate(getContainer(), date));
     }
 
     // Format date & time using the container-configured date & time format and HTML filter the result
     public HtmlString formatDateTime(Date date)
     {
-        return HtmlString.of(null == date ? "" : DateUtil.formatDateTime(getContainer(), date));
+        return h(null == date ? "" : DateUtil.formatDateTime(getContainer(), date));
     }
 
     // Format date & time using the specified date & time format and HTML filter the result
     public HtmlString formatDateTime(Date date, String pattern)
     {
-        return HtmlString.of(null == date ? "" : DateUtil.formatDateTime(date, pattern));
+        return h(null == date ? "" : DateUtil.formatDateTime(date, pattern));
     }
 
     public String getMessage(ObjectError e)
@@ -616,7 +609,7 @@ public abstract class JspBase extends JspContext implements HasViewContext
 
     public Errors getErrors(String bean)
     {
-        return (Errors)getViewContext().getRequest().getAttribute(BindingResult.MODEL_KEY_PREFIX + bean);
+        return (Errors)getViewContext().getRequestOrThrow().getAttribute(BindingResult.MODEL_KEY_PREFIX + bean);
     }
 
     protected List<ObjectError> _getErrorsForPath(String path)
@@ -696,7 +689,7 @@ public abstract class JspBase extends JspContext implements HasViewContext
                 if (!_returnedErrors.containsKey(e))
                 {
                     missed.add(e);
-                    _returnedErrors.put(e,"missed");
+                    _returnedErrors.put(e, "missed");
                 }
             }
         }
@@ -782,7 +775,7 @@ public abstract class JspBase extends JspContext implements HasViewContext
     @Deprecated // makeId() is preferred
     protected int getRequestScopedUID()
     {
-        return UniqueID.getRequestScopedUID(getViewContext().getRequest());
+        return UniqueID.getRequestScopedUID(getViewContext().getRequestOrThrow());
     }
 
     protected String makeId(String prefix)

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -212,7 +212,7 @@ public class ContentSecurityPolicyFilter implements Filter
 
             if (csp != null)
             {
-                if ("https".equals(req.getScheme()) && resp.getHeader(REPORTING_ENDPOINTS_HEADER) == null)
+                if (resp.getHeader(REPORTING_ENDPOINTS_HEADER) == null)
                 {
                     resp.addHeader(REPORTING_ENDPOINTS_HEADER, _reportingEndpointsHeaderValue);
                 }

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -203,8 +203,6 @@ public class ContentSecurityPolicyFilter implements Filter
         }
     }
 
-    private static final String X_FRAME_OPTIONS_HEADER_NAME = "X-Frame-Options";
-
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
     {
@@ -231,15 +229,7 @@ public class ContentSecurityPolicyFilter implements Filter
 
         if (getType() != ContentSecurityPolicyType.Enforce || !OptionalFeatureService.get().isFeatureEnabled(FEATURE_FLAG_DISABLE_ENFORCE_CSP))
         {
-            Map<String, String> map = Map.of(NONCE_SUBST, getScriptNonceHeader(req));
-            String csp = expression.eval(map);
-
-            if ("https".equals(req.getScheme()))
-            {
-                csp = csp + " report-to csp-report ;";
-            }
-
-            return csp;
+            return expression.eval(Map.of(NONCE_SUBST, getScriptNonceHeader(req)));
         }
 
         return null;

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -212,7 +212,7 @@ public class ContentSecurityPolicyFilter implements Filter
 
             if (csp != null)
             {
-                if (resp.getHeader(REPORTING_ENDPOINTS_HEADER) == null)
+                if ("https".equals(req.getScheme()) && resp.getHeader(REPORTING_ENDPOINTS_HEADER) == null)
                 {
                     resp.addHeader(REPORTING_ENDPOINTS_HEADER, _reportingEndpointsHeaderValue);
                 }
@@ -229,7 +229,15 @@ public class ContentSecurityPolicyFilter implements Filter
 
         if (getType() != ContentSecurityPolicyType.Enforce || !OptionalFeatureService.get().isFeatureEnabled(FEATURE_FLAG_DISABLE_ENFORCE_CSP))
         {
-            return expression.eval(Map.of(NONCE_SUBST, getScriptNonceHeader(req)));
+            Map<String, String> map = Map.of(NONCE_SUBST, getScriptNonceHeader(req));
+            String csp = expression.eval(map);
+
+            if ("https".equals(req.getScheme()))
+            {
+                csp = csp + " report-to csp-report ;";
+            }
+
+            return csp;
         }
 
         return null;

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -12321,8 +12321,8 @@ public class AdminController extends SpringActionController
         @Override
         protected ObjectMapper createRequestObjectMapper()
         {
-            // Annoyingly, Chrome posts an array of JSON objects but Safari posts individual JSON objects. Set a flag
-            // that ensures both cases deserialize into List<JSONObject>.
+            // Annoyingly, Chrome and Firefox post an array of JSON objects but Safari posts individual JSON objects.
+            // Set a flag that ensures both cases deserialize into List<JSONObject>.
             return JsonUtil.DEFAULT_MAPPER.copy().enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
         }
     }

--- a/core/test/src/org/labkey/test/tests/AttachmentsTest.java
+++ b/core/test/src/org/labkey/test/tests/AttachmentsTest.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.test.tests;
 
-import org.apache.commons.collections4.Bag;
-import org.apache.commons.collections4.bag.HashBag;
+import org.apache.commons.collections4.MultiSet;
+import org.apache.commons.collections4.multiset.HashMultiSet;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -116,7 +116,7 @@ public class AttachmentsTest extends BaseWebDriverTest
     {
         SelectRowsResponse auditResponse = new SelectRowsCommand("auditLog", AuditLogHelper.AuditEvent.ATTACHMENT_AUDIT_EVENT.getName()).execute(createDefaultConnection(), getProjectName());
         Assert.assertEquals(10, auditResponse.getRowCount());
-        Bag<String> parentTypes = new HashBag<>();
+        MultiSet<String> parentTypes = new HashMultiSet<>();
         auditResponse.getRowset().forEach(row -> parentTypes.add((String)row.getValue("ParentType")));
         Assert.assertEquals(ISSUE_ATTACHMENTS, parentTypes.getCount("IssueComment"));
         Assert.assertEquals(WIKI_ATTACHMENTS, parentTypes.getCount("Wiki"));

--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -16,8 +16,8 @@
 
 package org.labkey.query.persist;
 
-import org.apache.commons.collections4.Bag;
-import org.apache.commons.collections4.bag.HashBag;
+import org.apache.commons.collections4.MultiSet;
+import org.apache.commons.collections4.multiset.HashMultiSet;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1058,23 +1058,23 @@ public class QueryManager
         if (null != svc)
         {
             svc.registerUsageMetrics(moduleName, () -> {
-                Bag<String> bag = DbScope.getDbScopes().stream()
-                        .filter(scope -> !scope.isLabKeyScope()).map(DbScope::getDatabaseProductName)
-                        .collect(Collectors.toCollection(HashBag::new));
+                MultiSet<String> multiSet = DbScope.getDbScopes().stream()
+                    .filter(scope -> !scope.isLabKeyScope()).map(DbScope::getDatabaseProductName)
+                    .collect(Collectors.toCollection(HashMultiSet::new));
 
-                Map<String, Object> statsMap = bag.uniqueSet().stream()
-                        .collect(Collectors.toMap(Function.identity(), bag::getCount));
+                Map<String, Object> statsMap = multiSet.uniqueSet().stream()
+                    .collect(Collectors.toMap(Function.identity(), multiSet::getCount));
 
                 Map<String, Object> metrics = new HashMap<>();
                 metrics.put("externalDatasources", statsMap);
                 metrics.put(
-                        "customViewCounts",
-                        Map.of(
-                                "DataClasses", getSchemaCustomViewCounts("exp.data"),
-                                "SampleTypes", getSchemaCustomViewCounts("samples"),
-                                "Assays", getSchemaCustomViewCounts("assay"),
-                                "Inventory", getSchemaCustomViewCounts("inventory")
-                        )
+                    "customViewCounts",
+                    Map.of(
+                        "DataClasses", getSchemaCustomViewCounts("exp.data"),
+                        "SampleTypes", getSchemaCustomViewCounts("samples"),
+                        "Assays", getSchemaCustomViewCounts("assay"),
+                        "Inventory", getSchemaCustomViewCounts("inventory")
+                    )
                 );
                 metrics.put("customViewWithLineageColumn", getLineageCustomViewMetrics());
                 metrics.put("queryDefWithCalculatedFieldsCounts", getCalculatedFieldsCountsMetric());

--- a/specimen/src/org/labkey/specimen/SpecimenModule.java
+++ b/specimen/src/org/labkey/specimen/SpecimenModule.java
@@ -16,7 +16,8 @@
 
 package org.labkey.specimen;
 
-import org.apache.commons.collections4.bag.HashBag;
+import org.apache.commons.collections4.MultiSet;
+import org.apache.commons.collections4.multiset.HashMultiSet;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -74,12 +75,12 @@ import org.labkey.specimen.importer.SpecimenSchemaImporter;
 import org.labkey.specimen.importer.SpecimenSettingsImporter;
 import org.labkey.specimen.model.SpecimenRequestEventType;
 import org.labkey.specimen.pipeline.SpecimenPipeline;
-import org.labkey.specimen.requirements.SpecimenRequestRequirementProvider;
 import org.labkey.specimen.query.SpecimenPivotByDerivativeType;
 import org.labkey.specimen.query.SpecimenPivotByPrimaryType;
 import org.labkey.specimen.query.SpecimenPivotByRequestingLocation;
 import org.labkey.specimen.query.SpecimenQueryView;
 import org.labkey.specimen.query.SpecimenUpdateService;
+import org.labkey.specimen.requirements.SpecimenRequestRequirementProvider;
 import org.labkey.specimen.security.roles.SpecimenCoordinatorRole;
 import org.labkey.specimen.security.roles.SpecimenRequesterRole;
 import org.labkey.specimen.settings.RepositorySettings;
@@ -272,7 +273,7 @@ public class SpecimenModule extends SpringModule
             {
                 svc.registerUsageMetrics(NAME, () -> {
                     // Collect and add specimen repository statistics: simple vs. advanced study count, event/vial/specimen count, count of studies with requests enabled, request count by status
-                    HashBag<String> specimenBag = new HashBag<>();
+                    MultiSet<String> specimenBag = new HashMultiSet<>();
                     MutableInt requestsEnabled = new MutableInt(0);
                     MutableInt hasLocations = new MutableInt(0);
 

--- a/specimen/src/org/labkey/specimen/SpecimenModule.java
+++ b/specimen/src/org/labkey/specimen/SpecimenModule.java
@@ -273,7 +273,7 @@ public class SpecimenModule extends SpringModule
             {
                 svc.registerUsageMetrics(NAME, () -> {
                     // Collect and add specimen repository statistics: simple vs. advanced study count, event/vial/specimen count, count of studies with requests enabled, request count by status
-                    MultiSet<String> specimenBag = new HashMultiSet<>();
+                    MultiSet<String> specimenMultiSet = new HashMultiSet<>();
                     MutableInt requestsEnabled = new MutableInt(0);
                     MutableInt hasLocations = new MutableInt(0);
 
@@ -284,19 +284,19 @@ public class SpecimenModule extends SpringModule
 
                             if (settings.isSimple())
                             {
-                                specimenBag.add("simple");
+                                specimenMultiSet.add("simple");
                                 TableInfo simpleSpecimens = schema.getTable(SpecimenTablesProvider.SIMPLE_SPECIMEN_TABLE_NAME);
-                                specimenBag.add("simpleSpecimens", (int) new TableSelector(simpleSpecimens).getRowCount());
+                                specimenMultiSet.add("simpleSpecimens", (int) new TableSelector(simpleSpecimens).getRowCount());
                             }
                             else
                             {
-                                specimenBag.add("advanced");
+                                specimenMultiSet.add("advanced");
                                 TableInfo events = schema.getTable(SpecimenTablesProvider.SPECIMEN_EVENT_TABLE_NAME);
                                 TableInfo vials = schema.getTable(SpecimenTablesProvider.SPECIMEN_DETAIL_TABLE_NAME);
                                 TableInfo specimens = schema.getTable(SpecimenTablesProvider.SPECIMEN_SUMMARY_TABLE_NAME);
-                                specimenBag.add("events", (int) new TableSelector(events).getRowCount());
-                                specimenBag.add("vials", (int) new TableSelector(vials).getRowCount());
-                                specimenBag.add("specimens", (int) new TableSelector(specimens).getRowCount());
+                                specimenMultiSet.add("events", (int) new TableSelector(events).getRowCount());
+                                specimenMultiSet.add("vials", (int) new TableSelector(vials).getRowCount());
+                                specimenMultiSet.add("specimens", (int) new TableSelector(specimens).getRowCount());
                             }
 
                             if (settings.isEnableRequests())
@@ -304,15 +304,15 @@ public class SpecimenModule extends SpringModule
 
                             TableInfo locations = schema.getTable(SpecimenQuerySchema.LOCATION_TABLE_NAME);
                             long locationCount = new TableSelector(locations).getRowCount();
-                            specimenBag.add("locations", (int) locationCount);
-                            specimenBag.add("locationsInUse", (int) new TableSelector(locations, new SimpleFilter(FieldKey.fromParts("In Use"), true), null).getRowCount());
+                            specimenMultiSet.add("locations", (int) locationCount);
+                            specimenMultiSet.add("locationsInUse", (int) new TableSelector(locations, new SimpleFilter(FieldKey.fromParts("In Use"), true), null).getRowCount());
                             if (locationCount > 0)
                                 hasLocations.increment();
 
-                            LOG.debug(specimenBag.toString());
+                            LOG.debug(specimenMultiSet.toString());
                         });
 
-                    Map<String, Object> specimensMap = specimenBag.uniqueSet().stream().collect(Collectors.toMap(s -> s, specimenBag::getCount));
+                    Map<String, Object> specimensMap = specimenMultiSet.uniqueSet().stream().collect(Collectors.toMap(s -> s, specimenMultiSet::getCount));
                     Map<String, Object> requestsMap = new SqlSelector(SpecimenSchema.get().getSchema(), new SQLFragment("SELECT Label, COUNT(*) FROM study.SampleRequest INNER JOIN study.SampleRequestStatus srs ON StatusId = srs.RowId GROUP BY Label")).getValueMap(String.class);
                     requestsMap.put("enabled", requestsEnabled);
                     specimensMap.put("requests", requestsMap);

--- a/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.test.tests.study;
 
-import org.apache.commons.collections4.Bag;
-import org.apache.commons.collections4.bag.HashBag;
+import org.apache.commons.collections4.MultiSet;
+import org.apache.commons.collections4.multiset.HashMultiSet;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Assert;
 import org.junit.experimental.categories.Category;
@@ -346,14 +346,14 @@ public class StudyDataspaceTest extends StudyBaseTest implements PostgresOnlyTes
                               "1/3 - Heterologous boost regimen", "2/4 - Heterologous boost regimen",
                               "2/4 - Heterologous boost regimen", "1/3 - Heterologous boost regimen");
 
-        Bag<List<String>> expectedRows = new HashBag<>(DataRegionTable.collateColumnsIntoRows(VISIT_TAG_MAP_TAGS, VISIT_TAG_MAP_VISITS, VISIT_TAG_MAP_COHORTS));
+        MultiSet<List<String>> expectedRows = new HashMultiSet<>(DataRegionTable.collateColumnsIntoRows(VISIT_TAG_MAP_TAGS, VISIT_TAG_MAP_VISITS, VISIT_TAG_MAP_COHORTS));
 
         // Check visit tags
         clickProject(getProjectName());
         goToModule("Query");
         viewQueryData("study", "VisitTagMap");
         DataRegionTable visitTagMaps = new DataRegionTable("query", this);
-        Bag<List<String>> actualRows = new HashBag<>(visitTagMaps.getRows("VisitTag", "Visit", "Cohort"));
+        MultiSet<List<String>> actualRows = new HashMultiSet<>(visitTagMaps.getRows("VisitTag", "Visit", "Cohort"));
 
         assertEquals("Wrong Rows", expectedRows, actualRows);
 
@@ -364,13 +364,13 @@ public class StudyDataspaceTest extends StudyBaseTest implements PostgresOnlyTes
         final List<String> STUDY5_VISIT_TAG_MAP_TAGS = Arrays.asList("First Vaccination", "Second Vaccination", "Follow Up", "Follow Up");
         final List<String> STUDY5_VISIT_TAG_MAP_VISITS = Arrays.asList("Day -1001", "Day -1316", "Day -1351", "Day -1377");
         final List<String> STUDY5_VISIT_TAG_MAP_COHORTS = Arrays.asList(" ", " ", " ", " ");
-        expectedRows = new HashBag<>(DataRegionTable.collateColumnsIntoRows(STUDY5_VISIT_TAG_MAP_TAGS, STUDY5_VISIT_TAG_MAP_VISITS, STUDY5_VISIT_TAG_MAP_COHORTS));
+        expectedRows = new HashMultiSet<>(DataRegionTable.collateColumnsIntoRows(STUDY5_VISIT_TAG_MAP_TAGS, STUDY5_VISIT_TAG_MAP_VISITS, STUDY5_VISIT_TAG_MAP_COHORTS));
 
         clickFolder(FOLDER_STUDY5);
         goToModule("Query");
         viewQueryData("study", "VisitTagMap");
         visitTagMaps = new DataRegionTable("query", this);
-        actualRows = new HashBag<>(visitTagMaps.getRows("VisitTag", "Visit", "Cohort"));
+        actualRows = new HashMultiSet<>(visitTagMaps.getRows("VisitTag", "Visit", "Cohort"));
 
         assertEquals("Wrong Visit Tag Map Rows in study folder", expectedRows, actualRows);
 

--- a/study/test/src/org/labkey/test/tests/study/StudyVisitTagTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyVisitTagTest.java
@@ -15,8 +15,8 @@
  */
 package org.labkey.test.tests.study;
 
-import org.apache.commons.collections4.Bag;
-import org.apache.commons.collections4.bag.HashBag;
+import org.apache.commons.collections4.MultiSet;
+import org.apache.commons.collections4.multiset.HashMultiSet;
 import org.junit.experimental.categories.Category;
 import org.labkey.api.util.FileUtil;
 import org.labkey.test.BaseWebDriverTest;
@@ -129,24 +129,24 @@ public class StudyVisitTagTest extends StudyBaseTest
     {
         final List<String> VISIT_TAG_NAMES = Arrays.asList("day0", "finalvaccination", "finalvisit", "firstvaccination", "notsingleuse", "peakimmunogenicity");
         final List<String> VISIT_TAG_CAPTIONS = Arrays.asList("Day 0 (meaning varies)", "Final Vaccination", "Final visit", "First Vaccination", "Not Single Use Tag", "Predicted peak immunogenicity visit");
-        Bag<List<String>> expectedRows = new HashBag<>(DataRegionTable.collateColumnsIntoRows(VISIT_TAG_NAMES, VISIT_TAG_CAPTIONS));
+        MultiSet<List<String>> expectedRows = new HashMultiSet<>(DataRegionTable.collateColumnsIntoRows(VISIT_TAG_NAMES, VISIT_TAG_CAPTIONS));
 
         goToProjectHome();
         goToModule("Query");
         viewQueryData("study", "VisitTag");
         DataRegionTable visitTags = new DataRegionTable("query", this);
-        Bag<List<String>> actualRows = new HashBag<>(visitTags.getRows("Name", "Caption"));
+        MultiSet<List<String>> actualRows = new HashMultiSet<>(visitTags.getRows("Name", "Caption"));
         assertEquals("Wrong Visit Tag Data", expectedRows, actualRows);
 
         final List<String> VISIT_TAG_MAP_TAGS = Arrays.asList("Day 0 (meaning varies)", "First Vaccination", "Final Vaccination", "First Vaccination", "Final Vaccination", "Final visit");
         final List<String> VISIT_TAG_MAP_VISITS = Arrays.asList("Visit1", "Visit2", "Visit3", "Visit3", "Visit4", "Visit5");
         final List<String> VISIT_TAG_MAP_COHORTS = Arrays.asList(" ", "Positive", "Negative", "Negative", "Positive", " ");
-        expectedRows = new HashBag<>(DataRegionTable.collateColumnsIntoRows(VISIT_TAG_MAP_TAGS, VISIT_TAG_MAP_VISITS, VISIT_TAG_MAP_COHORTS));
+        expectedRows = new HashMultiSet<>(DataRegionTable.collateColumnsIntoRows(VISIT_TAG_MAP_TAGS, VISIT_TAG_MAP_VISITS, VISIT_TAG_MAP_COHORTS));
 
         goToModule("Query");
         viewQueryData("study", "VisitTagMap");
         DataRegionTable visitTagMaps = new DataRegionTable("query", this);
-        actualRows = new HashBag<>(visitTagMaps.getRows("VisitTag", "Visit", "Cohort"));
+        actualRows = new HashMultiSet<>(visitTagMaps.getRows("VisitTag", "Visit", "Cohort"));
         assertEquals("Wrong Visit Tag Map Data", expectedRows, actualRows);
 
         // verify insert/edit of tags


### PR DESCRIPTION
## Rationale
- Clean up some warnings and unused methods in `JspBase`
- Migrate uses of Commons Collections `Bag` to `MultiSet`. MultiSet is the replacement for Bag that's fully compatible with the Collection contract.

Note: Originally this was meant to update our CSPs to use report-to exclusively (https://github.com/LabKey/internal-issues/issues/900), but we'll revisit that after confirming support for this directive on TeamCity.