### PR TITLE
Stream StudyCachables in QueryHelper

### DIFF
--- a/api/src/org/labkey/api/data/Selector.java
+++ b/api/src/org/labkey/api/data/Selector.java
@@ -77,7 +77,7 @@ public interface Selector
 
     /**
      * Returns a sequential Stream of objects or records representing rows from the database. Converts each result row
-     * into an object the specified {@code Class}. The Stream is backed by a cached data structure (ResultSet and
+     * into an object of the specified {@code Class}. The Stream is backed by a cached data structure (ResultSet and
      * Connection are closed before returning the stream), so no need to close or fully exhaust this stream. Cached
      * streams are more convenient to use than uncached streams and should perform well in low-volume situations.
      */

--- a/study/api-src/org/labkey/api/study/QueryHelper.java
+++ b/study/api-src/org/labkey/api/study/QueryHelper.java
@@ -58,7 +58,10 @@ public class QueryHelper<K, T extends StudyCachable<K, T>, SC extends StudyCache
         {
             try (Stream<T> stream = getTableSelector(key).uncachedStream(_objectClass))
             {
-                return createCollections(stream);
+                return createCollections(Collections.unmodifiableMap(stream
+                    .peek(StudyCachable::lock)
+                    .collect(LabKeyCollectors.toLinkedMap(StudyCachable::getPrimaryKey, v -> v))
+                ));
             }
         });
     }
@@ -86,9 +89,10 @@ public class QueryHelper<K, T extends StudyCachable<K, T>, SC extends StudyCache
         return _cache.get(c, null);
     }
 
-    protected SC createCollections(Stream<T> stream)
+    // map is an unmodifiable, linked map of pk -> locked object
+    protected SC createCollections(Map<K, T> map)
     {
-        return (SC) new StudyCacheCollections<>(stream);
+        return (SC) new StudyCacheCollections<>(map);
     }
 
     public T create(User user, T obj)
