### PR TITLE
Add test workaround for grid header encoding

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyProtocolDesignerTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyProtocolDesignerTest.java
@@ -122,7 +122,6 @@ public class StudyProtocolDesignerTest extends BaseWebDriverTest implements Post
         clickProject(getProjectName());
     }
 
-    //Sometimes fails intermittently GitHub Issue 1335.
     @Test
     public void testStudyProtocolDesigner()
     {
@@ -344,6 +343,8 @@ public class StudyProtocolDesignerTest extends BaseWebDriverTest implements Post
         List<String> actualHeaders = singleManagementTable.columnHeaders();
         for(String expectedHeader : EXPECTED_HEADERS)
         {
+            // Workaround GitHub Issue 1335
+            expectedHeader = expectedHeader.replace("\\", "");
             Assert.assertTrue("Did not find header '" + expectedHeader + "'", actualHeaders.contains(expectedHeader));
         }
 


### PR DESCRIPTION
## Rationale
This is failing often enough to warrant a test workaround.

https://github.com/LabKey/internal-issues/issues/1335

## Related Pull Requests
- #7871 

## Changes
- Add test workaround for grid header encoding