### PR TITLE
Don't suppress derivation errors during import

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -1285,6 +1285,7 @@ public class ExpDataIterators
                 catch (ValidationException e)
                 {
                     getErrors().addRowError(e);
+                    throw getErrors();
                 }
             }
             return hasNext;


### PR DESCRIPTION
## Rationale
If an error happened during derivation, sample import fails with "This connection has already been closed" error, which is not helpful for troubleshoot. 

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7988
- https://github.com/LabKey/limsModules/pull/2436

## Changes
- throw error on derivation exception

## Tasks
- [x] Claude Code Review
- [x] Manual Testing  - not needed
- [x] Test Automation
- [ ] Verify Fix @labkey-hannah 