### PR TITLE
Admin button that hides the search icon in the SDMS header

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -82,7 +82,6 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
-import org.labkey.api.util.IntegerUtils;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.HttpView;
@@ -1383,17 +1382,5 @@ public interface ExperimentService extends ExperimentRunTypeSource
             _strictValidateExistingSampleType = strictValidateExistingSampleType;
             return this;
         }
-    }
-
-    @Deprecated // Use IntegerUtils.asLong() instead
-    static Long asLong(Object o)
-    {
-        return IntegerUtils.asLong(o);
-    }
-
-    @Deprecated // Use IntegerUtils.asInteger() instead
-    static Integer asInteger(Object o)
-    {
-        return IntegerUtils.asInteger(o);
     }
 }

--- a/api/src/org/labkey/api/query/UserIdRenderer.java
+++ b/api/src/org/labkey/api/query/UserIdRenderer.java
@@ -78,13 +78,13 @@ public class UserIdRenderer extends DataColumn
             return null;
         boolean isDeletedUser = UserManager.getUser(displayedUserId) == null;
 
-        if (!isDeletedUser && displayedUserId != null)
+        if (!isDeletedUser)
         {
-               ActionURL url = UserManager.getUserDetailsURL(ctx.getContainer(), loggedInUser, displayedUserId);
-               if (url != null)
-               {
-                   return url.toString();
-               }
+           ActionURL url = UserManager.getUserDetailsURL(ctx.getContainer(), loggedInUser, displayedUserId);
+           if (url != null)
+           {
+               return url.toString();
+           }
         }
 
         return null;

