### PR TITLE
Fix stale Content-Encoding header in ProxyServlet after HttpClient bump

### DIFF
--- a/api/src/org/mitre/dsmiley/httpproxy/LabKeyProxyServlet.java
+++ b/api/src/org/mitre/dsmiley/httpproxy/LabKeyProxyServlet.java
@@ -1,6 +1,8 @@
 package org.mitre.dsmiley.httpproxy;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.util.PageFlowUtil;
@@ -8,6 +10,7 @@ import org.labkey.api.util.PageFlowUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.net.HttpCookie;
 import java.util.Objects;
 
@@ -82,6 +85,23 @@ public class LabKeyProxyServlet extends ProxyServlet
     protected boolean skipXForwardedProto()
     {
         return true;
+    }
+
+    @Override
+    protected void copyResponseHeader(HttpServletRequest servletRequest, HttpServletResponse servletResponse, Header header)
+    {
+        // In Apache HttpClient <5.6.4, these headers were automatically removed after the client transparently
+        // decompressed the entity. Now we need to remove them manually, or the stale values reach the browser
+        // alongside the already-decompressed body.
+        if (doHandleCompression)
+        {
+            String headerName = header.getName();
+            if (headerName.equalsIgnoreCase(HttpHeaders.CONTENT_ENCODING) ||
+                    headerName.equalsIgnoreCase(HttpHeaders.CONTENT_LENGTH) ||
+                    headerName.equalsIgnoreCase(HttpHeaders.CONTENT_MD5))
+                return;
+        }
+        super.copyResponseHeader(servletRequest, servletResponse, header);
     }
 
     @Override

