### PR TITLE
Make ExperimentStressTest clean up after itself

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentStressTest.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentStressTest.java
@@ -17,6 +17,7 @@ package org.labkey.experiment.api;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -59,6 +60,12 @@ public class ExperimentStressTest
             LOG.info("deleting junit container");
             JunitUtil.deleteTestContainer();
         }
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        JunitUtil.deleteTestContainer();
     }
 
     private final Random random;


### PR DESCRIPTION
## Rationale
`ExperimentStressTest` periodically causes a cascade of deadlock and timeout failures when a subsequent test attempts to clean up the test folder. Adding a cleanup step to this test so that we will have a consistent failure point to track instead of it failing in whatever test happens to follow this one.

## Related Pull Requests
- N/A

## Changes
- Make ExperimentStressTest clean up after itself