### PR TITLE
Fix GuestUser serialization

### DIFF
--- a/api/src/org/labkey/api/security/GuestUser.java
+++ b/api/src/org/labkey/api/security/GuestUser.java
@@ -59,4 +59,10 @@ class GuestUser extends User
     {
         // Don't clear out GuestUser's groups since they're set in its constructor
     }
+
+    @Override
+    public String getPermissionsRestrictions()
+    {
+        return "You are connected as a Guest user, which limits your permissions. Provide a valid API key to access more content.";
+    }
 }

--- a/api/src/org/labkey/api/security/LimitedUser.java
+++ b/api/src/org/labkey/api/security/LimitedUser.java
@@ -173,12 +173,19 @@ public class LimitedUser extends ClonedUser
                 reconstitutedAdmin.getAssignedRoles(ContainerManager.getRoot()).collect(Collectors.toSet())
             );
 
-            // Serialize/deserialize search user
-            User user = User.getSearchUser();
+            // Test serialize/deserialize of some special users
+            testRoundTripping(User.getSearchUser());
+            testRoundTripping(User.guest);
+            testRoundTripping(User.nobody);
+        }
+
+        private void testRoundTripping(User user) throws JsonProcessingException
+        {
+            ObjectMapper mapper = PipelineJob.createObjectMapper();
             String json = mapper.writeValueAsString(user);
-            User limitedUser = mapper.readValue(json, LimitedUser.class);
-            assertEquals(user, limitedUser);
-            assertEquals(user.getEmail(), limitedUser.getEmail());
+            User reconstitutedUser = mapper.readValue(json, user.getClass());
+            assertEquals(user, reconstitutedUser);
+            assertEquals(user.getEmail(), reconstitutedUser.getEmail());
         }
     }
 }

--- a/api/src/org/labkey/api/security/NobodyUser.java
+++ b/api/src/org/labkey/api/security/NobodyUser.java
@@ -1,0 +1,15 @@
+package org.labkey.api.security;
+
+public class NobodyUser extends LimitedUser
+{
+    public NobodyUser()
+    {
+        super(User.guest);
+    }
+
+    @Override
+    public boolean isGuest()
+    {
+        return true;
+    }
+}

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -90,14 +90,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
     public static final User guest = new GuestUser("guest", "guest");
 
     // 'nobody' is a guest user who cannot be assigned permissions
-    public static final User nobody = new LimitedUser(guest)
-    {
-        @Override
-        public boolean isGuest()
-        {
-            return true;
-        }
-    };
+    public static final User nobody = new NobodyUser();
 
     private static User adminServiceUser;
 

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -87,14 +87,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
 
     private PermissionsContext _permissionsContext = NormalPermissionsContext.get();
 
-    public static final User guest = new GuestUser("guest", "guest")
-    {
-        @Override
-        public String getPermissionsRestrictions()
-        {
-            return "You are connected as a Guest user, which limits your permissions. Provide a valid API key to access more content.";
-        }
-    };
+    public static final User guest = new GuestUser("guest", "guest");
 
     // 'nobody' is a guest user who cannot be assigned permissions
     public static final User nobody = new LimitedUser(guest)


### PR DESCRIPTION
## Rationale
Related PR added the guest permissions message by creating an anonymous class. This is unnecessary and fouls up serialization of guest users, so move the method override to the `GuestUser` class where it belongs.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7894

## Tasks 📍
- [x] Claude Code Review
- [x] Code Review @labkey-gokhano 
- [x] Manual Testing @labkey-gokhano - See the comments for details. Validated both Guest and User.nobody flows.
- ~Test Automation~ Existing test flagged the serialization problem