### PR TITLE
Add startup property that overrides the distribution name

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -246,7 +246,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
     private final MultiValuedMap<String, StartupPropertyEntry> _startupPropertyMap = new CaseInsensitiveKeyedHashSetValuedMap<>();
 
     // If non-null (set by a startup property), overrides the name specified in the distribution.properties file
-    private String _distributionName = null;
+    private String _distributionNameOverride = null;
 
     private ModuleLoader()
     {
@@ -2067,14 +2067,17 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         }
     }
 
-    public @Nullable String getDistributionName()
+    public @Nullable String getDistributionNameOverride()
     {
-        return _distributionName;
+        return _distributionNameOverride;
     }
 
-    public void setDistributionName(String distributionName)
+    void setDistributionNameOverride(String distributionNameOverride)
     {
-        _distributionName = distributionName;
+        if (isStartupComplete())
+            throw new IllegalStateException("Distribution name override must be set during startup");
+
+        _distributionNameOverride = distributionNameOverride;
     }
 
     // Did this server start up with no modules installed? If so, it's a new installation. This lets us tailor the

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -245,8 +245,13 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
     private final Set<StartupPropertyHandler<? extends StartupProperty>> _startupPropertyHandlers = new ConcurrentSkipListSet<>(Comparator.comparing((StartupPropertyHandler<?> sph) -> sph.getScope(), String.CASE_INSENSITIVE_ORDER).thenComparing(StartupPropertyHandler::getStartupPropertyClassName));
     private final MultiValuedMap<String, StartupPropertyEntry> _startupPropertyMap = new CaseInsensitiveKeyedHashSetValuedMap<>();
 
-    // If non-null (set by a startup property), overrides the name specified in the distribution.properties file
-    private String _distributionNameOverride = null;
+    // All three are set by startup properties during doInitWithSourceModule() and read later from other threads
+
+    // If non-null, overrides the name specified in the distribution.properties file
+    private volatile String _distributionNameOverride;
+    // Modules to include and exclude in this server session; consumed by loadModules()
+    private volatile List<String> _moduleIncludeList = List.of();
+    private volatile List<String> _moduleExcludeList = List.of();
 
     private ModuleLoader()
     {
@@ -1188,8 +1193,8 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         }
 
         // filter by startup properties if they were specified
-        LinkedList<String> includeList = ModuleLoaderStartupProperties.include.getList();
-        Set<String> excludeSet = Sets.newCaseInsensitiveHashSet(ModuleLoaderStartupProperties.exclude.getList());
+        LinkedList<String> includeList = getModuleIncludeList();
+        Set<String> excludeSet = Sets.newCaseInsensitiveHashSet(getModuleExcludeList());
 
         List<String> missingModules = new ArrayList<>();
         CaseInsensitiveTreeMap<Module> includedModules = moduleNameToModule;
@@ -2072,12 +2077,39 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         return _distributionNameOverride;
     }
 
-    void setDistributionNameOverride(String distributionNameOverride)
+    void setDistributionNameOverride(@Nullable String distributionNameOverride)
+    {
+        checkStartupPropertyState("Distribution name override");
+        _distributionNameOverride = distributionNameOverride;
+    }
+
+    // Returns a mutable copy because loadModules() consumes the list destructively
+    LinkedList<String> getModuleIncludeList()
+    {
+        return new LinkedList<>(_moduleIncludeList);
+    }
+
+    void setModuleIncludeList(List<String> moduleIncludeList)
+    {
+        checkStartupPropertyState("Module include list");
+        _moduleIncludeList = List.copyOf(moduleIncludeList);
+    }
+
+    List<String> getModuleExcludeList()
+    {
+        return _moduleExcludeList;
+    }
+
+    void setModuleExcludeList(List<String> moduleExcludeList)
+    {
+        checkStartupPropertyState("Module exclude list");
+        _moduleExcludeList = List.copyOf(moduleExcludeList);
+    }
+
+    private void checkStartupPropertyState(String description)
     {
         if (isStartupComplete())
-            throw new IllegalStateException("Distribution name override must be set during startup");
-
-        _distributionNameOverride = distributionNameOverride;
+            throw new IllegalStateException(description + " must be set during startup");
     }
 
     // Did this server start up with no modules installed? If so, it's a new installation. This lets us tailor the

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -245,6 +245,9 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
     private final Set<StartupPropertyHandler<? extends StartupProperty>> _startupPropertyHandlers = new ConcurrentSkipListSet<>(Comparator.comparing((StartupPropertyHandler<?> sph) -> sph.getScope(), String.CASE_INSENSITIVE_ORDER).thenComparing(StartupPropertyHandler::getStartupPropertyClassName));
     private final MultiValuedMap<String, StartupPropertyEntry> _startupPropertyMap = new CaseInsensitiveKeyedHashSetValuedMap<>();
 
