### PR TITLE
Add audit reauthentication as its own event and improve diagnostics

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -1960,15 +1960,15 @@ public class AuthenticationManager
     }
 
     /**
-     * Records that a reauthentication happened; 21 CFR Part 11 wants proof of it. SSO reauth never reaches
-     * finalizePrimaryAuthentication(), so it left no server-side record at all, and local and signing reauth recorded
-     * themselves as logins. Mirrors the "logged in" event's phrasing so the two read alike in the audit log.
+     * Records that a reauthentication happened. SSO reauth never reaches finalizePrimaryAuthentication(), so it left
+     * no server-side record at all, and local and signing reauth recorded themselves as logins. Mirrors the "logged
+     * in" event's phrasing so the two read alike in the audit log.
      */
     public static void auditReauthSuccess(@NotNull User reauthUser, @NotNull AuthenticationResponse response)
     {
-        // Deliberately not addAuditEvent(), which throttles repeats of an identical message from the same user and
-        // address. Signing several records in a row produces exactly that, and dropping the second signature's
-        // reauthentication is the opposite of what an audit trail is for.
+        // Calls UserManager.addAuditEvent() directly rather than this class's addAuditEvent(), which drops a message
+        // identical to the previous one from the same user and address. Signing several records in a row produces
+        // exactly those identical messages, and dropping them would leave real reauthentications unrecorded.
         UserManager.addAuditEvent(reauthUser, ContainerManager.getRoot(), reauthUser,
             reauthUser.getEmail() + " " + UserManager.UserAuditEvent.REAUTHENTICATED + " successfully via " + response.getSuccessDetails() + ".");
     }

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -632,6 +632,10 @@ public class AuthenticationManager
 
             AuthenticationManager.setReauthUser(reauthUser, getUser(), getViewContext().getRequestOrThrow(), errorMessage, url);
 
+            // A token on the URL means setReauthUser() accepted the reauthentication.
+            if (null != reauthUser && null != url.getParameter(REAUTH_TOKEN_NAME))
+                AuthenticationManager.auditReauthSuccess(reauthUser, response);
+
             throw new RedirectException(url);
         }
 
@@ -1092,13 +1096,23 @@ public class AuthenticationManager
 
     public static @NotNull PrimaryAuthenticationResult authenticate(HttpServletRequest request, String id, String password, URLHelper returnUrl, boolean logFailures) throws InvalidEmailException
     {
+        return authenticate(request, id, password, returnUrl, logFailures, false);
+    }
+
+
+    /**
+     * @param reauth True when reauthenticating an already signed-in user rather than logging one in. See
+     *               {@link #finalizePrimaryAuthentication(HttpServletRequest, AuthenticationResponse, boolean)}.
+     */
+    public static @NotNull PrimaryAuthenticationResult authenticate(HttpServletRequest request, String id, String password, URLHelper returnUrl, boolean logFailures, boolean reauth) throws InvalidEmailException
+    {
         PrimaryAuthenticationResult result = null;
         try
         {
             result = _beforeAuthenticate(request, id, password);
             if (null != result)
                 return result;
-            result = _authenticate(request, id, password, returnUrl, logFailures);
+            result = _authenticate(request, id, password, returnUrl, logFailures, reauth);
             return result;
         }
         finally
@@ -1108,7 +1122,7 @@ public class AuthenticationManager
     }
 
 