--- a/api/src/org/labkey/api/search/NoopSearchService.java
+++ b/api/src/org/labkey/api/search/NoopSearchService.java
@@ -366,6 +366,13 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
+    public boolean isSearchIconVisible()
+    {
+        // No persisted setting to consult, so don't be the reason the header hides the icon
+        return true;
+    }
+
+    @Override
     public @Nullable Throwable getConfigurationError()
     {
         return null;

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -442,6 +442,9 @@ public interface SearchService extends SearchMXBean
     void resetIndex();
     void startCrawler();
     void pauseCrawler();
+
+    /** @return should the search icon be shown in the page header; controlled from the Full-Text Search admin page */
+    boolean isSearchIconVisible();
     void updateIndex(String reason);
     void refreshNow();
 

--- a/core/src/org/labkey/core/view/template/bootstrap/header.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/header.jsp
@@ -19,6 +19,7 @@
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.module.ModuleLoader" %>
 <%@ page import="org.labkey.api.portal.ProjectUrls" %>
+<%@ page import="org.labkey.api.search.SearchService" %>
 <%@ page import="org.labkey.api.search.SearchUrls" %>
 <%@ page import="org.labkey.api.search.SearchUtils" %>
 <%@ page import="org.labkey.api.security.AuthenticationManager" %>
@@ -83,7 +84,7 @@
     LookAndFeelProperties laf = LookAndFeelProperties.getInstance(c);
     ModuleLoader moduleLoader = ModuleLoader.getInstance();
     boolean isStartupComplete = moduleLoader.isStartupComplete();
-    boolean showSearch = isStartupComplete && PageFlowUtil.urlProviderOptional(SearchUrls.class) != null;
+    boolean showSearch = isStartupComplete && PageFlowUtil.urlProviderOptional(SearchUrls.class) != null && SearchService.get().isSearchIconVisible();
 
     HtmlView headerHtml = new HeaderProperties(getContainer()).getView();
     String siteShortName = (laf.getShortName() != null && !laf.getShortName().isEmpty()) ? laf.getShortName() : null;

--- a/core/src/org/labkey/core/view/template/bootstrap/header.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/header.jsp
@@ -84,7 +84,6 @@
     LookAndFeelProperties laf = LookAndFeelProperties.getInstance(c);
     ModuleLoader moduleLoader = ModuleLoader.getInstance();
     boolean isStartupComplete = moduleLoader.isStartupComplete();
-    boolean showSearch = isStartupComplete && PageFlowUtil.urlProviderOptional(SearchUrls.class) != null && SearchService.get().isSearchIconVisible();
 
     HtmlView headerHtml = new HeaderProperties(getContainer()).getView();
     String siteShortName = (laf.getShortName() != null && !laf.getShortName().isEmpty()) ? laf.getShortName() : null;
@@ -140,7 +139,12 @@
 %>
         <ul class="navbar-nav-lk">
 <%
-    if (showSearch && pageConfig.shouldIncludeSearch())
+    boolean showSearch =
+        isStartupComplete &&
+        PageFlowUtil.urlProviderOptional(SearchUrls.class) != null &&
+        SearchService.get().isSearchIconVisible() &&
+        pageConfig.shouldIncludeSearch();
+    if (showSearch)
     {
 %>
             <li class="navbar-search hidden-xs">

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -77,6 +77,7 @@ import org.labkey.search.model.AbstractSearchService;
 import org.labkey.search.model.CrawlerRunningState;
 import org.labkey.search.model.IndexInspector;
 import org.labkey.search.model.LuceneDirectoryType;
+import org.labkey.search.model.SearchIconState;
 import org.labkey.search.model.SearchPropertyManager;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.PropertyValues;
@@ -148,6 +149,8 @@ public class SearchController extends SpringActionController
         private int msg = 0;
         private boolean pause;
         private boolean start;
+        private boolean hideSearchIcon;
+        private boolean showSearchIcon;
         private boolean delete;
         private String indexPath;
 
@@ -197,6 +200,26 @@ public class SearchController extends SpringActionController
         public void setPause(boolean pause)
         {
             this.pause = pause;
+        }
+
+        public boolean isHideSearchIcon()
+        {
+            return hideSearchIcon;
+        }
+
+        public void setHideSearchIcon(boolean hideSearchIcon)
+        {
+            this.hideSearchIcon = hideSearchIcon;
+        }
+
+        public boolean isShowSearchIcon()
+        {
+            return showSearchIcon;
+        }
+
+        public void setShowSearchIcon(boolean showSearchIcon)
+        {
+            this.showSearchIcon = showSearchIcon;
         }
 
         public String getIndexPath()
@@ -334,6 +357,14 @@ public class SearchController extends SpringActionController
             {
                 SearchPropertyManager.setCrawlerRunningState(getUser(), CrawlerRunningState.Pause);
                 ss.pauseCrawler();
+            }
+            else if (form.isShowSearchIcon())
+            {
+                SearchPropertyManager.setSearchIconState(getUser(), SearchIconState.Show);
+            }
+            else if (form.isHideSearchIcon())
+            {
+                SearchPropertyManager.setSearchIconState(getUser(), SearchIconState.Hide);
             }
             else if (form.isDelete())
             {

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -963,6 +963,11 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         }
     }
 
+    @Override
+    public boolean isSearchIconVisible()
+    {
+        return SearchPropertyManager.getSearchIconState();
+    }
 
     @Override
     public void updateIndex(String reason)

--- a/search/src/org/labkey/search/model/SearchIconState.java
+++ b/search/src/org/labkey/search/model/SearchIconState.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.search.model;
+
+public enum SearchIconState
+{
+    Hide
+    {
+        @Override
+        String getAuditMessage()
+        {
+            return "Search Icon Hidden";
+        }
+
+        @Override
+        boolean isVisible()
+        {
+            return false;
+        }
+    },
+    Show
+    {
+        @Override
+        String getAuditMessage()
+        {
+            return "Search Icon Shown";
+        }
+
+        @Override
+        boolean isVisible()
+        {
+            return true;
+        }
+    };
+
+    abstract String getAuditMessage();
+    abstract boolean isVisible();
+}

--- a/search/src/org/labkey/search/model/SearchPropertyManager.java
+++ b/search/src/org/labkey/search/model/SearchPropertyManager.java
@@ -30,11 +30,6 @@ import org.labkey.search.SearchModule;
 import java.io.File;
 import java.util.Map;
 
-/**
- * User: adam
- * Date: Apr 20, 2010
- * Time: 7:01:16 PM
- */
 public class SearchPropertyManager
 {
     private static final String CATEGORY = SearchModule.class.getName();
@@ -42,6 +37,7 @@ public class SearchPropertyManager
     private static final String INDEX_PATH = "primaryIndexPath";  // Note: don't change this legacy name
     private static final String DIRECTORY_TYPE = "directoryType";
     private static final String FILE_SIZE_LIMIT = "fileSizeLimitMB";
+    private static final String SEARCH_ICON_STATE = "searchIconState";
 
 
     public static boolean getCrawlerRunningState()
@@ -57,6 +53,19 @@ public class SearchPropertyManager
     public static void setCrawlerRunningState(User user, CrawlerRunningState state)
     {
         setProperty(CRAWLER_RUNNING_STATE, String.valueOf(state.isRunning()));
+        audit(user, state.getAuditMessage());
+    }
+
+    /** @return true unless an admin has explicitly hidden the search icon */
+    public static boolean getSearchIconState()
+    {
+        String state = getProperty(SEARCH_ICON_STATE);
+        return null == state || "true".equals(state);
+    }
+
+    public static void setSearchIconState(User user, SearchIconState state)
+    {
+        setProperty(SEARCH_ICON_STATE, String.valueOf(state.isVisible()));
         audit(user, state.getAuditMessage());
     }
 

--- a/search/src/org/labkey/search/model/SearchStartupProperties.java
+++ b/search/src/org/labkey/search/model/SearchStartupProperties.java
@@ -63,6 +63,17 @@ public enum SearchStartupProperties implements StartupProperty
                 SearchPropertyManager.setCrawlerRunningState(null, state);
         }
     },
