### PR TITLE
GitHub Issue 929: MVTCs not used in lookup search

### DIFF
--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -1283,7 +1283,8 @@ public abstract class CompareType
                         targetColumn = column;
 
                     // skip more uninteresting columns
-                    if (!targetColumn.isStringType() ||
+                    boolean isArray = targetColumn.getJdbcType() == JdbcType.ARRAY;
+                    if ((!targetColumn.isStringType() && !isArray) ||
                             targetColumn.getName().equalsIgnoreCase("lsid") ||
                             targetColumn.getSqlTypeName().equalsIgnoreCase("lsidtype") ||
                             targetColumn.getSqlTypeName().equalsIgnoreCase("entityid"))
@@ -1337,14 +1338,29 @@ public abstract class CompareType
                 if (mappedColumn == null)
                     continue;
 
+                SQLFragment columnSql;
+                if (mappedColumn.getJdbcType() == JdbcType.ARRAY)
+                {
+                    if (!dialect.supportsArrays())
+                        continue;
+
+                    SQLFragment aliasSql = new SQLFragment();
+                    aliasSql.appendIdentifier(mappedColumn.getAlias());
+                    columnSql = dialect.array_element_like(aliasSql, param);
+                }
+                else
+                {
+                    columnSql = new SQLFragment();
+                    columnSql.appendIdentifier(mappedColumn.getAlias());
+                    columnSql.append(" ").append(dialect.getCaseInsensitiveLikeOperator()).append(" ");
+                    columnSql.append(dialect.concatenate(" '%'", "?", "'%' ")).add(LikeClause.escapeLikePattern(param));
+                    columnSql.append(LikeClause.sqlEscape());
+                }
+
                 hasResult = true;
                 sql.append(sep);
                 sep = " OR ";
-
-                sql.appendIdentifier(mappedColumn.getAlias());
-                sql.append(" ").append(dialect.getCaseInsensitiveLikeOperator()).append(" ");
-                sql.append(dialect.concatenate(" '%'", "?", "'%' ")).add(LikeClause.escapeLikePattern(param));
-                sql.append(LikeClause.sqlEscape());
+                sql.append(columnSql);
             }
 
             return hasResult ? sql : new SQLFragment("1=1");

--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -1344,9 +1344,16 @@ public abstract class CompareType
                     if (!dialect.supportsArrays())
                         continue;
 
+                    String[] likeValues = Arrays.stream(param.split(","))
+                            .map(String::trim)
+                            .filter(v -> !v.isEmpty())
+                            .toArray(String[]::new);
+                    if (likeValues.length == 0)
+                        continue;
+
                     SQLFragment aliasSql = new SQLFragment();
                     aliasSql.appendIdentifier(mappedColumn.getAlias());
-                    columnSql = dialect.array_element_like(aliasSql, param);
+                    columnSql = dialect.array_element_like(aliasSql, likeValues);
                 }
                 else
                 {

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -2391,6 +2391,13 @@ public abstract class SqlDialect
         throw new UnsupportedOperationException(getClass().getSimpleName() + " does not implement");
     }
 
+    // true if any element of array a matches the given value with a case-insensitive substring (LIKE '%value%')
+    public SQLFragment array_element_like(SQLFragment a, String value)
+    {
+        assert !supportsArrays();
+        throw new UnsupportedOperationException(getClass().getSimpleName() + " does not implement");
+    }
+
 
     //
     // TESTS

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -2391,8 +2391,8 @@ public abstract class SqlDialect
         throw new UnsupportedOperationException(getClass().getSimpleName() + " does not implement");
     }
 
-    // true if any element of array a matches the given value with a case-insensitive substring (LIKE '%value%')
-    public SQLFragment array_element_like(SQLFragment a, String value)
+    // true if the array a contains, for EACH given value, some element matching it with a case-insensitive substring
+    public SQLFragment array_element_like(SQLFragment a, String... values)
     {
         assert !supportsArrays();
         throw new UnsupportedOperationException(getClass().getSimpleName() + " does not implement");

--- a/api/src/org/labkey/api/exp/list/ListDefinition.java
+++ b/api/src/org/labkey/api/exp/list/ListDefinition.java
@@ -19,6 +19,7 @@ package org.labkey.api.exp.list;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.LookupResolutionType;
@@ -191,7 +192,7 @@ public interface ListDefinition extends Comparable<ListDefinition>
                     @Override
                     public boolean accept(ColumnInfo column)
                     {
-                        return AllFields.accept(column) && column.isStringType();
+                        return AllFields.accept(column) && (column.isStringType() || column.getJdbcType() == JdbcType.ARRAY);
                     }
                 },
         AllFields(1)