-    private static @NotNull PrimaryAuthenticationResult _authenticate(HttpServletRequest request, final String id, String password, URLHelper returnUrl, boolean logFailures) throws InvalidEmailException
+    private static @NotNull PrimaryAuthenticationResult _authenticate(HttpServletRequest request, final String id, String password, URLHelper returnUrl, boolean logFailures, boolean reauth) throws InvalidEmailException
     {
         if (areNotBlank(id, password))
         {
@@ -1132,7 +1146,7 @@ public class AuthenticationManager
 
                 if (authResponse.isAuthenticated())
                 {
-                    return finalizePrimaryAuthentication(request, authResponse);
+                    return finalizePrimaryAuthentication(request, authResponse, reauth);
                 }
                 else
                 {
@@ -1230,6 +1244,18 @@ public class AuthenticationManager
     @NotNull
     public static PrimaryAuthenticationResult finalizePrimaryAuthentication(HttpServletRequest request, AuthenticationResponse response)
     {
+        return finalizePrimaryAuthentication(request, response, false);
+    }
+
+    /**
+     * @param reauth True when reauthenticating an already signed-in user rather than logging one in. Suppresses the
+     *               "logged in" audit event: no session is created and the user was already signed in, so recording a
+     *               login misstates what happened. Callers passing true are responsible for recording the
+     *               reauthentication via {@link #auditReauthSuccess(User, AuthenticationResponse)}.
+     */
+    @NotNull
+    public static PrimaryAuthenticationResult finalizePrimaryAuthentication(HttpServletRequest request, AuthenticationResponse response, boolean reauth)
+    {
         User user = response.getUser();
         final String emailAddress;
 
@@ -1288,7 +1314,8 @@ public class AuthenticationManager
             return new PrimaryAuthenticationResult(AuthenticationStatus.InactiveUser);
         }
 
-        addAuditEvent(user, request, emailAddress + " " + UserManager.UserAuditEvent.LOGGED_IN + " successfully via " + response.getSuccessDetails() + ".");
+        if (!reauth)
+            addAuditEvent(user, request, emailAddress + " " + UserManager.UserAuditEvent.LOGGED_IN + " successfully via " + response.getSuccessDetails() + ".");
 
         return new PrimaryAuthenticationResult(user, response);
     }
@@ -1714,6 +1741,11 @@ public class AuthenticationManager
             session.removeAttribute(getReauthFlowSessionKey());
             URLHelper url = getAfterReauthURL(c, getLoginReturnProperties(request), primaryAuthUser);
             setReauthUser(primaryAuthUser, reauthFlow.local() ? SecurityManager.getSessionUser(request) : null, request, null, url);
+
+            // A token on the URL means setReauthUser() accepted the reauthentication.
+            if (null != url.getParameter(REAUTH_TOKEN_NAME))
+                auditReauthSuccess(primaryAuthUser, primaryAuthResult.getResponse());
+
             return new AuthenticationResult(primaryAuthUser, url);
         }
 
@@ -1884,11 +1916,33 @@ public class AuthenticationManager
      * @param errorMessage Pre-existing error message to add to the URL
      * @param redirectUrl  URL to which the token (on success) or error message (on failure) gets added
      */
-    public static void setReauthUser(User reauthUser, @Nullable User sessionUser, HttpServletRequest request, @Nullable String errorMessage, URLHelper redirectUrl)
+    public static void setReauthUser(@Nullable User reauthUser, @Nullable User sessionUser, HttpServletRequest request, @Nullable String errorMessage, URLHelper redirectUrl)
     {
         if (errorMessage == null && sessionUser != null && !sessionUser.equals(reauthUser))
         {
-            errorMessage = "Reauthentication failed: wrong user reauthenticated";
+            // One condition in code, but three different problems in practice -- sign in as the right user, fix the
+            // IdP's claim mapping, or fix the session cookie -- so each gets a message that says which one it is.
+            if (sessionUser.isGuest())
+            {
+                // The SSO validate actions are @RequiresNoPermission, so getUser() returns guest whenever the request
+                // carries no signed-in session -- typically because the session cookie didn't accompany the IdP's
+                // cross-site POST to the validate action, or because the session timed out mid-flow.
+                errorMessage = "Reauthentication failed: this browser is no longer signed in; please sign in again";
+                _log.warn("Reauthentication failed for \"{}\": the request carried no signed-in session. Check that the session cookie accompanies the identity provider's response to the validate action -- a JSESSIONID with no explicit SameSite value is withheld from that cross-site POST once it is more than a couple of minutes old.", null != reauthUser ? reauthUser.getEmail() : "an unrecognized identity");
+            }
+            else if (null == reauthUser)
+                // Narrow, but sign-in and reauthentication resolve users differently: finalizePrimaryAuthentication()
+                // can auto-create an account, and reauthentication never does. Reaching here means the asserted
+                // identity has no account by the time reauth runs -- deleted or renamed mid-session, or the IdP
+                // asserting a different identifier than it did at sign-in.
+                errorMessage = "Reauthentication failed: the reauthenticated identity does not match a LabKey user account";
+            else
+            {
+                errorMessage = "Reauthentication failed: wrong user reauthenticated";
+                // The only place that knows both identities. The audit log records neither, since no reauthentication
+                // completed, so without this the pairing can't be reconstructed afterward.
+                _log.warn("Reauthentication failed for \"{}\": \"{}\" reauthenticated instead.", sessionUser.getEmail(), reauthUser.getEmail());
+            }
         }
 
         if (errorMessage != null)
@@ -1903,6 +1957,20 @@ public class AuthenticationManager
             // (browser redirects with no user interaction). Five minute expiration should be more than ample.
             addToken(request, reauthUser, reauthToken, Instant.now().plus(5, ChronoUnit.MINUTES));
         }
+    }
+
+    /**
+     * Records that a reauthentication happened; 21 CFR Part 11 wants proof of it. SSO reauth never reaches
+     * finalizePrimaryAuthentication(), so it left no server-side record at all, and local and signing reauth recorded
+     * themselves as logins. Mirrors the "logged in" event's phrasing so the two read alike in the audit log.
+     */
+    public static void auditReauthSuccess(@NotNull User reauthUser, @NotNull AuthenticationResponse response)
+    {
+        // Deliberately not addAuditEvent(), which throttles repeats of an identical message from the same user and
+        // address. Signing several records in a row produces exactly that, and dropping the second signature's
+        // reauthentication is the opposite of what an audit trail is for.
+        UserManager.addAuditEvent(reauthUser, ContainerManager.getRoot(), reauthUser,
+            reauthUser.getEmail() + " " + UserManager.UserAuditEvent.REAUTHENTICATED + " successfully via " + response.getSuccessDetails() + ".");
     }
 
     // Separate method to allow unit testing

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -630,7 +630,7 @@ public class AuthenticationManager
 
             @Nullable User reauthUser = response.isAuthenticated() ? UserManager.getUser(response.getValidEmail()) : null;
 
