### PR TITLE
Experiment: fix data class cache population check

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -1189,17 +1189,24 @@ public void testDataClassLsidCache() throws Exception
     // first lookup populates the mapping, second is served from the container's data class cache
     for (int i = 0; i < 2; i++)
     {
-        ExpDataClass fromProject = ExperimentService.get().getDataClass(projectLsid);
+        ExpDataClassImpl fromProject = ExperimentServiceImpl.get().getDataClass(projectLsid);
         assertNotNull("Lookup " + i + " by LSID should resolve the data class", fromProject);
         assertEquals("lsidCacheProject", fromProject.getName());
         assertEquals(projectDataClass.getRowId(), fromProject.getRowId());
         assertEquals(c.getId(), fromProject.getContainer().getId());
 
-        ExpDataClass fromSub = ExperimentService.get().getDataClass(subLsid);
+        ExpDataClassImpl fromSub = ExperimentServiceImpl.get().getDataClass(subLsid);
         assertNotNull("Lookup " + i + " by LSID should resolve the subfolder data class", fromSub);
         assertEquals("lsidCacheSub", fromSub.getName());
         assertEquals(sub.getId(), fromSub.getContainer().getId());
     }
+
+    assertSame("LSID lookup should be served from the data class cache",
+            ExperimentServiceImpl.get().getDataClass(c, "lsidCacheProject").getDataObject(),
+            ExperimentServiceImpl.get().getDataClass(projectLsid).getDataObject());
+    assertSame("Subfolder LSID lookup should be served from the data class cache",
+            ExperimentServiceImpl.get().getDataClass(sub, "lsidCacheSub").getDataObject(),
+            ExperimentServiceImpl.get().getDataClass(subLsid).getDataObject());
 
     projectDataClass.delete(_user);
     assertNull("Deleted data class should not resolve from a stale LSID mapping", ExperimentService.get().getDataClass(projectLsid));
@@ -1223,9 +1230,12 @@ public void testFailedDataClassUpdateDoesNotCorruptCache() throws Exception
     helper.insertRows(c, rows, child.getName());
 
     // warm the mapping so the second lookup comes back from the container's data class cache
-    assertNotNull(ExperimentService.get().getDataClass(child.getLSID()));
-    final ExpDataClass toUpdate = ExperimentService.get().getDataClass(child.getLSID());
+    final ExpDataClassImpl toUpdate = ExperimentServiceImpl.get().getDataClass(child.getLSID());
     assertNotNull(toUpdate);
+
+    assertSame("Update target should wrap the cached DataClass",
+            ExperimentServiceImpl.get().getDataClass(c, "failedUpdateChild").getDataObject(),
+            toUpdate.getDataObject());
 
     Map<String, Object> parentAlias = new HashMap<>();
     parentAlias.put("inputType", ExperimentJSONConverter.DATA_INPUTS_ALIAS_PREFIX + "failedUpdateParent");

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -1230,6 +1230,7 @@ public void testFailedDataClassUpdateDoesNotCorruptCache() throws Exception
     helper.insertRows(c, rows, child.getName());
 
     // warm the mapping so the second lookup comes back from the container's data class cache
+    assertNotNull(ExperimentServiceImpl.get().getDataClass(child.getLSID()));
     final ExpDataClassImpl toUpdate = ExperimentServiceImpl.get().getDataClass(child.getLSID());
     assertNotNull(toUpdate);
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1894,12 +1894,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 dataClass = new ExpDataClassImpl(dc);
         }
 
-        if (null != dataClass)
-        {
-            Container dcContainer = dataClass.getContainer();
-            if (dcContainer != null && dcContainer.getId().equals(containerId))
-                dataClassLsidCache.put(lsid, dataClass.getContainer().getId());
-        }
+        if (null != dataClass && null == containerId)
+            dataClassLsidCache.put(lsid, dataClass.getContainer().getId());
 
         return dataClass;
     }


### PR DESCRIPTION
## Rationale
With #7922 I introduced data class caching by LSID. This was not populating the LSID cache properly thus not really doing any additional caching.

## Related Pull Requests
- #7922

## Changes
- Fix check. Aligns with similar logic in sample type caching.