--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -1229,4 +1229,15 @@ abstract class PostgreSql92Dialect extends BasePostgreSqlDialect
         ret.append(")");
         return ret;
     }
+
+    @Override
+    public SQLFragment array_element_like(SQLFragment a, String value)
+    {
+        SQLFragment sql = new SQLFragment("EXISTS (SELECT 1 FROM unnest(");
+        sql.append(a);
+        sql.append(") AS _elem WHERE _elem");
+        appendCaseInsensitiveLikeClause(sql, value);
+        sql.append(")");
+        return sql;
+    }
 }

--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -1231,12 +1231,20 @@ abstract class PostgreSql92Dialect extends BasePostgreSqlDialect
     }
 
     @Override
-    public SQLFragment array_element_like(SQLFragment a, String value)
+    public SQLFragment array_element_like(SQLFragment a, String... values)
     {
-        SQLFragment sql = new SQLFragment("EXISTS (SELECT 1 FROM unnest(");
-        sql.append(a);
-        sql.append(") AS _elem WHERE _elem");
-        appendCaseInsensitiveLikeClause(sql, value);
+        SQLFragment sql = new SQLFragment("(");
+        String sep = "";
+        for (String value : values)
+        {
+            sql.append(sep);
+            sql.append("EXISTS (SELECT 1 FROM unnest(");
+            sql.append(a);
+            sql.append(") AS _elem WHERE _elem");
+            appendCaseInsensitiveLikeClause(sql, value);
+            sql.append(")");
+            sep = " AND ";
+        }
         sql.append(")");
         return sql;
     }

--- a/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
+++ b/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
@@ -25,6 +25,8 @@ import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.MultiChoice;
 import org.labkey.api.data.MultiValuedLookupColumn;
 import org.labkey.api.data.MultiValuedRenderContext;
 import org.labkey.api.data.Results;
@@ -381,8 +383,8 @@ public abstract class AbstractRunItemImpl<Type extends RunItem> extends ExpIdent
             if (skipColumns.contains(col.getName()))
                 return false;
 
-            // skip non-text and non-int columns or columns that aren't lookups
-            if (!(col.getJdbcType().isText() || col.getJdbcType().isInteger() || col.getFk() != null))
+            // skip non-text and non-int columns or columns that aren't lookups; allow ARRAY (multi-value text choice / MVTC) columns (Issue 929)
+            if (!(col.getJdbcType().isText() || col.getJdbcType().isInteger() || col.getJdbcType() == JdbcType.ARRAY || col.getFk() != null))
                 return false;
 
             // Issue 52467: Skip indexing both the raw columns like LSID and the wrapped versions of those columns that are lookups to other data