-            AuthenticationManager.setReauthUser(reauthUser, getUser(), getViewContext().getRequestOrThrow(), errorMessage, url);
+            AuthenticationManager.setReauthUser(reauthUser, response.isAuthenticated() ? response.getValidEmail().getEmailAddress() : null, getUser(), getViewContext().getRequestOrThrow(), errorMessage, url);
 
             // A token on the URL means setReauthUser() accepted the reauthentication.
             if (null != reauthUser && null != url.getParameter(REAUTH_TOKEN_NAME))
@@ -1740,7 +1740,7 @@ public class AuthenticationManager
         {
             session.removeAttribute(getReauthFlowSessionKey());
             URLHelper url = getAfterReauthURL(c, getLoginReturnProperties(request), primaryAuthUser);
-            setReauthUser(primaryAuthUser, reauthFlow.local() ? SecurityManager.getSessionUser(request) : null, request, null, url);
+            setReauthUser(primaryAuthUser, null != primaryAuthUser ? primaryAuthUser.getEmail() : null, reauthFlow.local() ? SecurityManager.getSessionUser(request) : null, request, null, url);
 
             // A token on the URL means setReauthUser() accepted the reauthentication.
             if (null != url.getParameter(REAUTH_TOKEN_NAME))
@@ -1910,13 +1910,16 @@ public class AuthenticationManager
     public static final String REAUTH_TOKEN_MAP_NAME = "reauthTokenSet";    // Session attribute name for token map
 
     /**
-     * @param reauthUser   Re-auth user to stash in session with the re-auth token
-     * @param sessionUser  If not null, validate that this user and reauthUser are the same
-     * @param request      Request from which to retrieve the session
-     * @param errorMessage Pre-existing error message to add to the URL
-     * @param redirectUrl  URL to which the token (on success) or error message (on failure) gets added
+     * @param reauthUser    Re-auth user to stash in session with the re-auth token
+     * @param assertedEmail Identity asserted by the authentication provider, which is not always resolvable to a user.
+     *                      Only used for diagnostics: when reauthUser is null this is the sole record of what was
+     *                      asserted, since the caller has already discarded the response by the time reauth fails.
+     * @param sessionUser   If not null, validate that this user and reauthUser are the same
+     * @param request       Request from which to retrieve the session
+     * @param errorMessage  Pre-existing error message to add to the URL
+     * @param redirectUrl   URL to which the token (on success) or error message (on failure) gets added
      */
-    public static void setReauthUser(@Nullable User reauthUser, @Nullable User sessionUser, HttpServletRequest request, @Nullable String errorMessage, URLHelper redirectUrl)
+    public static void setReauthUser(@Nullable User reauthUser, @Nullable String assertedEmail, @Nullable User sessionUser, HttpServletRequest request, @Nullable String errorMessage, URLHelper redirectUrl)
     {
         if (errorMessage == null && sessionUser != null && !sessionUser.equals(reauthUser))
         {
@@ -1927,15 +1930,25 @@ public class AuthenticationManager
                 // The SSO validate actions are @RequiresNoPermission, so getUser() returns guest whenever the request
                 // carries no signed-in session -- typically because the session cookie didn't accompany the IdP's
                 // cross-site POST to the validate action, or because the session timed out mid-flow.
-                errorMessage = "Reauthentication failed: this browser is no longer signed in; please sign in again";
-                _log.warn("Reauthentication failed for \"{}\": the request carried no signed-in session. Check that the session cookie accompanies the identity provider's response to the validate action -- a JSESSIONID with no explicit SameSite value is withheld from that cross-site POST once it is more than a couple of minutes old.", null != reauthUser ? reauthUser.getEmail() : "an unrecognized identity");
+                // Deliberately does not claim the browser is signed out: the signed-in session usually still exists and
+                // works for same-site requests -- it just didn't accompany this one. Offers both remedies because the
+                // two causes (withheld cookie, expired session) are indistinguishable from here.
+                errorMessage = "Reauthentication failed: this request did not include your signed-in session. Try signing in again; if the problem persists, contact your administrator.";
+                // Names the remedy, not just the symptom: the only person who can act on this reads the server log,
+                // and the property is the same in dev and production even though the file's location is not.
+                _log.warn("Reauthentication failed for \"{}\": the identity provider's cross-site POST to the validate action carried no JSESSIONID, so the request had no signed-in session. Chromium-based browsers withhold a session cookie that has no explicit SameSite value from that POST once the cookie is more than a couple of minutes old. To fix, set server.servlet.session.cookie.same-site=none and server.servlet.session.cookie.secure=true in application.properties -- these require HTTPS -- and restart the server.", null != reauthUser ? reauthUser.getEmail() : "an unrecognized identity");
             }
             else if (null == reauthUser)
+            {
                 // Narrow, but sign-in and reauthentication resolve users differently: finalizePrimaryAuthentication()
                 // can auto-create an account, and reauthentication never does. Reaching here means the asserted
                 // identity has no account by the time reauth runs -- deleted or renamed mid-session, or the IdP
                 // asserting a different identifier than it did at sign-in.
                 errorMessage = "Reauthentication failed: the reauthenticated identity does not match a LabKey user account";
+                // The asserted identity is the whole diagnosis here and it appears nowhere else: no user resolved, so
+                // the audit log records nothing and the user-facing message can't name an account that doesn't exist.
+                _log.warn("Reauthentication failed for \"{}\": the identity provider asserted \"{}\", which matches no LabKey user account.", sessionUser.getEmail(), null != assertedEmail ? assertedEmail : "an unrecognized identity");
+            }
             else
             {
                 errorMessage = "Reauthentication failed: wrong user reauthenticated";
@@ -2064,7 +2077,7 @@ public class AuthenticationManager
             ActionURL url = new ActionURL("core", "begin.view", ContainerManager.getRoot());
 
             ActionURL clone = url.clone();
-            setReauthUser(admin, admin, request, null, clone);
+            setReauthUser(admin, admin.getEmail(), admin, request, null, clone);
             assertEquals(initialCount + 1, map.size());
             String token = clone.getParameter(REAUTH_TOKEN_NAME);
             ReauthContext ctx = map.get(token);
@@ -2080,14 +2093,14 @@ public class AuthenticationManager
 
             // Wrong user on set case
             clone = url.clone();
-            setReauthUser(admin, new User(), request, null, clone);
+            setReauthUser(admin, admin.getEmail(), new User(), request, null, clone);
             assertNull(clone.getParameter(REAUTH_TOKEN_NAME));
             assertEquals("Reauthentication failed: wrong user reauthenticated", clone.getParameter(ERROR_MESSAGE));
             assertEquals(initialCount, map.size());
 
             // Wrong user on get case
             clone = url.clone();
-            setReauthUser(admin, admin, request, null, clone);
+            setReauthUser(admin, admin.getEmail(), admin, request, null, clone);
             assertEquals(initialCount + 1, map.size());
             token = clone.getParameter(REAUTH_TOKEN_NAME);
             ctx = map.get(token);

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -2098,6 +2098,47 @@ public class AuthenticationManager
             assertEquals("Reauthentication failed: wrong user reauthenticated", clone.getParameter(ERROR_MESSAGE));
             assertEquals(initialCount, map.size());
 
+            // The remaining cases all fail the same way -- no token, no map entry -- but each reports a different
+            // problem, so assert the exact text. These messages are what an administrator greps for.
+            String noSessionMessage = "Reauthentication failed: this request did not include your signed-in session. Try signing in again; if the problem persists, contact your administrator.";
+            String noAccountMessage = "Reauthentication failed: the reauthenticated identity does not match a LabKey user account";
+
+            // Guest session: the request carried no signed-in session, so getUser() returned guest
+            clone = url.clone();
+            setReauthUser(admin, admin.getEmail(), User.guest, request, null, clone);
+            assertNull(clone.getParameter(REAUTH_TOKEN_NAME));
+            assertEquals(noSessionMessage, clone.getParameter(ERROR_MESSAGE));
+            assertEquals(initialCount, map.size());
+
+            // Same, with nothing to name in the warning -- covers the "unrecognized identity" fallback, which is
+            // impractical to reach against a live identity provider
+            clone = url.clone();
+            setReauthUser(null, null, User.guest, request, null, clone);
+            assertNull(clone.getParameter(REAUTH_TOKEN_NAME));
+            assertEquals(noSessionMessage, clone.getParameter(ERROR_MESSAGE));
+            assertEquals(initialCount, map.size());
+
+            // Asserted identity resolves to no LabKey account
+            clone = url.clone();
+            setReauthUser(null, "nobody@labkey.test", admin, request, null, clone);
+            assertNull(clone.getParameter(REAUTH_TOKEN_NAME));
+            assertEquals(noAccountMessage, clone.getParameter(ERROR_MESSAGE));
+            assertEquals(initialCount, map.size());
+
+            // Same, with no asserted identity to report
+            clone = url.clone();
+            setReauthUser(null, null, admin, request, null, clone);
+            assertNull(clone.getParameter(REAUTH_TOKEN_NAME));
+            assertEquals(noAccountMessage, clone.getParameter(ERROR_MESSAGE));
+            assertEquals(initialCount, map.size());
+
+            // A pre-existing error message short-circuits the branch entirely, so the caller's text survives
+            clone = url.clone();
+            setReauthUser(admin, admin.getEmail(), new User(), request, "Reauthentication failed", clone);
+            assertNull(clone.getParameter(REAUTH_TOKEN_NAME));
+            assertEquals("Reauthentication failed", clone.getParameter(ERROR_MESSAGE));
+            assertEquals(initialCount, map.size());
+
             // Wrong user on get case
             clone = url.clone();
             setReauthUser(admin, admin.getEmail(), admin, request, null, clone);

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -1110,6 +1110,7 @@ public class UserManager
         public static final String LOGGED_IN = "logged in";
         public static final String LOGGED_OUT = "logged out";
         public static final String API_KEY = "an API key";
+        public static final String REAUTHENTICATED = "reauthenticated";
 
         int _user;
 

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -354,7 +354,7 @@ public class LoginController extends SpringActionController
             {
                 // Attempt authentication with all active form providers
                 String formEmail = form.getEmail();
-                PrimaryAuthenticationResult result = AuthenticationManager.authenticate(request, formEmail, form.getPassword(), form.getReturnUrlHelper(), true);
+                PrimaryAuthenticationResult result = AuthenticationManager.authenticate(request, formEmail, form.getPassword(), form.getReturnUrlHelper(), true, form.isForceReauth());
                 AuthenticationStatus status = result.getStatus();
 
                 if (Success == status)


### PR DESCRIPTION
### Rationale

Nothing recorded that a reauthentication happened. SSO reauth wrote no audit event at all, and local reauth wrote a "logged in" event, which misstates what happened — no session is created and the user was already signed in. On the failure side, every distinct reauthentication failure produced the same "wrong user reauthenticated" message, with nothing in the server log at all, so an administrator hunts for a user mismatch that usually never happened.

### Related Pull Requests

- LabKey/server#1472 — documents the SameSite requirement behind the reauthentication failure these messages now describe.
- LabKey/premiumModules#692 — records electronic-signing reauthentication through this same audit accounting. Merges together with this PR.

### Changes

- Add a `REAUTHENTICATED` user audit event and `auditReauthSuccess()`, recorded from each path that completes a reauthentication. `finalizePrimaryAuthentication()` takes a `reauth` flag that suppresses the "logged in" event which previously misstated what happened.
- Split the single "wrong user reauthenticated" error into three, distinguishing a browser that is no longer signed in, and an identity matching no LabKey user account, from a genuinely different user. `setReauthUser()` keeps its existing name, `void` return, and signature.
- Log a warning when reauthentication fails in a way an administrator can act on, naming the identities involved and the likely cause.
- Note on activity counting: `UserManager.getAuthCount()` counts audit events matching "logged in", so suppressing that event means reauthentication no longer inflates it. `LastLogin` is unchanged by this PR and still updated on reauthentication, so the `recentUserCount` usage metric and the LastLogin column in the Users grid still count it as recent activity.