+    // If non-null (set by a startup property), overrides the name specified in the distribution.properties file
+    private String _distributionName = null;
+
     private ModuleLoader()
     {
         MemTracker.getInstance().register(this);
@@ -2062,6 +2065,16 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
         {
             return UpgradeState.UpgradeInProgress == _upgradeState;
         }
+    }
+
+    public @Nullable String getDistributionName()
+    {
+        return _distributionName;
+    }
+
+    public void setDistributionName(String distributionName)
+    {
+        _distributionName = distributionName;
     }
 
     // Did this server start up with no modules installed? If so, it's a new installation. This lets us tailor the

--- a/api/src/org/labkey/api/module/ModuleLoaderStartupProperties.java
+++ b/api/src/org/labkey/api/module/ModuleLoaderStartupProperties.java
@@ -48,7 +48,9 @@ public enum ModuleLoaderStartupProperties implements StartupProperty
         @Override
         public String getDescription()
         {
-            return "Distribution name to show in the admin console and the export diagnostics zip file. This name overrides the value provided in the distribution.properties file that's bundled with the distribution.";
+            return "Distribution name to show in the admin console, include in the export diagnostics zip file, and" +
+                "report to mothership. This name overrides the value provided in the distribution.properties file " +
+                "that's bundled with the distribution. Note: Respected only when the \"startup\" modifier is specified.";
         }
     };
 
@@ -68,7 +70,7 @@ public enum ModuleLoaderStartupProperties implements StartupProperty
                 map.forEach((sp, cp)-> {
                     if (sp == distributionName)
                     {
-                        ModuleLoader.getInstance().setDistributionName(cp.getValue());
+                        ModuleLoader.getInstance().setDistributionNameOverride(StringUtils.trimToNull(cp.getValue()));
                     }
                     else
                     {

--- a/api/src/org/labkey/api/module/ModuleLoaderStartupProperties.java
+++ b/api/src/org/labkey/api/module/ModuleLoaderStartupProperties.java
@@ -42,6 +42,14 @@ public enum ModuleLoaderStartupProperties implements StartupProperty
         {
             return "Comma-separated list of modules to disable during this server session. Note: Respected only when the \"startup\" modifier is specified.";
         }
+    },
+    distributionName
+    {
+        @Override
+        public String getDescription()
+        {
+            return "Distribution name to show in the admin console and the export diagnostics zip file. This name overrides the value provided in the distribution.properties file that's bundled with the distribution.";
+        }
     };
 
     private final LinkedList<String> _list = new LinkedList<>();
@@ -57,10 +65,19 @@ public enum ModuleLoaderStartupProperties implements StartupProperty
             @Override
             public void handle(Map<ModuleLoaderStartupProperties, StartupPropertyEntry> map)
             {
-                map.forEach((sp, cp)-> Arrays.stream(StringUtils.split(cp.getValue(), ","))
-                    .map(StringUtils::trimToNull)
-                    .filter(Objects::nonNull)
-                    .forEach(sp._list::add));
+                map.forEach((sp, cp)-> {
+                    if (sp == distributionName)
+                    {
+                        ModuleLoader.getInstance().setDistributionName(cp.getValue());
+                    }
+                    else
+                    {
+                        Arrays.stream(StringUtils.split(cp.getValue(), ","))
+                            .map(StringUtils::trimToNull)
+                            .filter(Objects::nonNull)
+                            .forEach(sp._list::add);
+                    }
+                });
             }
         });
     }

--- a/api/src/org/labkey/api/module/ModuleLoaderStartupProperties.java
+++ b/api/src/org/labkey/api/module/ModuleLoaderStartupProperties.java
@@ -60,7 +60,7 @@ public enum ModuleLoaderStartupProperties implements StartupProperty
         @Override
         public String getDescription()
         {
-            return "Distribution name to show in the admin console, include in the export diagnostics zip file, and " +
+            return "Distribution name to show in the Admin Console, include in the export diagnostics zip file, and " +
                 "report to mothership. This name overrides the value provided in the distribution.properties file " +
                 "that's bundled with the distribution. Note: Respected only when the \"startup\" modifier is specified.";
         }

--- a/api/src/org/labkey/api/module/ModuleLoaderStartupProperties.java
+++ b/api/src/org/labkey/api/module/ModuleLoaderStartupProperties.java
@@ -21,7 +21,7 @@ import org.labkey.api.settings.StartupProperty;
 import org.labkey.api.settings.StartupPropertyEntry;
 
 import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -34,6 +34,12 @@ public enum ModuleLoaderStartupProperties implements StartupProperty
         {
             return "Comma-separated list of modules to enable during this server session. Note: Respected only when the \"startup\" modifier is specified.";
         }
+
+        @Override
+        void handle(String value)
+        {
+            ModuleLoader.getInstance().setModuleIncludeList(splitValues(value));
+        }
     },
     exclude
     {
@@ -42,23 +48,42 @@ public enum ModuleLoaderStartupProperties implements StartupProperty
         {
             return "Comma-separated list of modules to disable during this server session. Note: Respected only when the \"startup\" modifier is specified.";
         }
+
+        @Override
+        void handle(String value)
+        {
+            ModuleLoader.getInstance().setModuleExcludeList(splitValues(value));
+        }
     },
     distributionName
     {
         @Override
         public String getDescription()
         {
-            return "Distribution name to show in the admin console, include in the export diagnostics zip file, and" +
+            return "Distribution name to show in the admin console, include in the export diagnostics zip file, and " +
                 "report to mothership. This name overrides the value provided in the distribution.properties file " +
                 "that's bundled with the distribution. Note: Respected only when the \"startup\" modifier is specified.";
         }
+
+        @Override
+        void handle(String value)
+        {
+            ModuleLoader.getInstance().setDistributionNameOverride(StringUtils.trimToNull(value));
+        }
     };
 
