### PR TITLE
Return distinct data ids for GetTransactionRowIds.api

### DIFF
--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -268,6 +268,11 @@ public class AuditLogImpl implements AuditLogService, StartupListener
                     .map(SampleTimelineAuditEvent.class::cast)
                     .toList();
         }
+        // Drop the secondary "added/removed sample to/from job" events; the same sample has a primary registration/update event in the transaction, so counting these would double-count it.
+        events = events.stream()
+                .filter(event -> SampleTimelineAuditEvent.SampleTimelineEventType.INSERT.getComment().equals(event.getComment()) || SampleTimelineAuditEvent.SampleTimelineEventType.MERGE.getComment().equals(event.getComment()))
+                .toList();
+
         Map<Long, Long> dataTypeRowCounts = new HashMap<>();
         // Return distinct set of sampleIds, since there might be multiple events in transaction for the same sample
         // For example: job derive action creates one registration event, one add to job event.

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -56,12 +56,13 @@ import org.labkey.audit.query.AuditQuerySchema;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 public class AuditLogImpl implements AuditLogService, StartupListener
 {
@@ -248,7 +249,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
         return new ActionURL(AuditController.ShowAuditLogAction.class, ContainerManager.getRoot());
     }
 
-    public record TransactionRowIds(List<Long> rowIds, Map<Long, Long> dataTypeRowCounts) {}
+    public record TransactionRowIds(Set<Long> rowIds, Map<Long, Long> dataTypeRowCounts) {}
 
     public TransactionRowIds getTransactionSampleIds(long transactionAuditId, User user, Container container, @Nullable ContainerFilter containerFilter)
     {
@@ -268,7 +269,9 @@ public class AuditLogImpl implements AuditLogService, StartupListener
                     .toList();
         }
         Map<Long, Long> dataTypeRowCounts = new HashMap<>();
-        List<Long> sampleIds = new ArrayList<>();
+        // Return distinct set of sampleIds, since there might be multiple events in transaction for the same sample
+        // For example: job derive action creates one registration event, one add to job event.
+        Set<Long> sampleIds = new HashSet<>();
         events.forEach(event -> {
             dataTypeRowCounts.merge(event.getSampleTypeId(), 1L, Long::sum);
             sampleIds.add(event.getSampleId());
@@ -279,7 +282,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
     public TransactionRowIds getTransactionSourceIds(long transactionAuditId, User user, Container container, @Nullable ContainerFilter containerFilter)
     {
         List<String> lsids = new ArrayList<>();
-        List<Long> sourceIds = new ArrayList<>();
+        Set<Long> sourceIds = new HashSet<>();
         Map<Long, Long> dataTypeRowCounts = new HashMap<>();
         List<AuditTypeEvent> transactionEvents = TRANSACTION_EVENT_CACHE.get(transactionAuditId).second;
         List<DetailedAuditTypeEvent> detailedEvents = transactionEvents.isEmpty()

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4651,6 +4651,10 @@ public class QueryController extends SpringActionController
             Map<String, Object> auditDetails = json.has("auditDetails") ? json.getJSONObject("auditDetails").toMap() : new CaseInsensitiveHashMap<>();
 
             Map<Enum, Object> configParameters = new HashMap<>();
+
+            if (extraContext.containsKey(AbstractQueryImportAction.Params.useTransactionAuditCache.name()))
+                configParameters.put(AbstractQueryImportAction.Params.useTransactionAuditCache, extraContext.get(AbstractQueryImportAction.Params.useTransactionAuditCache.name()));
+
             if (WorkflowService.get() != null)
                 WorkflowService.get().populateConfigParams(extraContext, configParameters);
 


### PR DESCRIPTION
## Rationale
A recent [change](https://github.com/LabKey/platform/pull/7909) was made to have the entire transaction respect the same useTransactionAuditCache setting. This change causes job derive actions to generate unexpected messages with double the data count. The double count was due to separate events in the transaction for sample creation and then adding the created sample to jobs. 
[workflow derive action success msg failures](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_ProductSuites_LabKeyLims_LimsStarterPostgres/4132091?buildTab=tests&status=failed) (develop)

This PR modifies GetTransactionRowIds to return distinct set of data ids.

This PR also modifies query.saveRows to respect useTransactionAuditCache setting passed in in extraContext.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7909

## Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->