### PR TITLE
Select only insert events for job sample actions

### DIFF
--- a/audit/src/org/labkey/audit/AuditController.java
+++ b/audit/src/org/labkey/audit/AuditController.java
@@ -428,7 +428,7 @@ public class AuditController extends SpringActionController
 
         public Boolean isInsertOnly()
         {
-            return  Boolean.TRUE.equals(_insertOnly);
+            return Boolean.TRUE.equals(_insertOnly);
         }
 
         public void setInsertOnly(Boolean insertOnly)

--- a/audit/src/org/labkey/audit/AuditController.java
+++ b/audit/src/org/labkey/audit/AuditController.java
@@ -386,7 +386,7 @@ public class AuditController extends SpringActionController
             // GitHub Issue 1307: use product folder data CF
             ContainerFilter cf = getContainer().getProductFoldersDataContainerFilter(elevatedUser);
             if (form.isSampleType())
-                results = AuditLogImpl.get().getTransactionSampleIds(form.getTransactionAuditId(), elevatedUser, getContainer(), cf);
+                results = AuditLogImpl.get().getTransactionSampleIds(form.getTransactionAuditId(), form.isInsertOnly(), elevatedUser, getContainer(), cf);
             else
                 results = AuditLogImpl.get().getTransactionSourceIds(form.getTransactionAuditId(), elevatedUser, getContainer(), cf);
 
@@ -404,6 +404,7 @@ public class AuditController extends SpringActionController
         private Long _transactionAuditId;
         private String _dataType;
         private boolean _isSampleType;
+        private Boolean _insertOnly;
 
         public Long getTransactionAuditId()
         {
@@ -423,6 +424,16 @@ public class AuditController extends SpringActionController
         public void setDataType(String dataType)
         {
             _dataType = dataType;
+        }
+
+        public Boolean isInsertOnly()
+        {
+            return  Boolean.TRUE.equals(_insertOnly);
+        }
+
+        public void setInsertOnly(Boolean insertOnly)
+        {
+            _insertOnly = insertOnly;
         }
 
         public boolean isSampleType()

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -251,7 +251,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
 
     public record TransactionRowIds(Set<Long> rowIds, Map<Long, Long> dataTypeRowCounts) {}
 
-    public TransactionRowIds getTransactionSampleIds(long transactionAuditId, User user, Container container, @Nullable ContainerFilter containerFilter)
+    public TransactionRowIds getTransactionSampleIds(long transactionAuditId, boolean includeInsertEventOnly, User user, Container container, @Nullable ContainerFilter containerFilter)
     {
         List<AuditTypeEvent> transactionEvents = TRANSACTION_EVENT_CACHE.get(transactionAuditId).second;
         List<SampleTimelineAuditEvent> events;
@@ -268,10 +268,14 @@ public class AuditLogImpl implements AuditLogService, StartupListener
                     .map(SampleTimelineAuditEvent.class::cast)
                     .toList();
         }
-        // Drop the secondary "added/removed sample to/from job" events; the same sample has a primary registration/update event in the transaction, so counting these would double-count it.
-        events = events.stream()
-                .filter(event -> SampleTimelineAuditEvent.SampleTimelineEventType.INSERT.getComment().equals(event.getComment()) || SampleTimelineAuditEvent.SampleTimelineEventType.MERGE.getComment().equals(event.getComment()))
-                .toList();
+
+        if (includeInsertEventOnly)
+        {
+            // Drop the secondary "added/removed sample to/from job/update parent status" events; the same sample has a primary registration/update event in the transaction, so counting these would double-count it.
+            events = events.stream()
+                    .filter(event -> SampleTimelineAuditEvent.SampleTimelineEventType.INSERT.getComment().equals(event.getComment()) || SampleTimelineAuditEvent.SampleTimelineEventType.MERGE.getComment().equals(event.getComment()))
+                    .toList();
+        }
 
         Map<Long, Long> dataTypeRowCounts = new HashMap<>();
         // Return distinct set of sampleIds, since there might be multiple events in transaction for the same sample


### PR DESCRIPTION
## Rationale
New samples can be created from job task actions (derive, pool, aliquot). Sample's parent status can be updated during those derive action. All of those events are recorded under the same transaction audit event. Job action success msg currently doesn't include parent samples whose status are updated. This PR modifies GetTransactionRowIds.api to take an insertOnly to only include sample registration events for job sample derive action msg generation.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7935
- https://github.com/LabKey/platform/pull/7909
- https://github.com/LabKey/labkey-ui-components/pull/2061
- https://github.com/LabKey/labkey-ui-premium/pull/1020
- https://github.com/LabKey/platform/pull/7949
- https://github.com/LabKey/limsModules/pull/2411

## Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
## Tasks 📍
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->