@@ -411,28 +413,46 @@ public abstract class AbstractRunItemImpl<Type extends RunItem> extends ExpIdent
                 {
                     FieldKey fieldKey = entry.getKey();
                     ColumnInfo col = entry.getValue();
-                    if (!col.getJdbcType().isText() && !col.getJdbcType().isInteger())
+                    if (!col.getJdbcType().isText() && !col.getJdbcType().isInteger() && col.getJdbcType() != JdbcType.ARRAY)
                         continue;
 
                     if (col.getName().equalsIgnoreCase("lsid") || col.getSqlTypeName().equalsIgnoreCase("lsidtype") || col.getSqlTypeName().equalsIgnoreCase("entityid"))
                         continue;
 
                     Object o = map.get(fieldKey);
-                    String s;
-                    // Issue 52961: DataClass: Integer fields are not index for data class
-                    if (o instanceof String)
-                        s = (String)o;
-                    else if (isIntegral(o))
-                        s = String.valueOf(o);
-                    else
-                        continue;
 
                     List<String> values;
-
-                    if (col instanceof MultiValuedLookupColumn)
-                        values = Arrays.asList(s.split(MultiValuedRenderContext.VALUE_DELIMITER_REGEX));
+                    // Issue 929: index each element of a multi-value text choice (MVTC / ARRAY) column
+                    if (col.getJdbcType() == JdbcType.ARRAY)
+                    {
+                        if (o == null)
+                            continue;
+                        o = col.convert(o);
+                        if (o instanceof MultiChoice.Array mca)
+                        {
+                            if (mca.isEmpty())
+                                continue;
+                            values = new ArrayList<>(mca);
+                        }
+                        else
+                            continue;
+                    }
                     else
-                        values = Arrays.asList(s);
+                    {
+                        String s;
+                        // Issue 52961: DataClass: Integer fields are not index for data class
+                        if (o instanceof String)
+                            s = (String)o;
+                        else if (isIntegral(o))
+                            s = String.valueOf(o);
+                        else
+                            continue;
+
+                        if (col instanceof MultiValuedLookupColumn)
+                            values = Arrays.asList(s.split(MultiValuedRenderContext.VALUE_DELIMITER_REGEX));
+                        else
+                            values = Arrays.asList(s);
+                    }
 
                     SearchService.PROPERTY searchProperty = table.getSearchIndexColumn(fieldKey);
                     if (searchProperty != null)

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -679,6 +679,7 @@ public class ListManager implements SearchService.DocumentProvider
         {
             FieldKeyStringExpression titleTemplate = createEachItemTitleTemplate(list, listTable);
             FieldKeyStringExpression bodyTemplate = createBodyTemplate(list, "\"each item as a separate document\" custom indexing template", list.getEachItemBodySetting(), list.getEachItemBodyTemplate(), listTable);
+            List<ColumnInfo> arrayColumns = getArrayColumns(listTable);
 
             FieldKey keyKey = new FieldKey(null, list.getKeyName());
             FieldKey entityIdKey = new FieldKey(null, "EntityId");
@@ -710,7 +711,7 @@ public class ListManager implements SearchService.DocumentProvider
                 if (map.get(modifiedKey) instanceof Date)
                     modified = (Date) map.get(modifiedKey);
 
-                String body = bodyTemplate.eval(map);
+                String body = bodyTemplate.eval(flattenArrayValues(map, arrayColumns));
 
                 ActionURL itemURL;
 
@@ -888,6 +889,7 @@ public class ListManager implements SearchService.DocumentProvider
                     {
                         body.append(sep);
                         FieldKeyStringExpression template = createBodyTemplate(list, "\"entire list as a single document\" custom indexing template", list.getEntireListBodySetting(), list.getEntireListBodyTemplate(), ti);
+                        List<ColumnInfo> arrayColumns = getArrayColumns(ti);
 
                         // All columns, all rows, no filters, no sorts
                         new TableSelector(ti).setJdbcCaching(false).setForDisplay(true).forEachResults(new ForEachBlock<>()
@@ -895,7 +897,7 @@ public class ListManager implements SearchService.DocumentProvider
                             @Override
                             public void exec(Results results) throws StopIteratingException
                             {
-                                body.append(template.eval(results.getFieldKeyRowMap())).append("\n");
+                                body.append(template.eval(flattenArrayValues(results.getFieldKeyRowMap(), arrayColumns))).append("\n");
                                 // Issue 25366: Short circuit for very large list
                                 if (body.length() > fileSizeLimit)
                                 {
@@ -1055,6 +1057,32 @@ public class ListManager implements SearchService.DocumentProvider
             throw new IllegalStateException(getTemplateErrorMessage(list, "auto-generated indexing template", error));
 
         return template;
+    }
+
+    private static List<ColumnInfo> getArrayColumns(TableInfo table)
+    {
+        return table.getColumns().stream().filter(ci -> ci.getJdbcType() == JdbcType.ARRAY).toList();
+    }
+
+    // GitHub Issue 929: search list by MVTC value.
+    private static Map<FieldKey, Object> flattenArrayValues(Map<FieldKey, Object> rowMap, List<ColumnInfo> arrayColumns)
+    {
+        if (arrayColumns.isEmpty())
+            return rowMap;
+
+        Map<FieldKey, Object> flattened = new HashMap<>(rowMap);
+        for (ColumnInfo arrayColumn : arrayColumns)
+        {
+            FieldKey fieldKey = arrayColumn.getFieldKey();
+            Object value = rowMap.get(fieldKey);
+            if (value == null)
+                continue;
+
+            Object converted = arrayColumn.convert(value);
+            if (converted instanceof MultiChoice.Array mca)
+                flattened.put(fieldKey, mca.toString());
+        }
+        return flattened;
     }
 
 

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -1896,7 +1896,7 @@ public class QueryServiceImpl implements QueryService
                 continue;
             for (FieldKey fieldKey : set)
             {
-                ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager, null);
+                ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager);
                 if (col != null)
                     ret.putIfAbsent(col.getFieldKey(),col);
             }
@@ -1905,29 +1905,11 @@ public class QueryServiceImpl implements QueryService
 
         if (filter != null)
         {
-            if (filter instanceof SimpleFilter simpleFilter)
+            for (FieldKey fieldKey : filter.getWhereParamFieldKeys())
             {
-                Map<FieldKey, List<SimpleFilter.FilterClause>> clausesByField = new HashMap<>();
-                for (SimpleFilter.FilterClause clause : simpleFilter.getClauses())
-                {
-                    for (FieldKey fk : clause.getFieldKeys())
-                        clausesByField.computeIfAbsent(fk, k -> new ArrayList<>()).add(clause);
-                }
-                for (FieldKey fieldKey : simpleFilter.getWhereParamFieldKeys())
-                {
-                    ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager, clausesByField.get(fieldKey));
-                    if (col != null)
-                        ret.putIfAbsent(col.getFieldKey(), col);
-                }
-            }
-            else
-            {
-                for (FieldKey fieldKey : filter.getWhereParamFieldKeys())
-                {
-                    ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager, null);
-                    if (col != null)
-                        ret.putIfAbsent(col.getFieldKey(), col);
-                }
+                ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager);
+                if (col != null)
+                    ret.putIfAbsent(col.getFieldKey(), col);
             }
         }
 
