### PR TITLE
Logging for script execution, including duration

### DIFF
--- a/api/src/org/labkey/api/assay/transform/DataTransformService.java
+++ b/api/src/org/labkey/api/assay/transform/DataTransformService.java
@@ -157,6 +157,11 @@ public class DataTransformService
 
                         bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, scriptDir.toNioPathForWrite().toString());
                         bindings.put(ExternalScriptEngine.SCRIPT_PATH, scriptFile.toNioPathForRead().toFile().getAbsolutePath());
+                        bindings.put(ExternalScriptEngine.INVOCATION_LABEL, "transform protocol=" + context.getProtocol().getRowId()
+                                + " name='" + context.getProtocol().getName() + "'"
+                                + " operation=" + operation.name()
+                                + " script='" + scriptFile.getName() + "'"
+                                + " container=" + context.getContainer().getPath());
 
                         Map<String, String> paramMap = new HashMap<>();
 

--- a/api/src/org/labkey/api/reports/ExternalScriptEngine.java
+++ b/api/src/org/labkey/api/reports/ExternalScriptEngine.java
@@ -80,6 +80,9 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
     /** Timeout in seconds. */
     public static final String TIMEOUT = "external.script.engine.timeout";
 
+    /** Caller-supplied identity for the invocation log; the engine knows the duration but not which report or assay design it ran for. */
+    public static final String INVOCATION_LABEL = "external.script.engine.invocationLabel";
+
     public static final String DEFAULT_WORKING_DIRECTORY = "ExternalScript";
     private static final Pattern scriptCmdPattern = Pattern.compile("'([^']+)'|\\\"([^\\\"]+)\\\"|(^[^\\s]+)|(\\s[^\\s^'^\\\"]+)");
 
@@ -110,7 +113,14 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
     }
 
     @Override
-    public Object eval(String script, ScriptContext context) throws ScriptException
+    public final Object eval(String script, ScriptContext context) throws ScriptException
+    {
+        // final so every engine in this hierarchy is timed from one place; subclasses override evalScript()
+        return ScriptInvocationLog.time(getClass().getSimpleName(), ScriptInvocationLog.label(context),
+                () -> evalScript(script, context));
+    }
+
+    protected Object evalScript(String script, ScriptContext context) throws ScriptException
     {
         List<String> extensions = getFactory().getExtensions();
 
@@ -139,6 +149,7 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
             int exitCode = runProcess(context, pb, output, timeout, TimeUnit.SECONDS);
             if (exitCode != 0)
             {
+                ScriptInvocationLog.nonZeroExit(getClass().getSimpleName(), ScriptInvocationLog.label(context), exitCode);
                 throw new ScriptException("An error occurred when running the script '" + scriptFile.getName() + "', exit code: " + exitCode + ".\n" + output);
             }
             else
@@ -384,6 +395,7 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
 
                         String msg = "Process killed after exceeding timeout of " + timeout + " " + timeoutUnit.name().toLowerCase() + "\n";
                         output.append(msg);
+                        ScriptInvocationLog.timedOut(getClass().getSimpleName(), ScriptInvocationLog.label(context), timeout, timeoutUnit);
                         if (writer != null)
                             writer.write(msg);
                     }

--- a/api/src/org/labkey/api/reports/ExternalScriptEngine.java
+++ b/api/src/org/labkey/api/reports/ExternalScriptEngine.java
@@ -88,6 +88,9 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
 
     private FileLike _workingDirectory;
 
+    /** Set when runProcess() kills the script, so the kill's exit code isn't logged as a second, separate failure. */
+    private boolean _timedOut;
+
     protected ExternalScriptEngineDefinition _def;
     protected Writer _originalWriter;
 
@@ -116,6 +119,7 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
     public final Object eval(String script, ScriptContext context) throws ScriptException
     {
         // final so every engine in this hierarchy is timed from one place; subclasses override evalScript()
+        _timedOut = false;
         return ScriptInvocationLog.time(getClass().getSimpleName(), ScriptInvocationLog.label(context),
                 () -> evalScript(script, context));
     }
@@ -149,7 +153,8 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
             int exitCode = runProcess(context, pb, output, timeout, TimeUnit.SECONDS);
             if (exitCode != 0)
             {
-                ScriptInvocationLog.nonZeroExit(getClass().getSimpleName(), ScriptInvocationLog.label(context), exitCode);
+                if (!_timedOut)
+                    ScriptInvocationLog.nonZeroExit(getClass().getSimpleName(), ScriptInvocationLog.label(context), exitCode);
                 throw new ScriptException("An error occurred when running the script '" + scriptFile.getName() + "', exit code: " + exitCode + ".\n" + output);
             }
             else
