### PR TITLE
Fix Impersonate Roles dialog rendering with a hugely oversized column

### DIFF
--- a/core/webapp/Impersonate.js
+++ b/core/webapp/Impersonate.js
@@ -313,6 +313,13 @@ Ext4.define('LABKEY.Security.ImpersonateRoles', {
 
         this.items = [this.getPanel()];
 
+        // The role grid's flex column can be laid out before this window has a final, on-screen width, leaving its
+        // width stuck at Ext's internal box-layout measurement value (a very large placeholder). Forcing a relayout
+        // once the window has actually been shown recalculates the column against the real, rendered width.
+        this.on('show', function() {
+            this.roleGrid.updateLayout();
+        }, this);
+
         this.callParent();
     },
 


### PR DESCRIPTION
## Rationale

The "Impersonate Roles" dialog intermittently rendered with its role grid massively oversized (column width in the tens of thousands of pixels), spilling the dialog content far outside its window frame. This was traced to a race in ExtJS 4's box layout: the grid's single `flex: 1` column can be laid out before the containing `Ext.window.Window` has a final, resolved width, leaving the column stuck at ExtJS's internal 20000px measurement placeholder (`Ext.layout.container.Box.beginLayoutCycle`) instead of being corrected to the real width. This is more likely to reproduce under CI timing than in normal local use.

<img width="549" height="635" alt="image" src="https://github.com/user-attachments/assets/2b35c866-29da-4b3a-ba09-896f91d2abc3" />


## Related Pull Requests

None

## Changes

- `core/webapp/Impersonate.js`: added a `show` listener on the `ImpersonateRoles` window that forces the role grid to relayout once the window is fully shown, so the flex column recalculates against the window's actual final width.
