### PR TITLE
GitHub Issue #899: App save grid view in subfolder overrides inherited default

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.58.6-fb-saveView899.1"
+        "@labkey/components": "7.59.0"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2366,9 +2366,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.58.6-fb-saveView899.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.6-fb-saveView899.1.tgz",
-      "integrity": "sha512-IyBLwHY7Z6X0QgWokop5dO/zLMe0xA86TZA5s+X5NTQf/zWjmZWvD3R/oq/9d3C74MxkIzv1Z0sSK0P9/JjsLQ==",
+      "version": "7.59.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.0.tgz",
+      "integrity": "sha512-wV5Wtqrz/dOzMWD6XpVuantMha8fetCYOXB7S/Jz6QMt2uE9Fg23lfxYArKWDylm8ufMgEzi9hqDmYdeYM6xYg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.58.1"
+        "@labkey/components": "7.58.6-fb-saveView899.1"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2366,9 +2366,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.58.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.1.tgz",
-      "integrity": "sha512-bgsETI9c7mOAY8/1sxoEWK8py40+YF4pUOxcWU2PdSObPHS/Ncv66nZCvB7l7GNDfghQnD4E8x01Ze6lvpoMmQ==",
+      "version": "7.58.6-fb-saveView899.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.6-fb-saveView899.1.tgz",
+      "integrity": "sha512-IyBLwHY7Z6X0QgWokop5dO/zLMe0xA86TZA5s+X5NTQf/zWjmZWvD3R/oq/9d3C74MxkIzv1Z0sSK0P9/JjsLQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package.json
+++ b/assay/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "eslint --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.58.1"
+    "@labkey/components": "7.58.6-fb-saveView899.1"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "eslint --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.58.6-fb-saveView899.1"
+    "@labkey/components": "7.59.0"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.58.6-fb-saveView899.1",
+        "@labkey/components": "7.59.0",
         "@labkey/themes": "1.9.5"
       },
       "devDependencies": {
@@ -2369,9 +2369,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.58.6-fb-saveView899.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.6-fb-saveView899.1.tgz",
-      "integrity": "sha512-IyBLwHY7Z6X0QgWokop5dO/zLMe0xA86TZA5s+X5NTQf/zWjmZWvD3R/oq/9d3C74MxkIzv1Z0sSK0P9/JjsLQ==",
+      "version": "7.59.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.0.tgz",
+      "integrity": "sha512-wV5Wtqrz/dOzMWD6XpVuantMha8fetCYOXB7S/Jz6QMt2uE9Fg23lfxYArKWDylm8ufMgEzi9hqDmYdeYM6xYg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.58.1",
+        "@labkey/components": "7.58.6-fb-saveView899.1",
         "@labkey/themes": "1.9.5"
       },
       "devDependencies": {
@@ -2369,9 +2369,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.58.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.1.tgz",
-      "integrity": "sha512-bgsETI9c7mOAY8/1sxoEWK8py40+YF4pUOxcWU2PdSObPHS/Ncv66nZCvB7l7GNDfghQnD4E8x01Ze6lvpoMmQ==",
+      "version": "7.58.6-fb-saveView899.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.6-fb-saveView899.1.tgz",
+      "integrity": "sha512-IyBLwHY7Z6X0QgWokop5dO/zLMe0xA86TZA5s+X5NTQf/zWjmZWvD3R/oq/9d3C74MxkIzv1Z0sSK0P9/JjsLQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package.json
+++ b/core/package.json
@@ -20,7 +20,7 @@
     "lint-branch-fix": "node lint.diff.mjs --currentBranch --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.58.6-fb-saveView899.1",
+    "@labkey/components": "7.59.0",
     "@labkey/themes": "1.9.5"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -20,7 +20,7 @@
     "lint-branch-fix": "node lint.diff.mjs --currentBranch --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.58.1",
+    "@labkey/components": "7.58.6-fb-saveView899.1",
     "@labkey/themes": "1.9.5"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.58.1"
+        "@labkey/components": "7.58.6-fb-saveView899.1"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2378,9 +2378,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.58.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.1.tgz",
-      "integrity": "sha512-bgsETI9c7mOAY8/1sxoEWK8py40+YF4pUOxcWU2PdSObPHS/Ncv66nZCvB7l7GNDfghQnD4E8x01Ze6lvpoMmQ==",
+      "version": "7.58.6-fb-saveView899.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.6-fb-saveView899.1.tgz",
+      "integrity": "sha512-IyBLwHY7Z6X0QgWokop5dO/zLMe0xA86TZA5s+X5NTQf/zWjmZWvD3R/oq/9d3C74MxkIzv1Z0sSK0P9/JjsLQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.58.6-fb-saveView899.1"
+        "@labkey/components": "7.59.0"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2378,9 +2378,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.58.6-fb-saveView899.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.6-fb-saveView899.1.tgz",
-      "integrity": "sha512-IyBLwHY7Z6X0QgWokop5dO/zLMe0xA86TZA5s+X5NTQf/zWjmZWvD3R/oq/9d3C74MxkIzv1Z0sSK0P9/JjsLQ==",
+      "version": "7.59.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.0.tgz",
+      "integrity": "sha512-wV5Wtqrz/dOzMWD6XpVuantMha8fetCYOXB7S/Jz6QMt2uE9Fg23lfxYArKWDylm8ufMgEzi9hqDmYdeYM6xYg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.58.6-fb-saveView899.1"
+    "@labkey/components": "7.59.0"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.58.1"
+    "@labkey/components": "7.58.6-fb-saveView899.1"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.58.1"
+        "@labkey/components": "7.58.6-fb-saveView899.1"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.58.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.1.tgz",
-      "integrity": "sha512-bgsETI9c7mOAY8/1sxoEWK8py40+YF4pUOxcWU2PdSObPHS/Ncv66nZCvB7l7GNDfghQnD4E8x01Ze6lvpoMmQ==",
+      "version": "7.58.6-fb-saveView899.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.6-fb-saveView899.1.tgz",
+      "integrity": "sha512-IyBLwHY7Z6X0QgWokop5dO/zLMe0xA86TZA5s+X5NTQf/zWjmZWvD3R/oq/9d3C74MxkIzv1Z0sSK0P9/JjsLQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.58.6-fb-saveView899.1"
+        "@labkey/components": "7.59.0"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.58.6-fb-saveView899.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.58.6-fb-saveView899.1.tgz",
-      "integrity": "sha512-IyBLwHY7Z6X0QgWokop5dO/zLMe0xA86TZA5s+X5NTQf/zWjmZWvD3R/oq/9d3C74MxkIzv1Z0sSK0P9/JjsLQ==",
+      "version": "7.59.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.0.tgz",
+      "integrity": "sha512-wV5Wtqrz/dOzMWD6XpVuantMha8fetCYOXB7S/Jz6QMt2uE9Fg23lfxYArKWDylm8ufMgEzi9hqDmYdeYM6xYg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production rspack build --config node_modules/@labkey/build/configs/prod.config.js"
   },
   "dependencies": {
-    "@labkey/components": "7.58.6-fb-saveView899.1"
+    "@labkey/components": "7.59.0"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production rspack build --config node_modules/@labkey/build/configs/prod.config.js"
   },
   "dependencies": {
-    "@labkey/components": "7.58.1"
+    "@labkey/components": "7.58.6-fb-saveView899.1"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2558,6 +2558,12 @@ public class QueryController extends SpringActionController
         else
             view = queryDef.getCustomView(owner, getViewContext().getRequest(), name);
 
+        // GitHub Issue #899: the lookups above also resolve views inherited from ancestor folders. containerPath is only
+        // honored when inherit is set, so otherwise shadow that view with a new local one rather than editing (and
+        // relocating) the ancestor's.
+        if (view != null && !inherit && view.getContainer() != null && !container.equals(view.getContainer()))
+            view = null;
+
         if (view != null && !replaceExisting && !StringUtils.isEmpty(name))
             errors.reject(ERROR_MSG, "A saved view by the name \"" + viewName + "\" already exists. ");
 
@@ -6220,8 +6226,9 @@ public class QueryController extends SpringActionController
 
             // Users may save views to a location other than the current container
             String containerPath = form.getContainerPath();
+            boolean explicitTargetContainer = form.isInherit() && containerPath != null;
             Container container;
-            if (form.isInherit() && containerPath != null)
+            if (explicitTargetContainer)
             {
                 // Only respect this request if it's a view that is inheritable in subfolders
                 container = ContainerManager.getForPath(containerPath);
@@ -6259,6 +6266,14 @@ public class QueryController extends SpringActionController
                     existingView = form.getQueryDef().getCustomView(getUser(), null, form.getNewName());
                 }
 
+                // GitHub Issue #899: getCustomView() also resolves views inherited from ancestor folders. Absent an explicit
+                // target folder, shadow that view with a new local one instead of rewriting (and un-inheriting) the ancestor's.
+                if (existingView != null && !explicitTargetContainer && existingView.getContainer() != null
+                        && !container.equals(existingView.getContainer()))
+                {
+                    existingView = null;
+                }
+
                 // save a new private view if shared is false but existing view is shared
                 if (existingView != null && !form.isShared() && existingView.getOwner() == null)
                 {
@@ -6278,8 +6293,7 @@ public class QueryController extends SpringActionController
                     viewCopy.setFilterAndSort(view.getFilterAndSort());
                     viewCopy.setColumnProperties(view.getColumnProperties());
                     viewCopy.setIsHidden(form.isHidden());
-                    if (form.isInherit())
-                        viewCopy.setContainer(container);
+                    viewCopy.setContainer(container);
 
                     viewCopy.save(getUser(), getViewContext().getRequest());
                 }

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2534,7 +2534,7 @@ public class QueryController extends SpringActionController
     // Uck. Supports the old and new view designer.
     protected JSONObject saveCustomView(Container container, QueryDefinition queryDef,
                                                  String regionName, String viewName, boolean replaceExisting,
-                                                 boolean share, boolean inherit,
+                                                 boolean share, boolean inherit, boolean explicitTargetContainer,
                                                  boolean session, boolean saveFilter,
                                                  boolean hidden, JSONObject jsonView,
                                                  ActionURL returnUrl,
@@ -2558,10 +2558,9 @@ public class QueryController extends SpringActionController
         else
             view = queryDef.getCustomView(owner, getViewContext().getRequest(), name);
 
-        // GitHub Issue #899: the lookups above also resolve views inherited from ancestor folders. containerPath is only
-        // honored when inherit is set, so otherwise shadow that view with a new local one rather than editing (and
-        // relocating) the ancestor's.
-        if (view != null && !inherit && view.getContainer() != null && !container.equals(view.getContainer()))
+        // GitHub Issue #899: the lookups above also resolve views inherited from ancestor folders. Absent an explicit
+        // target folder, shadow that view with a new local one rather than editing (and relocating) the ancestor's.
+        if (view != null && !explicitTargetContainer && view.getContainer() != null && !container.equals(view.getContainer()))
             view = null;
 
         if (view != null && !replaceExisting && !StringUtils.isEmpty(name))
@@ -2631,7 +2630,7 @@ public class QueryController extends SpringActionController
                     try
                     {
                         view.delete(getUser(), getViewContext().getRequest());
-                        JSONObject ret = saveCustomView(container, queryDef, regionName, viewName, replaceExisting, share, inherit, session, saveFilter, hidden, jsonView, returnUrl, errors);
+                        JSONObject ret = saveCustomView(container, queryDef, regionName, viewName, replaceExisting, share, inherit, explicitTargetContainer, session, saveFilter, hidden, jsonView, returnUrl, errors);
                         success = !errors.hasErrors() && ret != null;
                         return success ? ret : null;
                     }
@@ -2776,9 +2775,10 @@ public class QueryController extends SpringActionController
                 boolean session = jsonView.optBoolean("session", false);
                 boolean hidden = jsonView.optBoolean("hidden", false);
                 // Users may save views to a location other than the current container
-                String containerPath = jsonView.optString("containerPath", getContainer().getPath());
+                String containerPath = jsonView.optString("containerPath", null);
+                boolean explicitTargetContainer = inherit && containerPath != null;
                 Container container;
-                if (inherit)
+                if (explicitTargetContainer)
                 {
                     // Only respect this request if it's a view that is inheritable in subfolders
                     container = ContainerManager.getForPath(containerPath);
@@ -2796,7 +2796,7 @@ public class QueryController extends SpringActionController
 
                 JSONObject savedView = saveCustomView(
                         container, queryDef, QueryView.DATAREGIONNAME_DEFAULT, viewName, replace,
-                        shared, inherit, session, true, hidden, jsonView, null, errors);
+                        shared, inherit, explicitTargetContainer, session, true, hidden, jsonView, null, errors);
 
                 if (savedView != null)
                 {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2560,11 +2560,17 @@ public class QueryController extends SpringActionController
 
         // GitHub Issue #899: the lookups above also resolve views inherited from ancestor folders. Absent an explicit
         // target folder, shadow that view with a new local one rather than editing (and relocating) the ancestor's.
+        CustomView inheritedView = null;
         if (view != null && !explicitTargetContainer && view.getContainer() != null && !container.equals(view.getContainer()))
+        {
+            inheritedView = view;
             view = null;
+        }
 
         if (view != null && !replaceExisting && !StringUtils.isEmpty(name))
             errors.reject(ERROR_MSG, "A saved view by the name \"" + viewName + "\" already exists. ");
+        else if (inheritedView != null && !replaceExisting && !StringUtils.isEmpty(name))
+            errors.reject(ERROR_MSG, "A saved view by the name \"" + viewName + "\" is already inherited from folder \"" + inheritedView.getContainer().getPath() + "\". ");
 
         // 11179: Allow editing the view if we're saving to session.
         // NOTE: Check for session flag first otherwise the call to canEdit() will add errors to the errors collection.
@@ -6268,11 +6274,16 @@ public class QueryController extends SpringActionController
 
                 // GitHub Issue #899: getCustomView() also resolves views inherited from ancestor folders. Absent an explicit
                 // target folder, shadow that view with a new local one instead of rewriting (and un-inheriting) the ancestor's.
+                CustomView inheritedView = null;
                 if (existingView != null && !explicitTargetContainer && existingView.getContainer() != null
                         && !container.equals(existingView.getContainer()))
                 {
+                    inheritedView = existingView;
                     existingView = null;
                 }
+
+                if (inheritedView != null && !form.isReplace() && !StringUtils.isEmpty(form.getNewName()))
+                    throw new IllegalArgumentException("A saved view by the name \"" + form.getNewName() + "\" is already inherited from folder \"" + inheritedView.getContainer().getPath() + "\". ");
 
                 // save a new private view if shared is false but existing view is shared
                 if (existingView != null && !form.isShared() && existingView.getOwner() == null)

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2531,6 +2531,38 @@ public class QueryController extends SpringActionController
         }
     }
 
+    /**
+     * GitHub Issue #899: custom view lookups also resolve views inherited from ancestor folders. Absent an explicit target
+     * folder, such a view must be shadowed by a new local one instead of rewritten (and un-inherited), so a name collision
+     * with an ancestor's view reports differently from one with a local view.
+     *
+     * @param localView the resolved view, null once it turns out to belong to an ancestor
+     * @param message a name-collision error, or null if the save may proceed
+     */
+    private record ResolvedViewName(CustomView localView, String message) {}
+
+    private static ResolvedViewName resolveViewName(CustomView existingView, String name, Container container,
+                                                    boolean inheritToTargetContainer, boolean replaceExisting)
+    {
+        CustomView inheritedView = null;
+        if (existingView != null && !inheritToTargetContainer && existingView.getContainer() != null
+                && !container.equals(existingView.getContainer()))
+        {
+            inheritedView = existingView;
+            existingView = null;
+        }
+
+        String message = null;
+        if (!replaceExisting && !StringUtils.isEmpty(name))
+        {
+            if (inheritedView != null)
+                message = "A saved view by the name \"" + name + "\" is already inherited from folder \"" + inheritedView.getContainer().getPath() + "\". ";
+            else if (existingView != null)
+                message = "A saved view by the name \"" + name + "\" already exists. ";
+        }
+        return new ResolvedViewName(existingView, message);
+    }
+
     // Uck. Supports the old and new view designer.
     protected JSONObject saveCustomView(Container container, QueryDefinition queryDef,
                                                  String regionName, String viewName, boolean replaceExisting,
@@ -2558,19 +2590,10 @@ public class QueryController extends SpringActionController
         else
             view = queryDef.getCustomView(owner, getViewContext().getRequest(), name);
 
-        // GitHub Issue #899: the lookups above also resolve views inherited from ancestor folders. Absent an explicit
-        // target folder, shadow that view with a new local one rather than editing (and relocating) the ancestor's.
-        CustomView inheritedView = null;
-        if (view != null && !inheritToTargetContainer && view.getContainer() != null && !container.equals(view.getContainer()))
-        {
-            inheritedView = view;
-            view = null;
-        }
-
-        if (view != null && !replaceExisting && !StringUtils.isEmpty(name))
-            errors.reject(ERROR_MSG, "A saved view by the name \"" + viewName + "\" already exists. ");
-        if (inheritedView != null && !replaceExisting && !StringUtils.isEmpty(name))
-            errors.reject(ERROR_MSG, "A saved view by the name \"" + viewName + "\" is already inherited from folder \"" + inheritedView.getContainer().getPath() + "\". ");
+        ResolvedViewName resolved = resolveViewName(view, name, container, inheritToTargetContainer, replaceExisting);
+        view = resolved.localView();
+        if (resolved.message() != null)
+            errors.reject(ERROR_MSG, resolved.message());
 
         // 11179: Allow editing the view if we're saving to session.
         // NOTE: Check for session flag first otherwise the call to canEdit() will add errors to the errors collection.
@@ -6281,21 +6304,10 @@ public class QueryController extends SpringActionController
                     existingView = null;
                 }
 
-                // GitHub Issue #899: getCustomView() also resolves views inherited from ancestor folders. Absent an explicit
-                // target folder, shadow that view with a new local one instead of rewriting (and un-inheriting) the ancestor's.
-                CustomView inheritedView = null;
-                if (existingView != null && !inheritToTargetContainer && existingView.getContainer() != null
-                        && !container.equals(existingView.getContainer()))
-                {
-                    inheritedView = existingView;
-                    existingView = null;
-                }
-
-                if (inheritedView != null && !form.isReplace() && !StringUtils.isEmpty(form.getNewName()))
-                    throw new IllegalArgumentException("A saved view by the name \"" + form.getNewName() + "\" is already inherited from folder \"" + inheritedView.getContainer().getPath() + "\". ");
-
-                if (existingView != null && !form.isReplace() && !StringUtils.isEmpty(form.getNewName()))
-                    throw new IllegalArgumentException("A saved view by the name \"" + form.getNewName() + "\" already exists. ");
+                ResolvedViewName resolved = resolveViewName(existingView, form.getNewName(), container, inheritToTargetContainer, form.isReplace());
+                existingView = resolved.localView();
+                if (resolved.message() != null)
+                    throw new IllegalArgumentException(resolved.message());
 
                 if (existingView == null || (existingView instanceof ModuleCustomView && existingView.isEditable()))
                 {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2534,7 +2534,7 @@ public class QueryController extends SpringActionController
     // Uck. Supports the old and new view designer.
     protected JSONObject saveCustomView(Container container, QueryDefinition queryDef,
                                                  String regionName, String viewName, boolean replaceExisting,
-                                                 boolean share, boolean inherit, boolean explicitTargetContainer,
+                                                 boolean share, boolean inherit, boolean inheritToTargetContainer,
                                                  boolean session, boolean saveFilter,
                                                  boolean hidden, JSONObject jsonView,
                                                  ActionURL returnUrl,
@@ -2561,7 +2561,7 @@ public class QueryController extends SpringActionController
         // GitHub Issue #899: the lookups above also resolve views inherited from ancestor folders. Absent an explicit
         // target folder, shadow that view with a new local one rather than editing (and relocating) the ancestor's.
         CustomView inheritedView = null;
-        if (view != null && !explicitTargetContainer && view.getContainer() != null && !container.equals(view.getContainer()))
+        if (view != null && !inheritToTargetContainer && view.getContainer() != null && !container.equals(view.getContainer()))
         {
             inheritedView = view;
             view = null;
@@ -2569,7 +2569,7 @@ public class QueryController extends SpringActionController
 
         if (view != null && !replaceExisting && !StringUtils.isEmpty(name))
             errors.reject(ERROR_MSG, "A saved view by the name \"" + viewName + "\" already exists. ");
-        else if (inheritedView != null && !replaceExisting && !StringUtils.isEmpty(name))
+        if (inheritedView != null && !replaceExisting && !StringUtils.isEmpty(name))
             errors.reject(ERROR_MSG, "A saved view by the name \"" + viewName + "\" is already inherited from folder \"" + inheritedView.getContainer().getPath() + "\". ");
 
         // 11179: Allow editing the view if we're saving to session.
@@ -2636,7 +2636,7 @@ public class QueryController extends SpringActionController
                     try
                     {
                         view.delete(getUser(), getViewContext().getRequest());
-                        JSONObject ret = saveCustomView(container, queryDef, regionName, viewName, replaceExisting, share, inherit, explicitTargetContainer, session, saveFilter, hidden, jsonView, returnUrl, errors);
+                        JSONObject ret = saveCustomView(container, queryDef, regionName, viewName, replaceExisting, share, inherit, inheritToTargetContainer, session, saveFilter, hidden, jsonView, returnUrl, errors);
                         success = !errors.hasErrors() && ret != null;
                         return success ? ret : null;
                     }
@@ -2782,9 +2782,9 @@ public class QueryController extends SpringActionController
                 boolean hidden = jsonView.optBoolean("hidden", false);
                 // Users may save views to a location other than the current container
                 String containerPath = jsonView.optString("containerPath", null);
-                boolean explicitTargetContainer = inherit && containerPath != null;
+                boolean inheritToTargetContainer = inherit && containerPath != null;
                 Container container;
-                if (explicitTargetContainer)
+                if (inheritToTargetContainer)
                 {
                     // Only respect this request if it's a view that is inheritable in subfolders
                     container = ContainerManager.getForPath(containerPath);
@@ -2800,9 +2800,12 @@ public class QueryController extends SpringActionController
                     throw new NotFoundException("No such container: " + containerPath);
                 }
 
+                if (inheritToTargetContainer && !container.hasPermission(getUser(), EditSharedViewPermission.class))
+                    throw new UnauthorizedException();
+
                 JSONObject savedView = saveCustomView(
                         container, queryDef, QueryView.DATAREGIONNAME_DEFAULT, viewName, replace,
-                        shared, inherit, explicitTargetContainer, session, true, hidden, jsonView, null, errors);
+                        shared, inherit, inheritToTargetContainer, session, true, hidden, jsonView, null, errors);
 
                 if (savedView != null)
                 {
@@ -6232,9 +6235,9 @@ public class QueryController extends SpringActionController
 
             // Users may save views to a location other than the current container
             String containerPath = form.getContainerPath();
-            boolean explicitTargetContainer = form.isInherit() && containerPath != null;
+            boolean inheritToTargetContainer = form.isInherit() && containerPath != null;
             Container container;
-            if (explicitTargetContainer)
+            if (inheritToTargetContainer)
             {
                 // Only respect this request if it's a view that is inheritable in subfolders
                 container = ContainerManager.getForPath(containerPath);
@@ -6272,10 +6275,16 @@ public class QueryController extends SpringActionController
                     existingView = form.getQueryDef().getCustomView(getUser(), null, form.getNewName());
                 }
 
+                // save a new private view if shared is false but existing view is shared
+                if (existingView != null && !form.isShared() && existingView.getOwner() == null)
+                {
+                    existingView = null;
+                }
+
                 // GitHub Issue #899: getCustomView() also resolves views inherited from ancestor folders. Absent an explicit
                 // target folder, shadow that view with a new local one instead of rewriting (and un-inheriting) the ancestor's.
                 CustomView inheritedView = null;
-                if (existingView != null && !explicitTargetContainer && existingView.getContainer() != null
+                if (existingView != null && !inheritToTargetContainer && existingView.getContainer() != null
                         && !container.equals(existingView.getContainer()))
                 {
                     inheritedView = existingView;
@@ -6284,12 +6293,6 @@ public class QueryController extends SpringActionController
 
                 if (inheritedView != null && !form.isReplace() && !StringUtils.isEmpty(form.getNewName()))
                     throw new IllegalArgumentException("A saved view by the name \"" + form.getNewName() + "\" is already inherited from folder \"" + inheritedView.getContainer().getPath() + "\". ");
-
-                // save a new private view if shared is false but existing view is shared
-                if (existingView != null && !form.isShared() && existingView.getOwner() == null)
-                {
-                    existingView = null;
-                }
 
                 if (existingView != null && !form.isReplace() && !StringUtils.isEmpty(form.getNewName()))
                     throw new IllegalArgumentException("A saved view by the name \"" + form.getNewName() + "\" already exists. ");


### PR DESCRIPTION
## Rationale
https://github.com/LabKey/internal-issues/issues/899

Saving a grid view from a subfolder currently resolves the view inherited from an ancestor folder, edits it in place, and then on save relocates it — so the subfolder save destroys the parent's inherited default. The fix threads a new explicitTargetContainer flag through both save actions: unless the caller explicitly named a target folder, an ancestor-owned view found by the lookup is discarded so a new local view shadows it instead. On the client, SaveViewModal stops offering/sending inherit outside the app home folder, and reads inherit/shared off the new server-supplied shadowed sub-object (a session view is never itself shared or inheritable, so its own flags were always wrong defaults).

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7974
- https://github.com/LabKey/labkey-ui-components/pull/2066
- https://github.com/LabKey/limsModules/pull/2427

## Changes
- Save grid view fix for saving/resolving inherited view when target folder provided