-    private final LinkedList<String> _list = new LinkedList<>();
+    /**
+     * Apply the value supplied for this property. Abstract, rather than a shared default implementation, so that adding
+     * a constant forces a decision about how its value is handled.
+     */
+    abstract void handle(String value);
 
-    LinkedList<String> getList()
+    private static List<String> splitValues(String value)
     {
-        return new LinkedList<>(_list);
+        return Arrays.stream(StringUtils.split(value, ","))
+            .map(StringUtils::trimToNull)
+            .filter(Objects::nonNull)
+            .toList();
     }
 
     static void populate()
@@ -67,19 +92,7 @@ public enum ModuleLoaderStartupProperties implements StartupProperty
             @Override
             public void handle(Map<ModuleLoaderStartupProperties, StartupPropertyEntry> map)
             {
-                map.forEach((sp, cp)-> {
-                    if (sp == distributionName)
-                    {
-                        ModuleLoader.getInstance().setDistributionNameOverride(StringUtils.trimToNull(cp.getValue()));
-                    }
-                    else
-                    {
-                        Arrays.stream(StringUtils.split(cp.getValue(), ","))
-                            .map(StringUtils::trimToNull)
-                            .filter(Objects::nonNull)
-                            .forEach(sp._list::add);
-                    }
-                });
+                map.forEach((sp, cp) -> sp.handle(cp.getValue()));
             }
         });
     }

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -703,7 +703,7 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
     @Override
     public @NotNull String getDistributionName()
     {
-        return Objects.requireNonNullElse(ModuleLoader.getInstance().getDistributionName(), DISTRIBUTION_NAME);
+        return Objects.requireNonNullElse(ModuleLoader.getInstance().getDistributionNameOverride(), DISTRIBUTION_NAME);
     }
 
     @Override

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -55,6 +55,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 
@@ -702,7 +703,7 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
     @Override
     public @NotNull String getDistributionName()
     {
-        return DISTRIBUTION_NAME;
+        return Objects.requireNonNullElse(ModuleLoader.getInstance().getDistributionName(), DISTRIBUTION_NAME);
     }
 
     @Override

--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -17,20 +17,22 @@
 %>
 <%@ page import="org.apache.commons.lang3.ObjectUtils" %>
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
+<%@ page import="org.apache.commons.lang3.Strings" %>
 <%@ page import="org.labkey.api.admin.AdminBean" %>
 <%@ page import="org.labkey.api.data.DbScope" %>
 <%@ page import="org.labkey.api.data.dialect.SqlDialect" %>
 <%@ page import="org.labkey.api.files.FileContentService" %>
 <%@ page import="org.labkey.api.module.DefaultModule" %>
 <%@ page import="org.labkey.api.module.Module" %>
-<%@ page import="org.labkey.api.module.ModuleLoader"%>
+<%@ page import="org.labkey.api.module.ModuleLoader" %>
 <%@ page import="org.labkey.api.moduleeditor.api.ModuleEditorService" %>
 <%@ page import="org.labkey.api.settings.AdminConsole" %>
 <%@ page import="org.labkey.api.settings.AdminConsole.AdminLink" %>
 <%@ page import="org.labkey.api.settings.AdminConsole.SettingsLinkType" %>
 <%@ page import="org.labkey.api.settings.AppProps" %>
+<%@ page import="org.labkey.api.util.DateUtil" %>
 <%@ page import="org.labkey.api.util.Formats" %>
-<%@ page import="org.labkey.api.util.HtmlString"%>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.util.HtmlStringBuilder" %>
 <%@ page import="org.labkey.api.view.NavTree" %>
 <%@ page import="org.labkey.core.admin.AdminController" %>
@@ -41,8 +43,6 @@
 <%@ page import="java.util.Comparator" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.TreeMap" %>
-<%@ page import="org.apache.commons.lang3.Strings" %>
-<%@ page import="org.labkey.api.util.DateUtil" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -101,9 +101,9 @@
     {
         timeCellCls = "lk-server-time-warning";
         warning = HtmlStringBuilder.of(" - Warning: Web and database server times differ by ")
-                .append(timeDifference.getSeconds())
-                .append(" seconds!")
-                .getHtmlString();
+            .append(timeDifference.getSeconds())
+            .append(" seconds!")
+            .getHtmlString();
     }
 %>
             <h4>Runtime Information</h4>


### PR DESCRIPTION
## Rationale
New startup property for overriding the distribution name. For example: `ModuleLoader.distributionName;startup=lims_starter`

https://github.com/LabKey/kanban/issues/2075

## Related Pull Requests
- https://github.com/LabKey/distributions/pull/610