### PR TITLE
GitHub Issue 1219: Summary statistics fail with "Character read limit of 100000 exceeded" on wide datasets (Backport)

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -2889,6 +2889,15 @@ if (!LABKEY.DataRegions) {
             session: true
         });
 
+        // GitHub Issue 1219: the 'fields' column-metadata for the view is never used on the server-side save action
+        // so it can be removed from the payload. Also, only fieldKey/title are read per column so we can trim down that as well.
+        delete viewConfig.fields;
+        if (LABKEY.Utils.isArray(viewConfig.columns)) {
+            viewConfig.columns = $.map(viewConfig.columns, function(col) {
+                return col.title ? { fieldKey: col.fieldKey, title: col.title } : { fieldKey: col.fieldKey };
+            });
+        }
+
         LABKEY.Query.saveQueryViews({
             containerPath: this.containerPath,
             schemaName: this.schemaName,


### PR DESCRIPTION
## Rationale
Backport changes to 26.7 for https://github.com/LabKey/internal-issues/issues/1219

On wide grids (many columns), setting a summary statistic posts the full custom-view JSON to the saveQueryViews action, which is capped at `@JsonInputLimit(100_000)` characters. The per-column field metadata array (fields) plus full column objects blow past that limit and the save fails ("Character read limit of 100000 exceeded"). The fix trims the POST body in `_updateSessionCustomView`: drop the unused top-level fields array and reduce each column to just fieldKey (+ title when present).

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7800
- https://github.com/LabKey/platform/pull/7940
- https://github.com/LabKey/testAutomation/pull/3154

## Changes
- DataRegion call to saveQueryViews does not need to include view 'fields' info in post