@@ -1935,7 +1917,7 @@ public class QueryServiceImpl implements QueryService
         {
             for (Sort.SortField field : sort.getSortList())
             {
-                ColumnInfo col = resolveFieldKey(field.getFieldKey(), table, columnMap, unresolvedColumns, manager, null);
+                ColumnInfo col = resolveFieldKey(field.getFieldKey(), table, columnMap, unresolvedColumns, manager);
                 if (col != null)
                 {
                     ret.putIfAbsent(col.getFieldKey(),col);
@@ -1982,7 +1964,7 @@ public class QueryServiceImpl implements QueryService
 
             for (FieldKey key : sortFieldKeys)
             {
-                ColumnInfo sortCol = resolveFieldKey(key, col.getParentTable(), columnMap, null, manager, null);
+                ColumnInfo sortCol = resolveFieldKey(key, col.getParentTable(), columnMap, null, manager);
                 if (sortCol != null)
                 {
                     toAdd.add(sortCol);
@@ -2014,7 +1996,7 @@ public class QueryServiceImpl implements QueryService
         }
     }
 
-    private ColumnInfo resolveFieldKey(FieldKey fieldKey, TableInfo table, Map<FieldKey, ColumnInfo> columnMap, Set<FieldKey> unresolvedColumns, AliasManager manager, @Nullable List<SimpleFilter.FilterClause> filterClauses)
+    private ColumnInfo resolveFieldKey(FieldKey fieldKey, TableInfo table, Map<FieldKey, ColumnInfo> columnMap, Set<FieldKey> unresolvedColumns, AliasManager manager)
     {
         if (fieldKey == null) // TODO: Can this resolve "selectionMethods/selectionMethodId$Sname"?
             return null;
@@ -2042,22 +2024,6 @@ public class QueryServiceImpl implements QueryService
         {
             assert Table.checkColumn(table, column, "ensureRequiredColumns():");
             assert fieldKey.getTable() == null || columnMap.containsKey(fieldKey);
-
-            if (filterClauses != null)
-            {
-                boolean isArrayColumn = column.getJdbcType() == JdbcType.ARRAY;
-                for (SimpleFilter.FilterClause clause : filterClauses)
-                {
-                    boolean isArrayFilter = clause instanceof CompareType.ArrayClause;
-                    boolean invalidArrayFilter = (isArrayFilter && !isArrayColumn) || (!isArrayFilter && isArrayColumn);
-                    if (invalidArrayFilter)
-                    {
-                        if (unresolvedColumns != null)
-                            unresolvedColumns.add(fieldKey);
-                        return column; // return column, but mark as unresolvedColumns to drop filters
-                    }
-                }
-            }
 
             // getColumn() might return a column with a different field key than we asked for!
             if (!column.getFieldKey().equals(fieldKey))

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -1896,7 +1896,7 @@ public class QueryServiceImpl implements QueryService
                 continue;
             for (FieldKey fieldKey : set)
             {
-                ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager);
+                ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager, null);
                 if (col != null)
                     ret.putIfAbsent(col.getFieldKey(),col);
             }
@@ -1905,9 +1905,21 @@ public class QueryServiceImpl implements QueryService
 
         if (filter != null)
         {
+            // Map fields to the single-field clauses that reference them, so resolveFieldKey() can detect a clause
+            // whose array-ness no longer matches its column (GitHUb Issue 946).
+            Map<FieldKey, List<SimpleFilter.FilterClause>> clausesByField = new HashMap<>();
+            if (filter instanceof SimpleFilter simpleFilter)
+            {
+                for (SimpleFilter.FilterClause clause : simpleFilter.getClauses())
+                {
+                    if (clause.getFieldKeys().size() == 1) // GitHub Issue 929: Clauses spanning multiple fields (e.g. the "Q" search clause, which references every searchable column) are deliberately excluded here
+                        clausesByField.computeIfAbsent(clause.getFieldKeys().get(0), k -> new ArrayList<>()).add(clause);
+                }
+            }
+
             for (FieldKey fieldKey : filter.getWhereParamFieldKeys())
             {
-                ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager);
+                ColumnInfo col = resolveFieldKey(fieldKey, table, columnMap, unresolvedColumns, manager, clausesByField.get(fieldKey));
                 if (col != null)
                     ret.putIfAbsent(col.getFieldKey(), col);
             }
@@ -1917,7 +1929,7 @@ public class QueryServiceImpl implements QueryService
         {
             for (Sort.SortField field : sort.getSortList())
             {
-                ColumnInfo col = resolveFieldKey(field.getFieldKey(), table, columnMap, unresolvedColumns, manager);
+                ColumnInfo col = resolveFieldKey(field.getFieldKey(), table, columnMap, unresolvedColumns, manager, null);
                 if (col != null)
                 {
                     ret.putIfAbsent(col.getFieldKey(),col);
@@ -1964,7 +1976,7 @@ public class QueryServiceImpl implements QueryService
 
             for (FieldKey key : sortFieldKeys)
             {
-                ColumnInfo sortCol = resolveFieldKey(key, col.getParentTable(), columnMap, null, manager);
+                ColumnInfo sortCol = resolveFieldKey(key, col.getParentTable(), columnMap, null, manager, null);
                 if (sortCol != null)
                 {
                     toAdd.add(sortCol);
@@ -1996,7 +2008,7 @@ public class QueryServiceImpl implements QueryService
         }
     }
 
-    private ColumnInfo resolveFieldKey(FieldKey fieldKey, TableInfo table, Map<FieldKey, ColumnInfo> columnMap, Set<FieldKey> unresolvedColumns, AliasManager manager)
+    private ColumnInfo resolveFieldKey(FieldKey fieldKey, TableInfo table, Map<FieldKey, ColumnInfo> columnMap, Set<FieldKey> unresolvedColumns, AliasManager manager, @Nullable List<SimpleFilter.FilterClause> filterClauses)
     {
         if (fieldKey == null) // TODO: Can this resolve "selectionMethods/selectionMethodId$Sname"?
             return null;
@@ -2024,6 +2036,22 @@ public class QueryServiceImpl implements QueryService
         {
             assert Table.checkColumn(table, column, "ensureRequiredColumns():");
             assert fieldKey.getTable() == null || columnMap.containsKey(fieldKey);
+
+            if (filterClauses != null)
+            {
+                boolean isArrayColumn = column.getJdbcType() == JdbcType.ARRAY;
+                for (SimpleFilter.FilterClause clause : filterClauses)
+                {
+                    boolean isArrayFilter = clause instanceof CompareType.ArrayClause;
+                    boolean invalidArrayFilter = (isArrayFilter && !isArrayColumn) || (!isArrayFilter && isArrayColumn);
+                    if (invalidArrayFilter)
+                    {
+                        if (unresolvedColumns != null)
+                            unresolvedColumns.add(fieldKey);
+                        return column; // return column, but mark as unresolvedColumns to drop filters
+                    }
+                }
+            }
 
             // getColumn() might return a column with a different field key than we asked for!
             if (!column.getFieldKey().equals(fieldKey))


### PR DESCRIPTION
## Rationale
The gridbar search Q filter currently doesn't support MVTC fields. Even worse, when a MVTC field is present on a grid, the gridbar search is not usable for any fields. This PR adds support for Q filtering on MVTC fields, by applying ILIKE op on each part (delimited by comma) of the provided search string against each element in array.

This PR also wires up document indexing for samples, dataclass data and lists. dataset and assay results currently aren't wired up to index custom fields.

## Related Pull Requests
- https://github.com/LabKey/limsModules/pull/2372

## Changes
- Support q filter for MVTC array fields
- Added `SqlDialect.array_element_like` to allow ILIKE filter on array
- Wire up indexer for MVTC fields when applicable (samples, dataclass data, list)

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->