### PR TITLE
Stop supporting SMTP startup properties

### DIFF
--- a/api/src/org/labkey/api/util/SmtpTransportProvider.java
+++ b/api/src/org/labkey/api/util/SmtpTransportProvider.java
@@ -78,7 +78,10 @@ public class SmtpTransportProvider implements EmailTransportProvider
                     @Override
                     public void handle(Collection<StartupPropertyEntry> entries)
                     {
-                        throw new RuntimeException("Configuring SMTP via startup properties is no longer supported. Use application.properties.");
+                        if (!entries.isEmpty())
+                        {
+                            throw new ConfigurationException("Configuring SMTP via startup properties is no longer supported. Use application.properties.");
+                        }
                     }
                 });
 

--- a/api/src/org/labkey/api/util/SmtpTransportProvider.java
+++ b/api/src/org/labkey/api/util/SmtpTransportProvider.java
@@ -56,7 +56,7 @@ public class SmtpTransportProvider implements EmailTransportProvider
         @Override
         public String getDescription()
         {
-            return "No longer supported. Configure SMTP setting in application.properties.";
+            return "No longer supported. Configure SMTP settings in application.properties.";
         }
     }
 
@@ -85,7 +85,7 @@ public class SmtpTransportProvider implements EmailTransportProvider
 
         try
         {
-            // Load SMTP settings from ServletContext (populated from application.properties))
+            // Load SMTP settings from ServletContext (populated from application.properties)
             ServletContext context = ModuleLoader.getServletContext();
             Enumeration<String> names = Objects.requireNonNull(context).getInitParameterNames();
             while (names.hasMoreElements())

--- a/api/src/org/labkey/api/util/SmtpTransportProvider.java
+++ b/api/src/org/labkey/api/util/SmtpTransportProvider.java
@@ -69,22 +69,22 @@ public class SmtpTransportProvider implements EmailTransportProvider
     @Override
     public void loadConfiguration()
     {
+        // TODO: Startup failure if SMTP startup properties are present, for now. Remove in 26.11.
+        ModuleLoader.getInstance().handleStartupProperties(
+            new LenientStartupPropertyHandler<>("mail_smtp", new SmtpStartupProperty())
+            {
+                @Override
+                public void handle(Collection<StartupPropertyEntry> entries)
+                {
+                    if (!entries.isEmpty())
+                    {
+                        throw new ConfigurationException("Configuring SMTP via startup properties is no longer supported. Use application.properties.");
+                    }
+                }
+            });
+
         try
         {
-            // TODO: Leave in place for now to provide clear error if startup properties are present. Remove in 26.11.
-            ModuleLoader.getInstance().handleStartupProperties(
-                new LenientStartupPropertyHandler<>("mail_smtp", new SmtpStartupProperty())
-                {
-                    @Override
-                    public void handle(Collection<StartupPropertyEntry> entries)
-                    {
-                        if (!entries.isEmpty())
-                        {
-                            throw new ConfigurationException("Configuring SMTP via startup properties is no longer supported. Use application.properties.");
-                        }
-                    }
-                });
-
             // Load SMTP settings from ServletContext (populated from application.properties))
             ServletContext context = ModuleLoader.getServletContext();
             Enumeration<String> names = Objects.requireNonNull(context).getInitParameterNames();

--- a/api/src/org/labkey/api/util/SmtpTransportProvider.java
+++ b/api/src/org/labkey/api/util/SmtpTransportProvider.java
@@ -56,7 +56,7 @@ public class SmtpTransportProvider implements EmailTransportProvider
         @Override
         public String getDescription()
         {
-            return "One property for each JavaMail SMTP setting, documented here: https://javaee.github.io/javamail/docs/api/com/sun/mail/smtp/package-summary.html";
+            return "No longer supported. Configure SMTP setting in application.properties.";
         }
     }
 
@@ -71,29 +71,25 @@ public class SmtpTransportProvider implements EmailTransportProvider
     {
         try
         {
-            // Load from startup properties group "mail_smtp"
+            // TODO: Leave in place for now to provide clear error if startup properties are present. Remove in 25.11.
             ModuleLoader.getInstance().handleStartupProperties(
                 new LenientStartupPropertyHandler<>("mail_smtp", new SmtpStartupProperty())
                 {
                     @Override
                     public void handle(Collection<StartupPropertyEntry> entries)
                     {
-                        entries.forEach(entry ->
-                            _properties.put("mail.smtp." + entry.getName(), entry.getValue()));
+                        throw new RuntimeException("Configuring SMTP via startup properties is no longer supported. Use application.properties.");
                     }
                 });
 
-            // Fallback: check ServletContext for SMTP settings
-            if (_properties.isEmpty())
+            // Load SMTP settings from ServletContext (populated from application.properties))
+            ServletContext context = ModuleLoader.getServletContext();
+            Enumeration<String> names = Objects.requireNonNull(context).getInitParameterNames();
+            while (names.hasMoreElements())
             {
-                ServletContext context = ModuleLoader.getServletContext();
-                Enumeration<String> names = Objects.requireNonNull(context).getInitParameterNames();
-                while (names.hasMoreElements())
-                {
-                    String name = names.nextElement();
-                    if (name.startsWith("mail.smtp."))
-                        _properties.put(name, context.getInitParameter(name));
-                }
+                String name = names.nextElement();
+                if (name.startsWith("mail.smtp."))
+                    _properties.put(name, context.getInitParameter(name));
             }
 
             // Create session if configured

--- a/api/src/org/labkey/api/util/SmtpTransportProvider.java
+++ b/api/src/org/labkey/api/util/SmtpTransportProvider.java
@@ -71,7 +71,7 @@ public class SmtpTransportProvider implements EmailTransportProvider
     {
         try
         {
-            // TODO: Leave in place for now to provide clear error if startup properties are present. Remove in 25.11.
+            // TODO: Leave in place for now to provide clear error if startup properties are present. Remove in 26.11.
             ModuleLoader.getInstance().handleStartupProperties(
                 new LenientStartupPropertyHandler<>("mail_smtp", new SmtpStartupProperty())
                 {


### PR DESCRIPTION
## Rationale
Having two places to configure SMTP properties (`application.properties` and startup properties) leads to confusion and uncertainty over merge/override behavior. Simplify to one place: application.properties.

We believe no one is configuring SMTP via startup properties, but I'm leaving the startup property handler in place for now to provide a clear error message and fail startup. We can remove that on develop.

## Related Pull Requests
- https://github.com/LabKey/server/pull/1465