### PR TITLE
GitHub Issue 1509, 1510 & 1511: Workflow performance issues with large number of samples

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -247,6 +247,8 @@ public interface SampleTypeService
 
     void addAuditEvent(User user, Container container, String comment, String userComment, ExpMaterial sample, Map<String, Object> metadata, String updateType);
 
+    void addAuditEvents(User user, Container container, String comment, String userComment, Collection<? extends ExpMaterial> samples, Map<String, Object> metadata);
+
     // find the max sequence number with '${sampleName}-' prefix
     long getMaxAliquotId(@NotNull String sampleName, @NotNull String sampleTypeLsid, Container container);
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1375,6 +1375,15 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     @Override
+    public void addAuditEvents(User user, Container container, String comment, String userComment, Collection<? extends ExpMaterial> samples, Map<String, Object> metadata)
+    {
+        List<SampleTimelineAuditEvent> events = samples.stream()
+                .map(sample -> createAuditRecord(container, comment, userComment, sample, metadata))
+                .collect(Collectors.toList());
+        AuditLogService.get().addEvents(user, events);
+    }
+
+    @Override
     public long getMaxAliquotId(@NotNull String sampleName, @NotNull String sampleTypeLsid, Container container)
     {
         long max = 0;


### PR DESCRIPTION
## Rationale
When job creation and certain update events, a SampleTimelineEvent is created for each sample that's associated with this job. When a job has a large number of samples, the audit log creation can be costly. This PR adds util to support batch sample audit log creation.

## Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/1029
- https://github.com/LabKey/platform/pull/7992
- https://github.com/LabKey/limsModules/pull/2439

## Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
## Tasks
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->