+    searchIconState("Hide or show the search icon in the page header. Valid values: " + Arrays.toString(SearchIconState.values())){
+        @Override
+        public void setProperty(@NotNull SearchService ss, SearchIndexStartupHandler indexStartupHandler, String value)
+        {
+            SearchIconState state = EnumUtils.getEnum(SearchIconState.class, value);
+            if (null == state)
+                LOG.error("Unrecognized value for \"searchIconState\": \"{}\"", value);
+            else
+                SearchPropertyManager.setSearchIconState(null, state);
+        }
+    },
     deleteIndex("Delete index and clear last indexed, after setting other properties"){
         @Override
         public void setProperty(@NotNull SearchService ss, SearchIndexStartupHandler indexStartupHandler, String value)

--- a/search/src/org/labkey/search/view/indexerAdmin.jsp
+++ b/search/src/org/labkey/search/view/indexerAdmin.jsp
@@ -129,6 +129,35 @@ else
     }
     %>
         </table>
+    </labkey:form></p>
+
+    <p><labkey:form method="POST" action="<%=urlFor(AdminAction.class)%>">
+        <table><%
+
+    if (ss.isSearchIconVisible())
+    {
+        %><tr><td>The search icon is shown in the page header.</td></tr><%
+
+        if (hasAdminOpsPerms)
+        {
+        %>
+        <tr><td><input type="hidden" name="hideSearchIcon" value="1"></td></tr>
+        <tr><td><%= button("Hide Search Icon").submit(true) %></td></tr><%
+        }
+    }
+    else
+    {
+        %><tr><td>The search icon is hidden in the page header.</td></tr><%
+
+        if (hasAdminOpsPerms)
+        {
+        %>
+        <tr><td><input type="hidden" name="showSearchIcon" value="1"></td></tr>
+        <tr><td><%= button("Show Search Icon").submit(true) %></td></tr><%
+        }
+    }
+    %>
+        </table>
     </labkey:form></p><%
     if (hasAdminOpsPerms)
     {

--- a/search/test/src/org/labkey/test/tests/search/HideSearchIconTest.java
+++ b/search/test/src/org/labkey/test/tests/search/HideSearchIconTest.java
@@ -1,0 +1,48 @@
+package org.labkey.test.tests.search;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.categories.Search;
+import org.labkey.test.components.html.SiteNavBar;
+import org.labkey.test.util.search.SearchAdminAPIHelper;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Category({Search.class})
+@BaseWebDriverTest.ClassTimeout(minutes = 1)
+public class HideSearchIconTest extends BaseWebDriverTest
+{
+    @Override
+    protected String getProjectName()
+    {
+        return null;
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return List.of("Search");
+    }
+
+    @Test
+    public void testHideSearchIcon()
+    {
+        goToHome();
+        assertTrue(new SiteNavBar(getDriver()).isSearchIconPresent());
+
+        // Hide icon, refresh page, and verify icon is gone
+        SearchAdminAPIHelper.hideSearchIcon(getDriver());
+        goToHome();
+        assertFalse(new SiteNavBar(getDriver()).isSearchIconPresent());
+
+        // Show icon, refresh page, and verify icon is back
+        SearchAdminAPIHelper.showSearchIcon(getDriver());
+        goToHome();
+        assertTrue( new SiteNavBar(getDriver()).isSearchIconPresent());
+    }
+}
+


### PR DESCRIPTION
## Rationale
Client request: https://github.com/LabKey/internal-issues/issues/1338

## Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/3149

## Changes
- Add a "Show/Hide Search Icon" on the full-text search admin page. Toggles whether the search icon appears in the SDMS header.
- Eliminate unused `ExperimentService` `asLong()` and `asInteger()` methods.
- Eliminate pointless check in `UserIdRenderer`