### PR TITLE
1350: check if model is ready for AI features

### DIFF
--- a/api/src/org/labkey/api/mcp/AbstractAgentAction.java
+++ b/api/src/org/labkey/api/mcp/AbstractAgentAction.java
@@ -83,7 +83,7 @@ public abstract class AbstractAgentAction<F extends PromptForm> extends ReadOnly
     @Override
     public void validateForm(F form, Errors errors)
     {
-        if (!McpService.get().isAIFeaturesEnabled())
+        if (!McpService.get().isAIFeaturesReady())
         {
             errors.reject(ERROR_GENERIC, "Agent actions are not available.");
             return;

--- a/api/src/org/labkey/api/mcp/McpService.java
+++ b/api/src/org/labkey/api/mcp/McpService.java
@@ -152,10 +152,12 @@ public interface McpService extends ToolCallbackProvider
 
     boolean isReady();
 
-    // Convenience for in-product AI features: the AI feature flag is on AND the service has started.
+    boolean isModelReady();
+
+    // Convenience for in-product AI features: the AI feature flag is on, the service is ready, and the model is ready.
     default boolean isAIFeaturesReady()
     {
-        return isAIFeaturesEnabled() && isReady();
+        return isAIFeaturesEnabled() && isReady() && isModelReady();
     }
 
     // Register MCPs in Module.startup()

--- a/api/src/org/labkey/api/mcp/NoopMcpService.java
+++ b/api/src/org/labkey/api/mcp/NoopMcpService.java
@@ -55,6 +55,12 @@ class NoopMcpService implements McpService
     }
 
     @Override
+    public boolean isModelReady()
+    {
+        return false;
+    }
+
+    @Override
     public void registerTools(@NotNull List<ToolCallback> tools, McpImpl mcp)
     {
     }


### PR DESCRIPTION
## Rationale
This addresses [#1350](https://github.com/LabKey/internal-issues/issues/1350) by refining the logic that determines if the LLM is available and ready for servicing features.

## Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/731

## Changes
- Introduce interface for `isModelReady()` to distinguish when the LLM model is ready from the MCP server being ready.
- Gate `isAIFeaturesReady()` by `isModelReady()`