### PR TITLE
Fix ExecuteSqlAction to handle includeMetadata with v8.3

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -3824,7 +3824,7 @@ public class QueryController extends SpringActionController
                 response = new ApiQueryResponse(view, isEditable,
                         false, schemaName, form.isSaveInSession() ? settings.getQueryName() : "sql", offset, null,
                         metaDataOnly, form.isIncludeDetailsColumn(), form.isIncludeUpdateColumn(),
-                        form.isIncludeDisplayValues());
+                        form.isIncludeDisplayValues(), form.isIncludeMetadata());
             }
             response.includeStyle(form.isIncludeStyle());
 


### PR DESCRIPTION
## Rationale
Form was conveying this flag, but action wasn't passing it along to `ApiQueryResponse`. https://github.com/LabKey/internal-issues/issues/1414

## Related Pull Requests
- https://github.com/LabKey/labkey-api-java/pull/95