@@ -395,6 +400,7 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
 
                         String msg = "Process killed after exceeding timeout of " + timeout + " " + timeoutUnit.name().toLowerCase() + "\n";
                         output.append(msg);
+                        _timedOut = true;
                         ScriptInvocationLog.timedOut(getClass().getSimpleName(), ScriptInvocationLog.label(context), timeout, timeoutUnit);
                         if (writer != null)
                             writer.write(msg);

--- a/api/src/org/labkey/api/reports/ScriptInvocationLog.java
+++ b/api/src/org/labkey/api/reports/ScriptInvocationLog.java
@@ -22,15 +22,18 @@ import org.labkey.api.util.logging.LogHelper;
 import javax.script.ScriptContext;
 import javax.script.ScriptException;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 /**
  * Start/completion/duration logging for external script invocations. Separate class so it gets its own logger
- * category, enabling timing without the engines' unrelated debug output, and so the non-ExternalScriptEngine
- * paths can share it. Messages are key=value to keep log analysis parser-free.
+ * category, enabling timing without the engines' unrelated debug output. Messages are key=value to keep log
+ * analysis parser-free.
  */
 public final class ScriptInvocationLog
 {
     private static final Logger LOG = LogHelper.getLogger(ScriptInvocationLog.class, "R and Python script invocation start, completion, and duration");
+
+    private static final Pattern LINE_BREAKS = Pattern.compile("[\\r\\n]+");
 
     private ScriptInvocationLog()
     {
@@ -42,32 +45,40 @@ public final class ScriptInvocationLog
     }
 
     /**
-     * The caller's INVOCATION_LABEL binding, or null if the caller didn't set one.
+     * The caller's INVOCATION_LABEL binding, or null if the caller didn't set one. Labels embed user-supplied report
+     * and assay design names, so line breaks are collapsed to keep one invocation on one line.
      */
     @Nullable
     public static String label(ScriptContext context)
     {
         Object label = context == null ? null : context.getAttribute(ExternalScriptEngine.INVOCATION_LABEL, ScriptContext.ENGINE_SCOPE);
-        return label == null ? null : String.valueOf(label);
+        return label == null ? null : LINE_BREAKS.matcher(String.valueOf(label)).replaceAll(" ");
     }
 
     /**
      * Start is DEBUG because it only matters for diagnosing a hang, where a start with no completion is the sole evidence.
+     * The failure line deliberately omits the exception message: for a non-zero exit that message carries the script's
+     * entire stdout/stderr, which can be huge and can echo the transform session's API key.
      */
     public static <T> T time(String engine, @Nullable String label, ScriptBody<T> body) throws ScriptException
     {
         LOG.debug("script start engine={} label={}", engine, label);
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
+        boolean completed = false;
         try
         {
             T result = body.run();
-            LOG.info("script done engine={} label={} durationMs={}", engine, label, start);
+            completed = true;
             return result;
         }
-        catch (ScriptException | RuntimeException e)
+        finally
         {
-            LOG.warn("script failed engine={} label={} durationMs={} error={}", engine, label, start, e.getMessage());
-            throw e;
+            // finally rather than catch so an Error still logs a duration, which a hang never does
+            long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+            if (completed)
+                LOG.info("script done engine={} label={} durationMs={}", engine, label, durationMs);
+            else
+                LOG.warn("script failed engine={} label={} durationMs={}", engine, label, durationMs);
         }
     }
 

--- a/api/src/org/labkey/api/reports/ScriptInvocationLog.java
+++ b/api/src/org/labkey/api/reports/ScriptInvocationLog.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.api.reports;
+
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.util.logging.LogHelper;
+
+import javax.script.ScriptContext;
+import javax.script.ScriptException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Start/completion/duration logging for external script invocations. Separate class so it gets its own logger
+ * category, enabling timing without the engines' unrelated debug output, and so the non-ExternalScriptEngine
+ * paths can share it. Messages are key=value to keep log analysis parser-free.
+ */
+public final class ScriptInvocationLog
+{
+    private static final Logger LOG = LogHelper.getLogger(ScriptInvocationLog.class, "R and Python script invocation start, completion, and duration");
+
+    private ScriptInvocationLog()
+    {
+    }
+
+    public interface ScriptBody<T>
+    {
+        T run() throws ScriptException;
+    }
+
+    /**
+     * The caller's INVOCATION_LABEL binding, or null if the caller didn't set one.
+     */
+    @Nullable
+    public static String label(ScriptContext context)
+    {
+        Object label = context == null ? null : context.getAttribute(ExternalScriptEngine.INVOCATION_LABEL, ScriptContext.ENGINE_SCOPE);
+        return label == null ? null : String.valueOf(label);
+    }
+
+    /**
+     * Start is DEBUG because it only matters for diagnosing a hang, where a start with no completion is the sole evidence.
+     */
+    public static <T> T time(String engine, @Nullable String label, ScriptBody<T> body) throws ScriptException
+    {
+        LOG.debug("script start engine={} label={}", engine, label);
+        long start = System.currentTimeMillis();
+        try
+        {
+            T result = body.run();
+            LOG.info("script done engine={} label={} durationMs={}", engine, label, start);
+            return result;
+        }
+        catch (ScriptException | RuntimeException e)
+        {
+            LOG.warn("script failed engine={} label={} durationMs={} error={}", engine, label, start, e.getMessage());
+            throw e;
+        }
+    }
+
+    public static void timedOut(String engine, @Nullable String label, long timeout, TimeUnit unit)
+    {
+        LOG.warn("script timeout engine={} label={} timeout={} unit={}", engine, label, timeout, unit.name().toLowerCase());
+    }
+
+    public static void nonZeroExit(String engine, @Nullable String label, int exitCode)
+    {
+        LOG.warn("script exit engine={} label={} exitCode={}", engine, label, exitCode);
+    }
+}

--- a/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
@@ -344,6 +344,10 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
         {
             Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
             bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDirFileLike(context.getContainer().getId()).toNioPathForWrite().toString());
+            bindings.put(ExternalScriptEngine.INVOCATION_LABEL, "report id=" + getDescriptor().getReportId()
+                    + " type=" + getType()
+                    + " name='" + getDescriptor().getReportName() + "'"
+                    + " container=" + context.getContainer().getPath());
 
             Map<String, String> paramMap = new HashMap<>();
             DataTransformService.get().addStandardParameters(null, context.getContainer(), null, session.getApiKey(), paramMap);

--- a/api/src/org/labkey/api/reports/report/r/RScriptEngine.java
+++ b/api/src/org/labkey/api/reports/report/r/RScriptEngine.java
@@ -87,7 +87,7 @@ public class RScriptEngine extends ExternalScriptEngine
     }
 
     @Override
