### PR TITLE
GitHub Issue #696: Make Applying Filters to Custom Grid View More Apparent

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2366,9 +2366,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.2.tgz",
-      "integrity": "sha512-V+WMpeoAA9WGFg9+l+bF8waA1m3KJxVmgWBUBUsES3fQumhdQyAI9l2WzGJ9I5ZmJpfPCM3+zN+GJf6KNtVVog==",
+      "version": "7.59.1-fb-saveViewFilters696.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.3.tgz",
+      "integrity": "sha512-mNwK0EjvJjz4oYDwRu39CiHcw3Be3Z0vhZCERyZMy03bahZ/Nb1Ciofo0Yl1xDVDEi/f+bTEktfl/7svO2PHwA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.0"
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2366,9 +2366,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.0.tgz",
-      "integrity": "sha512-wV5Wtqrz/dOzMWD6XpVuantMha8fetCYOXB7S/Jz6QMt2uE9Fg23lfxYArKWDylm8ufMgEzi9hqDmYdeYM6xYg==",
+      "version": "7.59.1-fb-saveViewFilters696.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.1.tgz",
+      "integrity": "sha512-/sDJ568CxrQ76Dm1Ib80sti8/7MX3H7Olq4CAfSEs2vSHciPNXg+bwfJODHsNzf0lSnGi2FR+mCh+qP+IcYtaw==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
+        "@labkey/components": "7.60.0"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2366,9 +2366,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.3.tgz",
-      "integrity": "sha512-mNwK0EjvJjz4oYDwRu39CiHcw3Be3Z0vhZCERyZMy03bahZ/Nb1Ciofo0Yl1xDVDEi/f+bTEktfl/7svO2PHwA==",
+      "version": "7.60.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.60.0.tgz",
+      "integrity": "sha512-ZaTOtof5Pvf6BU6gxufH044qiRSDXsFKwFFtDojc/dLKZwcXiKQNfUd3Wv3QgoOoiRPuJ7eWO/nF8yFRiJIEDg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2366,9 +2366,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.1.tgz",
-      "integrity": "sha512-/sDJ568CxrQ76Dm1Ib80sti8/7MX3H7Olq4CAfSEs2vSHciPNXg+bwfJODHsNzf0lSnGi2FR+mCh+qP+IcYtaw==",
+      "version": "7.59.1-fb-saveViewFilters696.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.2.tgz",
+      "integrity": "sha512-V+WMpeoAA9WGFg9+l+bF8waA1m3KJxVmgWBUBUsES3fQumhdQyAI9l2WzGJ9I5ZmJpfPCM3+zN+GJf6KNtVVog==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package.json
+++ b/assay/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "eslint --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
+    "@labkey/components": "7.60.0"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "eslint --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "eslint --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.59.0"
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -15,7 +15,7 @@
     "lint-fix": "eslint --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.2",
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.3",
         "@labkey/themes": "1.9.5"
       },
       "devDependencies": {
@@ -2369,9 +2369,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.2.tgz",
-      "integrity": "sha512-V+WMpeoAA9WGFg9+l+bF8waA1m3KJxVmgWBUBUsES3fQumhdQyAI9l2WzGJ9I5ZmJpfPCM3+zN+GJf6KNtVVog==",
+      "version": "7.59.1-fb-saveViewFilters696.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.3.tgz",
+      "integrity": "sha512-mNwK0EjvJjz4oYDwRu39CiHcw3Be3Z0vhZCERyZMy03bahZ/Nb1Ciofo0Yl1xDVDEi/f+bTEktfl/7svO2PHwA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.1",
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.2",
         "@labkey/themes": "1.9.5"
       },
       "devDependencies": {
@@ -2369,9 +2369,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.1.tgz",
-      "integrity": "sha512-/sDJ568CxrQ76Dm1Ib80sti8/7MX3H7Olq4CAfSEs2vSHciPNXg+bwfJODHsNzf0lSnGi2FR+mCh+qP+IcYtaw==",
+      "version": "7.59.1-fb-saveViewFilters696.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.2.tgz",
+      "integrity": "sha512-V+WMpeoAA9WGFg9+l+bF8waA1m3KJxVmgWBUBUsES3fQumhdQyAI9l2WzGJ9I5ZmJpfPCM3+zN+GJf6KNtVVog==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.3",
+        "@labkey/components": "7.60.0",
         "@labkey/themes": "1.9.5"
       },
       "devDependencies": {
@@ -2369,9 +2369,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.3.tgz",
-      "integrity": "sha512-mNwK0EjvJjz4oYDwRu39CiHcw3Be3Z0vhZCERyZMy03bahZ/Nb1Ciofo0Yl1xDVDEi/f+bTEktfl/7svO2PHwA==",
+      "version": "7.60.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.60.0.tgz",
+      "integrity": "sha512-ZaTOtof5Pvf6BU6gxufH044qiRSDXsFKwFFtDojc/dLKZwcXiKQNfUd3Wv3QgoOoiRPuJ7eWO/nF8yFRiJIEDg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.0",
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.1",
         "@labkey/themes": "1.9.5"
       },
       "devDependencies": {
@@ -2369,9 +2369,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.0.tgz",
-      "integrity": "sha512-wV5Wtqrz/dOzMWD6XpVuantMha8fetCYOXB7S/Jz6QMt2uE9Fg23lfxYArKWDylm8ufMgEzi9hqDmYdeYM6xYg==",
+      "version": "7.59.1-fb-saveViewFilters696.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.1.tgz",
+      "integrity": "sha512-/sDJ568CxrQ76Dm1Ib80sti8/7MX3H7Olq4CAfSEs2vSHciPNXg+bwfJODHsNzf0lSnGi2FR+mCh+qP+IcYtaw==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package.json
+++ b/core/package.json
@@ -20,7 +20,7 @@
     "lint-branch-fix": "node lint.diff.mjs --currentBranch --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.59.0",
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.1",
     "@labkey/themes": "1.9.5"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -20,7 +20,7 @@
     "lint-branch-fix": "node lint.diff.mjs --currentBranch --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.1",
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.2",
     "@labkey/themes": "1.9.5"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -20,7 +20,7 @@
     "lint-branch-fix": "node lint.diff.mjs --currentBranch --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.2",
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.3",
     "@labkey/themes": "1.9.5"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -20,7 +20,7 @@
     "lint-branch-fix": "node lint.diff.mjs --currentBranch --fix"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.3",
+    "@labkey/components": "7.60.0",
     "@labkey/themes": "1.9.5"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2378,9 +2378,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.1.tgz",
-      "integrity": "sha512-/sDJ568CxrQ76Dm1Ib80sti8/7MX3H7Olq4CAfSEs2vSHciPNXg+bwfJODHsNzf0lSnGi2FR+mCh+qP+IcYtaw==",
+      "version": "7.59.1-fb-saveViewFilters696.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.2.tgz",
+      "integrity": "sha512-V+WMpeoAA9WGFg9+l+bF8waA1m3KJxVmgWBUBUsES3fQumhdQyAI9l2WzGJ9I5ZmJpfPCM3+zN+GJf6KNtVVog==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2378,9 +2378,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.2.tgz",
-      "integrity": "sha512-V+WMpeoAA9WGFg9+l+bF8waA1m3KJxVmgWBUBUsES3fQumhdQyAI9l2WzGJ9I5ZmJpfPCM3+zN+GJf6KNtVVog==",
+      "version": "7.59.1-fb-saveViewFilters696.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.3.tgz",
+      "integrity": "sha512-mNwK0EjvJjz4oYDwRu39CiHcw3Be3Z0vhZCERyZMy03bahZ/Nb1Ciofo0Yl1xDVDEi/f+bTEktfl/7svO2PHwA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
+        "@labkey/components": "7.60.0"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2378,9 +2378,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.3.tgz",
-      "integrity": "sha512-mNwK0EjvJjz4oYDwRu39CiHcw3Be3Z0vhZCERyZMy03bahZ/Nb1Ciofo0Yl1xDVDEi/f+bTEktfl/7svO2PHwA==",
+      "version": "7.60.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.60.0.tgz",
+      "integrity": "sha512-ZaTOtof5Pvf6BU6gxufH044qiRSDXsFKwFFtDojc/dLKZwcXiKQNfUd3Wv3QgoOoiRPuJ7eWO/nF8yFRiJIEDg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.0"
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -2378,9 +2378,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.0.tgz",
-      "integrity": "sha512-wV5Wtqrz/dOzMWD6XpVuantMha8fetCYOXB7S/Jz6QMt2uE9Fg23lfxYArKWDylm8ufMgEzi9hqDmYdeYM6xYg==",
+      "version": "7.59.1-fb-saveViewFilters696.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.1.tgz",
+      "integrity": "sha512-/sDJ568CxrQ76Dm1Ib80sti8/7MX3H7Olq4CAfSEs2vSHciPNXg+bwfJODHsNzf0lSnGi2FR+mCh+qP+IcYtaw==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
+    "@labkey/components": "7.60.0"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.59.0"
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.2.tgz",
-      "integrity": "sha512-V+WMpeoAA9WGFg9+l+bF8waA1m3KJxVmgWBUBUsES3fQumhdQyAI9l2WzGJ9I5ZmJpfPCM3+zN+GJf6KNtVVog==",
+      "version": "7.59.1-fb-saveViewFilters696.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.3.tgz",
+      "integrity": "sha512-mNwK0EjvJjz4oYDwRu39CiHcw3Be3Z0vhZCERyZMy03bahZ/Nb1Ciofo0Yl1xDVDEi/f+bTEktfl/7svO2PHwA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
+        "@labkey/components": "7.60.0"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.3.tgz",
-      "integrity": "sha512-mNwK0EjvJjz4oYDwRu39CiHcw3Be3Z0vhZCERyZMy03bahZ/Nb1Ciofo0Yl1xDVDEi/f+bTEktfl/7svO2PHwA==",
+      "version": "7.60.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.60.0.tgz",
+      "integrity": "sha512-ZaTOtof5Pvf6BU6gxufH044qiRSDXsFKwFFtDojc/dLKZwcXiKQNfUd3Wv3QgoOoiRPuJ7eWO/nF8yFRiJIEDg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.1-fb-saveViewFilters696.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.1.tgz",
-      "integrity": "sha512-/sDJ568CxrQ76Dm1Ib80sti8/7MX3H7Olq4CAfSEs2vSHciPNXg+bwfJODHsNzf0lSnGi2FR+mCh+qP+IcYtaw==",
+      "version": "7.59.1-fb-saveViewFilters696.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.2.tgz",
+      "integrity": "sha512-V+WMpeoAA9WGFg9+l+bF8waA1m3KJxVmgWBUBUsES3fQumhdQyAI9l2WzGJ9I5ZmJpfPCM3+zN+GJf6KNtVVog==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "7.59.0"
+        "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
       },
       "devDependencies": {
         "@labkey/build": "10.1.2",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "7.59.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.0.tgz",
-      "integrity": "sha512-wV5Wtqrz/dOzMWD6XpVuantMha8fetCYOXB7S/Jz6QMt2uE9Fg23lfxYArKWDylm8ufMgEzi9hqDmYdeYM6xYg==",
+      "version": "7.59.1-fb-saveViewFilters696.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-7.59.1-fb-saveViewFilters696.1.tgz",
+      "integrity": "sha512-/sDJ568CxrQ76Dm1Ib80sti8/7MX3H7Olq4CAfSEs2vSHciPNXg+bwfJODHsNzf0lSnGi2FR+mCh+qP+IcYtaw==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production rspack build --config node_modules/@labkey/build/configs/prod.config.js"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production rspack build --config node_modules/@labkey/build/configs/prod.config.js"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.2"
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production rspack build --config node_modules/@labkey/build/configs/prod.config.js"
   },
   "dependencies": {
-    "@labkey/components": "7.59.1-fb-saveViewFilters696.3"
+    "@labkey/components": "7.60.0"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production rspack build --config node_modules/@labkey/build/configs/prod.config.js"
   },
   "dependencies": {
-    "@labkey/components": "7.59.0"
+    "@labkey/components": "7.59.1-fb-saveViewFilters696.1"
   },
   "devDependencies": {
     "@labkey/build": "10.1.2",


### PR DESCRIPTION
## Rationale
https://github.com/LabKey/internal-issues/issues/696

App grid filter updates to makes it obvious that saving a grid view includes the current set of filters and sorts. Read-only (saved-with-view) filter pills in the grid message bar are greyed and get a hover popover explaining why they can't be edited. The Save Grid View modal replaces the easy-to-miss "Columns, sort order, and filters will be saved" sentence with two labelled sections listing the actual filter and sort pills that will be persisted, with empty-state messages when there are none.

## Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/2068
- https://github.com/LabKey/limsModules/pull/2433
- https://github.com/LabKey/platform/pull/7987
- https://github.com/LabKey/testAutomation/pull/3177

## Changes
- update @labkey/components package version