### PR TITLE
Plates: deprecate primary plate sets

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -30,6 +30,7 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.view.ActionURL;
 
 import java.sql.SQLException;
@@ -38,6 +39,7 @@ import java.util.List;
 public interface PlateService
 {
     long NO_RUNID = -1;
+    String DEPRECATE_PRIMARY_PLATE_SET_FLAG = "primaryPlateSets";
 
     class NameConflictException extends Exception
     {
@@ -271,5 +273,10 @@ public interface PlateService
          * @return A valid and complete ActionURL if the plate is recognized, or null if it is not.
          */
         ActionURL getDetailsURL(Plate plate);
+    }
+
+    static boolean isPrimaryPlateSetsEnabled()
+    {
+        return OptionalFeatureService.get().isFeatureEnabled(DEPRECATE_PRIMARY_PLATE_SET_FLAG);
     }
 }

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -201,6 +201,14 @@ public class AssayModule extends SpringModule
                 false,
                 false,
                 OptionalFeatureService.FeatureType.Deprecated));
+
+        OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(
+                PlateService.DEPRECATE_PRIMARY_PLATE_SET_FLAG,
+                "Allow for Primary Plate Sets to be created",
+                "Enables the creation of Primary Plate Sets. This option will be removed in a future release of LabKey Server.",
+                false,
+                false,
+                OptionalFeatureService.FeatureType.Deprecated));
     }
 
     @Override

--- a/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
@@ -23,6 +23,7 @@ import org.labkey.api.assay.DefaultAssayRunCreator;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateCustomField;
+import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateSetType;
 import org.labkey.api.assay.plate.PlateType;
@@ -77,6 +78,12 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
 
     public void generatePlateSets()
     {
+        if (!PlateService.isPrimaryPlateSetsEnabled())
+        {
+            _log.error("PlateSetDataGenerator is not able to generate plate sets when primary plate sets are disabled.");
+            return;
+        }
+
         Config config = getConfig();
         if (validateConfiguration(config))
         {

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -121,7 +121,6 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.sql.LabKeySql;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.PageFlowUtil;

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -121,6 +121,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.sql.LabKeySql;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.PageFlowUtil;
@@ -2886,6 +2887,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
         if (plateSet.getType() == null)
             plateSet.setType(PlateSetType.assay);
+        if (!PlateService.isPrimaryPlateSetsEnabled() && plateSet.getType() == PlateSetType.primary)
+            throw new ValidationException("The primary plate set feature is not enabled.");
 
         try (DbScope.Transaction tx = ensureTransaction())
         {

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateCustomField;
 import org.labkey.api.assay.plate.PlateLayoutHandler;
+import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateSetType;
 import org.labkey.api.assay.plate.PlateType;
@@ -55,6 +56,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
@@ -99,6 +101,7 @@ public final class PlateManagerTest
     private static Container container;
     private static ExpSampleType sampleType;
     private static User user;
+    private static boolean primaryPlateSetFlag;
 
     private enum PlateMetadataFields
     {
@@ -125,6 +128,10 @@ public final class PlateManagerTest
             newActiveModules.add(assayModule);
             container.setActiveModules(newActiveModules);
         }
+
+        // Configure optional feature flag
+        primaryPlateSetFlag = OptionalFeatureService.get().isFeatureEnabled(PlateService.DEPRECATE_PRIMARY_PLATE_SET_FLAG);
+        OptionalFeatureService.get().setFeatureEnabled(PlateService.DEPRECATE_PRIMARY_PLATE_SET_FLAG, true, user);
 
         Domain domain = PlateManager.get().getPlateMetadataDomain(container, user);
         if (domain != null)
@@ -201,9 +208,31 @@ public final class PlateManagerTest
     @AfterClass
     public static void cleanup()
     {
+        // Restore optional feature flag
+        OptionalFeatureService.get().setFeatureEnabled(PlateService.DEPRECATE_PRIMARY_PLATE_SET_FLAG, primaryPlateSetFlag, user);
+
         deleteTestContainer();
         container = null;
         user = null;
+    }
+
+    @Test
+    public void testDeprecatePrimaryPlateSetFlag()
+    {
+        try
+        {
+            OptionalFeatureService.get().setFeatureEnabled(PlateService.DEPRECATE_PRIMARY_PLATE_SET_FLAG, false, user);
+
+            PlateSetImpl plateSetImpl = new PlateSetImpl();
+            plateSetImpl.setType(PlateSetType.primary);
+            plateSetImpl.setName("testDeprecatePrimaryPlateSetFlag");
+
+            assertCreatePlateSetThrows("The primary plate set feature is not enabled.", plateSetImpl, null, null);
+        }
+        finally
+        {
+            OptionalFeatureService.get().setFeatureEnabled(PlateService.DEPRECATE_PRIMARY_PLATE_SET_FLAG, true, user);
+        }
     }
 
     @Test


### PR DESCRIPTION
#### Rationale
This puts creation of primary plate sets (PPS) under a deprecated feature flag. See [#1505](https://github.com/LabKey/internal-issues/issues/1505).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/1027
- https://github.com/LabKey/limsModules/pull/2429
- https://github.com/LabKey/platform/pull/7977

#### Changes
- Declare deprecated feature flag
- Respect flag setting