--- a/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -489,6 +489,9 @@ public class ProxyServlet extends HttpServlet {
         // control the Accept-Encoding header, not the client
         if (doHandleCompression && headerName.equals(HttpHeaders.ACCEPT_ENCODING))
             return;
+        // In Apache HttpClient <5.6.4, these headers were automatically removed. Now we need to remove them manually.
+        if (doHandleCompression && (headerName.equals(HttpHeaders.CONTENT_ENCODING) || headerName.equals(HttpHeaders.CONTENT_MD5)))
+            return;
 
         @SuppressWarnings("unchecked")
         Enumeration<String> headers = servletRequest.getHeaders(headerName);

--- a/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -550,13 +550,6 @@ public class ProxyServlet extends HttpServlet {
         String headerName = header.getName();
         if (hopByHopHeaders.containsHeader(headerName))
             return;
-        // In Apache HttpClient <5.6.4, these headers were automatically removed after the client transparently
-        // decompressed the entity. Now we need to remove them manually, or the stale values reach the browser
-        // alongside the already-decompressed body.
-        if (doHandleCompression && (headerName.equalsIgnoreCase(HttpHeaders.CONTENT_ENCODING) ||
-                headerName.equalsIgnoreCase(HttpHeaders.CONTENT_LENGTH) ||
-                headerName.equalsIgnoreCase(HttpHeaders.CONTENT_MD5)))
-            return;
         String headerValue = header.getValue();
         if (headerName.equalsIgnoreCase(SM.SET_COOKIE) ||
                 headerName.equalsIgnoreCase(SM.SET_COOKIE2)) {

--- a/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -299,6 +299,9 @@ public class ProxyServlet extends HttpServlet {
         return HttpClientBuilder.create()
             .useSystemProperties()
             .setDefaultRequestConfig(config)
+            // httpclient5 5.6+ leaves stale Content-Encoding/Content-Length headers after auto-decompressing a response
+            // (5.5.x stripped them), so copyResponseHeaders() would forward a mismatched header/body pair to the client
+            .disableContentCompression()
             .build();
     }
 

--- a/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -489,9 +489,6 @@ public class ProxyServlet extends HttpServlet {
         // control the Accept-Encoding header, not the client
         if (doHandleCompression && headerName.equals(HttpHeaders.ACCEPT_ENCODING))
             return;
-        // In Apache HttpClient <5.6.4, these headers were automatically removed. Now we need to remove them manually.
-        if (doHandleCompression && (headerName.equals(HttpHeaders.CONTENT_ENCODING) || headerName.equals(HttpHeaders.CONTENT_MD5)))
-            return;
 
         @SuppressWarnings("unchecked")
         Enumeration<String> headers = servletRequest.getHeaders(headerName);
@@ -552,6 +549,13 @@ public class ProxyServlet extends HttpServlet {
                                       HttpServletResponse servletResponse, Header header) {
         String headerName = header.getName();
         if (hopByHopHeaders.containsHeader(headerName))
+            return;
+        // In Apache HttpClient <5.6.4, these headers were automatically removed after the client transparently
+        // decompressed the entity. Now we need to remove them manually, or the stale values reach the browser
+        // alongside the already-decompressed body.
+        if (doHandleCompression && (headerName.equalsIgnoreCase(HttpHeaders.CONTENT_ENCODING) ||
+                headerName.equalsIgnoreCase(HttpHeaders.CONTENT_LENGTH) ||
+                headerName.equalsIgnoreCase(HttpHeaders.CONTENT_MD5)))
             return;
         String headerValue = header.getValue();
         if (headerName.equalsIgnoreCase(SM.SET_COOKIE) ||

--- a/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -296,13 +296,14 @@ public class ProxyServlet extends HttpServlet {
                 .setProtocolUpgradeEnabled(allowProtocolUpgrade()) // LKS override
                 .build();
 
-        return HttpClientBuilder.create()
-            .useSystemProperties()
-            .setDefaultRequestConfig(config)
-            // httpclient5 5.6+ leaves stale Content-Encoding/Content-Length headers after auto-decompressing a response
-            // (5.5.x stripped them), so copyResponseHeaders() would forward a mismatched header/body pair to the client
-            .disableContentCompression()
-            .build();
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create()
+                .useSystemProperties()
+                .setDefaultRequestConfig(config);
+
+        if (!doHandleCompression)
+            httpClientBuilder.disableContentCompression();
+
+        return httpClientBuilder.build();
     }
 
     // LKS override


### PR DESCRIPTION
## Rationale
**The bug, in ProxyServlet:**
```
  proxyResponse = proxyClient.execute(getTargetHost(servletRequest), proxyRequest);
  copyResponseHeaders(proxyResponse, servletRequest, servletResponse);   // copies Content-Encoding verbatim
  copyResponseEntity(proxyResponse, servletResponse, proxyRequest, servletRequest);  // streams whatever entity HttpClient gave it
  copyResponseHeader only skips hop-by-hop headers (Connection, Keep-Alive, Transfer-Encoding, etc.) — Content-Encoding and Content-Length are copied through unconditionally.
```
  
**Why 5.6.4 breaks this:** Apache HttpClient5's internal ContentCompressionExec auto-decompresses gzip/deflate response bodies transparently. In 5.5.2 it also scrubbed the now-stale headers off the raw response:
```
  response.setEntity(new DecompressingEntity(response.getEntity(), decoderFactory));
  response.removeHeaders(HttpHeaders.CONTENT_LENGTH);
  response.removeHeaders(HttpHeaders.CONTENT_ENCODING);   // <- removed
  response.removeHeaders(HttpHeaders.CONTENT_MD5);
```
  In 5.6.4 (part of a rewrite adding pluggable codecs — Brotli/Zstd/etc. — via a new ContentCodecRegistry), that cleanup was dropped:
```
  response.setEntity(decoder.apply(response.getEntity()));
  // no more removeHeaders() calls
```
  The entity is still silently decompressed, but Content-Encoding: gzip (and the old compressed Content-Length) now survive on the response object and get forwarded verbatim by ProxyServlet.

**Net effect:** browser receives Content-Encoding: gzip header + already-decompressed plaintext body → Firefox refuses to render it → exactly the contentEncodingError you're seeing.


## Related Pull Requests
- https://github.com/LabKey/server/pull/1476 (httpclient5 5.5.2 -> 5.6.4 bump that exposed this)

## Changes
- Disable HttpClient's automatic content-decompression on the shared proxyClient in ProxyServlet.createHttpClient(), so ProxyServlet always streams the backend's original bytes and headers through unmodified.
