### PR TITLE
Log database maintenance commands

### DIFF
--- a/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
@@ -743,9 +743,9 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     }
 
     @Override
-    protected @Nullable String getDatabaseMaintenanceSql()
+    protected SQLFragment getDatabaseMaintenanceSql()
     {
-        return "VACUUM ANALYZE;";
+        return new SQLFragment("VACUUM ANALYZE");
     }
 
     @Override

--- a/api/src/org/labkey/api/data/dialect/DatabaseMaintenanceTask.java
+++ b/api/src/org/labkey/api/data/dialect/DatabaseMaintenanceTask.java
@@ -59,12 +59,14 @@ public class DatabaseMaintenanceTask implements MaintenanceTask
             log.error("Exception retrieving url", e);
         }
 
-        String sql = scope.getSqlDialect().getDatabaseMaintenanceSql();
+        SqlDialect dialect = scope.getSqlDialect();
+        SQLFragment sql = dialect.getDatabaseMaintenanceSql();
         if (null != sql)
         {
             try
             {
-                new SqlExecutor(scope).execute(SQLFragment.unsafe(sql));
+                log.info("Executing {}", sql.toDebugString(dialect));
+                new SqlExecutor(scope).execute(sql);
             }
             catch (BadSqlGrammarException e)
             {

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -360,7 +360,7 @@ public abstract class SqlDialect
 
     public abstract String getSqlTypeName(PropertyStorageSpec prop);
 
-    protected @Nullable String getDatabaseMaintenanceSql()
+    protected @Nullable SQLFragment getDatabaseMaintenanceSql()
     {
         return null;
     }


### PR DESCRIPTION
## Rationale
We can log the commands to better inform curious administrators about what nightly database maintenance is doing

Also, make dialects provide a `SQLFragment`.

## Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/710