@@ -136,12 +140,10 @@ public class QueryHelper<K, T extends StudyCachable<K, T>, SC extends StudyCache
     {
         private final Map<K, V> _map;
 
-        public StudyCacheCollections(Stream<V> stream)
+        // map should be an unmodifiable, linked map of pk -> locked objects
+        public StudyCacheCollections(Map<K, V> map)
         {
-            _map = Collections.unmodifiableMap(stream
-                .peek(StudyCachable::lock)
-                .collect(LabKeyCollectors.toLinkedMap(StudyCachable::getPrimaryKey, v -> v))
-            );
+            _map = map;
         }
 
         public @Nullable V get(K key)

--- a/study/api-src/org/labkey/api/study/QueryHelper.java
+++ b/study/api-src/org/labkey/api/study/QueryHelper.java
@@ -29,12 +29,14 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableInfoGetter;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.security.User;
+import org.labkey.api.study.QueryHelper.StudyCacheCollections;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.stream.Stream;
 
-public class QueryHelper<K, T extends StudyCachable<K, T>, SC extends QueryHelper.StudyCacheCollections<K, T>>
+public class QueryHelper<K, T extends StudyCachable<K, T>, SC extends StudyCacheCollections<K, T>>
 {
     private final BlockingCache<Container, SC> _cache;
     private final Class<T> _objectClass;
@@ -52,12 +54,13 @@ public class QueryHelper<K, T extends StudyCachable<K, T>, SC extends QueryHelpe
         _objectClass = objectClass;
         _defaultSortString = defaultSortString;
         TableInfo tableInfo = _tableInfoGetter.getTableInfo();
-        _cache = DatabaseCache.get(tableInfo.getSchema().getScope(), tableInfo.getCacheSize(), "StudyCache: " + tableInfo.getName(), (key, argument) ->
-            createCollections(
-                getTableSelector(key).stream(_objectClass)
-                    .peek(StudyCachable::lock)
-                    .toList()
-            ));
+        _cache = DatabaseCache.get(tableInfo.getSchema().getScope(), tableInfo.getCacheSize(), "StudyCache: " + tableInfo.getName(), (key, _) ->
+        {
+            try (Stream<T> stream = getTableSelector(key).uncachedStream(_objectClass))
+            {
+                return createCollections(stream);
+            }
+        });
     }
 
     /**
@@ -83,9 +86,9 @@ public class QueryHelper<K, T extends StudyCachable<K, T>, SC extends QueryHelpe
         return _cache.get(c, null);
     }
 
-    protected SC createCollections(Collection<T> collection)
+    protected SC createCollections(Stream<T> stream)
     {
-        return (SC) new QueryHelper.StudyCacheCollections<>(collection);
+        return (SC) new StudyCacheCollections<>(stream);
     }
 
     public T create(User user, T obj)
@@ -133,11 +136,12 @@ public class QueryHelper<K, T extends StudyCachable<K, T>, SC extends QueryHelpe
     {
         private final Map<K, V> _map;
 
-        // Receives a collection of locked T objects
-        public StudyCacheCollections(Collection<V> collection)
+        public StudyCacheCollections(Stream<V> stream)
         {
-            _map = Collections.unmodifiableMap(collection.stream()
-                .collect(LabKeyCollectors.toLinkedMap(StudyCachable::getPrimaryKey, v -> v)));
+            _map = Collections.unmodifiableMap(stream
+                .peek(StudyCachable::lock)
+                .collect(LabKeyCollectors.toLinkedMap(StudyCachable::getPrimaryKey, v -> v))
+            );
         }
 
         public @Nullable V get(K key)

--- a/study/api-src/org/labkey/api/study/QueryHelper.java
+++ b/study/api-src/org/labkey/api/study/QueryHelper.java
@@ -56,13 +56,15 @@ public class QueryHelper<K, T extends StudyCachable<K, T>, SC extends StudyCache
         TableInfo tableInfo = _tableInfoGetter.getTableInfo();
         _cache = DatabaseCache.get(tableInfo.getSchema().getScope(), tableInfo.getCacheSize(), "StudyCache: " + tableInfo.getName(), (key, _) ->
         {
+            final Map<K, T> map;
             try (Stream<T> stream = getTableSelector(key).uncachedStream(_objectClass))
             {
-                return createCollections(Collections.unmodifiableMap(stream
+                map = Collections.unmodifiableMap(stream
                     .peek(StudyCachable::lock)
                     .collect(LabKeyCollectors.toLinkedMap(StudyCachable::getPrimaryKey, v -> v))
-                ));
+                );
             }
+            return createCollections(map);
         });
     }
 
@@ -141,7 +143,7 @@ public class QueryHelper<K, T extends StudyCachable<K, T>, SC extends StudyCache
         private final Map<K, V> _map;
 
         // map should be an unmodifiable, linked map of pk -> locked objects
-        public StudyCacheCollections(Map<K, V> map)
+        protected StudyCacheCollections(Map<K, V> map)
         {
             _map = map;
         }

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -224,6 +224,7 @@ import java.util.TreeMap;
 import java.util.WeakHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.labkey.api.action.SpringActionController.ERROR_MSG;
 import static org.labkey.api.studydesign.query.StudyDesignQuerySchema.PERSONNEL_TABLE_NAME;
@@ -354,9 +355,9 @@ public class StudyManager
         }
 
         @Override
-        protected VisitCollections createCollections(Collection<VisitImpl> collection)
+        protected VisitCollections createCollections(Stream<VisitImpl> stream)
         {
-            return new VisitCollections(collection);
+            return new VisitCollections(stream);
         }
 
         private static class VisitCollections extends StudyCacheCollections<Integer, VisitImpl>
@@ -364,9 +365,11 @@ public class StudyManager
             private final Collection<VisitImpl> _sequenceNumVisits;
             private final Collection<VisitImpl> _chronologicalVisits;
 
-            private VisitCollections(Collection<VisitImpl> collection)
+            private VisitCollections(Stream<VisitImpl> stream)
             {
-                super(collection);
+                super(stream);
+
+                Collection<VisitImpl> collection = getCollection();
 
                 // I'd prefer to push comparators into Visit.Order, but Visit (in API) doesn't know about the display
                 // order field.
@@ -427,9 +430,9 @@ public class StudyManager
         }
 
         @Override
-        protected DatasetCollections createCollections(Collection<DatasetDefinition> collection)
+        protected DatasetCollections createCollections(Stream<DatasetDefinition> stream)
         {
-            return new DatasetCollections(collection);
+            return new DatasetCollections(stream);
         }
 
         protected DatasetCollections getCollections(Study study)
@@ -447,9 +450,11 @@ public class StudyManager
             private final Map<Integer, List<DatasetDefinition>> _cohortMap;
             private final List<DatasetDefinition> _nullCohortDatasets;
 
-            private DatasetCollections(Collection<DatasetDefinition> collection)
+            private DatasetCollections(Stream<DatasetDefinition> stream)
             {
-                super(collection);
+                super(stream);
+
+                Collection<DatasetDefinition> collection = getCollection();
 
                 // study.Dataset has constraints on LOWER(Name) and LOWER(Label), so this code path should never attempt
                 // to put duplicates into these maps. Use asserts to verify this.

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -355,9 +355,9 @@ public class StudyManager
         }
 
         @Override
-        protected VisitCollections createCollections(Stream<VisitImpl> stream)
+        protected VisitCollections createCollections(Map<Integer, VisitImpl> map)
         {
-            return new VisitCollections(stream);
+            return new VisitCollections(map);
         }
 
         private static class VisitCollections extends StudyCacheCollections<Integer, VisitImpl>
@@ -365,9 +365,9 @@ public class StudyManager
             private final Collection<VisitImpl> _sequenceNumVisits;
             private final Collection<VisitImpl> _chronologicalVisits;
 
-            private VisitCollections(Stream<VisitImpl> stream)
+            private VisitCollections(Map<Integer, VisitImpl> map)
             {
-                super(stream);
+                super(map);
 
                 Collection<VisitImpl> collection = getCollection();
 
@@ -430,9 +430,9 @@ public class StudyManager
         }
 
         @Override
-        protected DatasetCollections createCollections(Stream<DatasetDefinition> stream)
+        protected DatasetCollections createCollections(Map<Integer, DatasetDefinition> map)
         {
-            return new DatasetCollections(stream);
+            return new DatasetCollections(map);
         }
 
         protected DatasetCollections getCollections(Study study)
@@ -450,7 +450,7 @@ public class StudyManager
             private final Map<Integer, List<DatasetDefinition>> _cohortMap;
             private final List<DatasetDefinition> _nullCohortDatasets;
 
-            private DatasetCollections(Stream<DatasetDefinition> stream)
+            private DatasetCollections(Map<Integer, DatasetDefinition> stream)
             {
                 super(stream);
 

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -224,7 +224,6 @@ import java.util.TreeMap;
 import java.util.WeakHashMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.labkey.api.action.SpringActionController.ERROR_MSG;
 import static org.labkey.api.studydesign.query.StudyDesignQuerySchema.PERSONNEL_TABLE_NAME;
@@ -450,9 +449,9 @@ public class StudyManager
             private final Map<Integer, List<DatasetDefinition>> _cohortMap;
             private final List<DatasetDefinition> _nullCohortDatasets;
 
-            private DatasetCollections(Map<Integer, DatasetDefinition> stream)
+            private DatasetCollections(Map<Integer, DatasetDefinition> map)
             {
-                super(stream);
+                super(map);
 
                 Collection<DatasetDefinition> collection = getCollection();
 


### PR DESCRIPTION
## Rationale
`QueryHelper()` retrieved objects from the database via a cached stream (backed by a list), copied those objects into another list, and then enumerated the second list to create the map that it actually caches. This meant it (temporarily) held three in-memory copies of the collection at initialization time. Large studies (e.g., many study visits) also produced a warning at retrieval time. This switches to retrieving the objects via an uncached stream, and passing that stream through to the map-creation code path, eliminating the warning and two collection copies. It's still caching a (potentially large) map, but that's an acceptable trade-off for commonly used objects.