-    public Object eval(String script, ScriptContext context) throws ScriptException
+    protected Object evalScript(String script, ScriptContext context) throws ScriptException
     {
         List<String> extensions = getFactory().getExtensions();
 

--- a/api/src/org/labkey/api/reports/report/r/RserveScriptEngine.java
+++ b/api/src/org/labkey/api/reports/report/r/RserveScriptEngine.java
@@ -290,7 +290,7 @@ public class RserveScriptEngine extends RScriptEngine
 
 
     @Override
-    public Object eval(String script, ScriptContext context) throws ScriptException
+    protected Object evalScript(String script, ScriptContext context) throws ScriptException
     {
         List<String> extensions = getFactory().getExtensions();
         RConnection rconn = null;

--- a/pipeline/src/org/labkey/pipeline/api/ScriptTaskImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/ScriptTaskImpl.java
@@ -170,6 +170,9 @@ public class ScriptTaskImpl extends CommandTaskImpl
                 bindings.put(ExternalScriptEngine.SCRIPT_PATH, scriptFile.toNioPathForRead().toFile().toString());
 
             bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, _wd.getDir().toNioPathForRead().toString());
+            bindings.put(ExternalScriptEngine.INVOCATION_LABEL, "pipeline task=" + _factory.getId()
+                    + " job=" + getJob().getJobGUID()
+                    + " container=" + container.getPath());
 
             // Thread the timeout option through to the external script engine
             if (_factory.getTimeout() != null && _factory.getTimeout() > 0)


### PR DESCRIPTION
## Rationale
We want to have a better handle on how long scripts are taking to execute.

## Changes
- `DEBUG` level logging for starting a script
- `INFO` or higher for completion depending on result
- Let script invokers provide context about their usage

## Tasks 📍
- [x] Claude Code Review @labkey-jeckels 
- [x] Manual Testing - not needed
- [x] Test Automation
