### PR TITLE
Let DockerSessionListener subclasses route their own container stop

### DIFF
--- a/api/src/org/labkey/api/docker/DockerSessionListener.java
+++ b/api/src/org/labkey/api/docker/DockerSessionListener.java
@@ -48,7 +48,7 @@ public class DockerSessionListener implements HttpSessionBindingListener
 
         try
         {
-            DockerService.get().stop(_containerId);
+            stopContainer(_containerId);
         }
         catch (Exception ex)
         {
@@ -57,4 +57,13 @@ public class DockerSessionListener implements HttpSessionBindingListener
     }
 
     protected void preStop() {}
+
+    /**
+     * Override to route the stop through a service-specific manager (e.g. DockerRStudioManager) when one tracks
+     * its own cache of containers; the default here stops via DockerService directly, leaving such a cache stale.
+     */
+    protected void stopContainer(@NotNull String containerId)
+    {
+        DockerService.get().stop(containerId);
+    }
 }


### PR DESCRIPTION
## Rationale
`DockerSessionListener.valueUnbound()` always stopped a container via the generic `DockerService`, so a subclass that keeps its own cache of tracked containers (like RStudio's `DockerRStudioManager`) had no way to keep that cache in sync when a container was stopped this way.

## Related Pull Requests
- LabKey/premiumModules#704 — the consumer of this change, fixing stale RStudio container caching

## Changes
- Added an overridable `stopContainer()` hook that `valueUnbound()` calls instead of hard-coding `DockerService.get().stop()`; default behavior is unchanged for existing callers.
