### PR TITLE
Postgres dialect and PIVOT fixes surfaced by the SNPRC migration

### DIFF
--- a/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
@@ -1133,6 +1133,8 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
             return formatFunction(call, nativeFn, arguments);
         else if (fn.equalsIgnoreCase("timestampdiff"))
             return timestampdiff(arguments);
+        else if (fn.equalsIgnoreCase("week"))
+            return week(arguments);
         else
             return super.formatJdbcFunction(fn, arguments);
     }
@@ -1171,6 +1173,24 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
             return epoch.append("/3600.0");
 
         return super.formatJdbcFunction("timestampdiff", arguments);
+    }
+
+    /* week() inconsistent between sql server and postgres: pgjdbc translates {fn week(x)} to
+     * EXTRACT(WEEK FROM x), which returns ISO 8601 week numbering (week 1 contains the year's
+     * first Thursday; weeks start on Monday). The Microsoft SQL Server JDBC driver translates
+     * {fn week(x)} to DATEPART(week, x), which uses US-style numbering (week 1 always contains
+     * Jan 1; weeks start on Sunday under the default DATEFIRST=7). The two agree most of the
+     * year but disagree by 1 on Sundays and around year boundaries. Emit an equivalent US-style
+     * expression here so LabKey SQL's week() returns matching values on both databases.
+     */
+    private SQLFragment week(SQLFragment... arguments)
+    {
+        SQLFragment ret = new SQLFragment("CAST(FLOOR((EXTRACT(doy FROM ");
+        ret.append(arguments[0]);
+        ret.append(") + EXTRACT(dow FROM date_trunc('year', ");
+        ret.append(arguments[0]);
+        ret.append(")) - 1) / 7) + 1 AS INTEGER)");
+        return ret;
     }
 
     @Override

--- a/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
@@ -937,8 +937,11 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     @Override
     public SQLFragment isNumericExpr(SQLFragment expression)
     {
-        return new SQLFragment("(CASE WHEN CAST((").append(expression)
-                .append(") AS TEXT) ~ '^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$' THEN 1 ELSE 0 END)");
+        // Return a boolean predicate, matching SQL Server's contract, so callers that place this in a
+        // boolean context (CASE WHEN, WHERE) get valid Postgres syntax. In SELECT position Postgres
+        // returns it as a boolean column and JDBC's getInt() converts true/false to 1/0.
+        return new SQLFragment("(CAST((").append(expression)
+                .append(") AS TEXT) ~ '^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$')");
     }
 
     private class PostgreSqlColumnMetaDataReader extends ColumnMetaDataReader

--- a/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
@@ -937,9 +937,7 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     @Override
     public SQLFragment isNumericExpr(SQLFragment expression)
     {
-        // Return a boolean predicate, matching SQL Server's contract, so callers that place this in a
-        // boolean context (CASE WHEN, WHERE) get valid Postgres syntax. In SELECT position Postgres
-        // returns it as a boolean column and JDBC's getInt() converts true/false to 1/0.
+        // A boolean predicate, not 1/0, to match SQL Server's contract; in SELECT position JDBC's getInt() converts true/false to 1/0.
         return new SQLFragment("(CAST((").append(expression)
                 .append(") AS TEXT) ~ '^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$')");
     }
@@ -1175,14 +1173,8 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
         return super.formatJdbcFunction("timestampdiff", arguments);
     }
 
-    /* week() inconsistent between sql server and postgres: pgjdbc translates {fn week(x)} to
-     * EXTRACT(WEEK FROM x), which returns ISO 8601 week numbering (week 1 contains the year's
-     * first Thursday; weeks start on Monday). The Microsoft SQL Server JDBC driver translates
-     * {fn week(x)} to DATEPART(week, x), which uses US-style numbering (week 1 always contains
-     * Jan 1; weeks start on Sunday under the default DATEFIRST=7). The two agree most of the
-     * year but disagree by 1 on Sundays and around year boundaries. Emit an equivalent US-style
-     * expression here so LabKey SQL's week() returns matching values on both databases.
-     */
+    // pgjdbc translates {fn week(x)} to EXTRACT(WEEK FROM x) -- ISO 8601, weeks start Monday -- while the SQL Server
+    // driver emits DATEPART(week, x) -- US-style, weeks start Sunday. Emit US-style so both databases agree.
     private SQLFragment week(SQLFragment... arguments)
     {
         SQLFragment ret = new SQLFragment("CAST(FLOOR((EXTRACT(doy FROM ");

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3786,9 +3786,8 @@ public class QueryServiceImpl implements QueryService
         @Test
         public void testRightAndIsnumeric() throws SQLException
         {
-            // Portable LabKey-SQL functions: right() dispatches via the JDBC {fn right} escape;
-            // isnumeric() returns a boolean predicate on both -- (ISNUMERIC(x) = 1) on SQL Server, a regex match on PostgreSQL.
-            // This test exercises both against whichever dialect the test container is using.
+            // Portable LabKey-SQL functions: right() dispatches via the JDBC {fn right} escape; isnumeric() is a
+            // boolean predicate on both -- (ISNUMERIC(x) = 1) on SQL Server, a regex match on PostgreSQL.
             String sql =
                 "SELECT " +
                 "  right('hello', 2) AS r1, " +

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3820,5 +3820,47 @@ public class QueryServiceImpl implements QueryService
                 assertEquals("isnumeric(NULL) on " + dialect, 0, results.getInt("n4"));
             }
         }
+
+        @Test
+        public void testWeek() throws SQLException
+        {
+            // week() must return SQL Server's US numbering on both platforms: weeks start Sunday, and week 1 is
+            // whatever week contains Jan 1. pgjdbc expands {fn week} to ISO 8601 -- Monday start, week 1 anchored
+            // on the year's first Thursday -- so BasePostgreSqlDialect intercepts it rather than deferring.
+            //
+            // The two rules diverge independently, and how they combine depends on the day Jan 1 falls on, so a
+            // single year badly understates the difference. 2026 (Jan 1 = Thursday) agrees with ISO except on
+            // Sundays; 2027 (Jan 1 = Friday) is off by one every day, and ISO assigns 2027-01-01 to week 53 of
+            // the prior year. Both are covered below; do not reduce this to a mid-year sample.
+            String sql =
+                "SELECT " +
+                "  week(CAST('2026-01-01 00:00:00' AS TIMESTAMP)) AS w1, " +   // Thursday -> 1
+                "  week(CAST('2026-01-03 00:00:00' AS TIMESTAMP)) AS w2, " +   // Saturday -> 1
+                "  week(CAST('2026-01-04 00:00:00' AS TIMESTAMP)) AS w3, " +   // Sunday   -> 2   (ISO gives 1)
+                "  week(CAST('2027-01-01 00:00:00' AS TIMESTAMP)) AS w4, " +   // Friday   -> 1   (ISO gives 53)
+                "  week(CAST('2027-07-15 00:00:00' AS TIMESTAMP)) AS w5 " +    // Thursday -> 29  (ISO gives 28)
+                "FROM core.Containers";
+
+            QueryDef qd = new QueryDef();
+            qd.setSchema("core");
+            qd.setName("junit" + GUID.makeHash());
+            qd.setContainer(JunitUtil.getTestContainer().getId());
+            qd.setSql(sql);
+            QueryDefinition qdef = new CustomQueryDefinitionImpl(TestContext.get().getUser(), JunitUtil.getTestContainer(), qd);
+            List<QueryException> errors = new ArrayList<>();
+            TableInfo t = qdef.getTable(errors, false);
+            String dialect = t == null ? "?" : t.getSqlDialect().getProductName();
+            assertTrue("Query parse errors on " + dialect + ": " + errors, errors.isEmpty());
+
+            try (Results results = new TableSelector(t).getResults())
+            {
+                assertTrue("Expected at least one row from core.Containers", results.next());
+                assertEquals("week(2026-01-01), Thursday, on " + dialect, 1, results.getInt("w1"));
+                assertEquals("week(2026-01-03), Saturday, on " + dialect, 1, results.getInt("w2"));
+                assertEquals("week(2026-01-04), Sunday, on " + dialect, 2, results.getInt("w3"));
+                assertEquals("week(2027-01-01), Friday, on " + dialect, 1, results.getInt("w4"));
+                assertEquals("week(2027-07-15), Fri-Sun-anchored year, on " + dialect, 29, results.getInt("w5"));
+            }
+        }
     }
 }

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3787,7 +3787,7 @@ public class QueryServiceImpl implements QueryService
         public void testRightAndIsnumeric() throws SQLException
         {
             // Portable LabKey-SQL functions: right() dispatches via the JDBC {fn right} escape;
-            // isnumeric() emits ISNUMERIC(x) on SQL Server and a regex-based CASE on PostgreSQL.
+            // isnumeric() returns a boolean predicate on both -- (ISNUMERIC(x) = 1) on SQL Server, a regex match on PostgreSQL.
             // This test exercises both against whichever dialect the test container is using.
             String sql =
                 "SELECT " +

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3824,14 +3824,15 @@ public class QueryServiceImpl implements QueryService
         @Test
         public void testWeek() throws SQLException
         {
-            // week() must return SQL Server's US numbering on both platforms: weeks start Sunday, and week 1 is
-            // whatever week contains Jan 1. pgjdbc expands {fn week} to ISO 8601 -- Monday start, week 1 anchored
-            // on the year's first Thursday -- so BasePostgreSqlDialect intercepts it rather than deferring.
+            // Verifies week() returns the same number on both platforms.
             //
-            // The two rules diverge independently, and how they combine depends on the day Jan 1 falls on, so a
-            // single year badly understates the difference. 2026 (Jan 1 = Thursday) agrees with ISO except on
-            // Sundays; 2027 (Jan 1 = Friday) is off by one every day, and ISO assigns 2027-01-01 to week 53 of
-            // the prior year. Both are covered below; do not reduce this to a mid-year sample.
+            // pgjdbc expands {fn week} to ISO 8601 numbering (weeks start Monday, week 1 holds the year's first
+            // Thursday) where SQL Server uses US numbering (weeks start Sunday, week 1 holds Jan 1), so the two
+            // disagreed. BasePostgreSqlDialect.formatJdbcFunction now emits the US form instead of deferring to
+            // the driver.
+            //
+            // The dates cover both rule differences and the year boundary; a mid-year sample in a year whose
+            // Jan 1 falls Mon-Thu passes either way.
             String sql =
                 "SELECT " +
                 "  week(CAST('2026-01-01 00:00:00' AS TIMESTAMP)) AS w1, " +   // Thursday -> 1

--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -1076,9 +1076,11 @@ public abstract class Method
         }
     }
 
-    // Portable isnumeric() emits ISNUMERIC(x) on SQL Server and a regex-based CASE on PostgreSQL.
-    // Returns 1 for digit strings with an optional sign/decimal point, 0 otherwise.
-    // This is stricter than SQL Server's ISNUMERIC(), which also accepts formats like scientific notation.
+    // Portable isnumeric() returns a boolean predicate on both databases, so it is valid in a boolean
+    // context (CASE WHEN, WHERE) as well as in a SELECT list: (ISNUMERIC(x) = 1) on SQL Server, and a
+    // regex match on PostgreSQL. True for digit strings with an optional sign/decimal point.
+    // The PostgreSQL regex is stricter than SQL Server's ISNUMERIC(), which also accepts formats like
+    // scientific notation and currency.
     static class IsNumericInfo extends AbstractMethodInfo
     {
         IsNumericInfo()

--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -1076,11 +1076,9 @@ public abstract class Method
         }
     }
 
-    // Portable isnumeric() returns a boolean predicate on both databases, so it is valid in a boolean
-    // context (CASE WHEN, WHERE) as well as in a SELECT list: (ISNUMERIC(x) = 1) on SQL Server, and a
-    // regex match on PostgreSQL. True for digit strings with an optional sign/decimal point.
-    // The PostgreSQL regex is stricter than SQL Server's ISNUMERIC(), which also accepts formats like
-    // scientific notation and currency.
+    // Portable isnumeric() is a boolean predicate on both databases -- (ISNUMERIC(x) = 1) on SQL Server, a regex
+    // match on PostgreSQL -- so it is valid in CASE WHEN and WHERE, not just a SELECT list. The PostgreSQL regex
+    // accepts only digits with an optional sign/decimal point, stricter than SQL Server's ISNUMERIC().
     static class IsNumericInfo extends AbstractMethodInfo
     {
         IsNumericInfo()

--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -551,7 +551,7 @@ public class QueryPivot extends AbstractQueryRelation
 
                         String pivotName = makePivotAggName(name, pivotValue);
                         RelationColumn pvt = _makePivotedAggColumn(s, new FieldKey(null, pivotName), pivotValue);
-                        // _makePivotedAggColumn() returns null when parse errors are present; don't store nulls
+                        // _makePivotedAggColumn() returns null when parse errors are present
                         if (null != pvt)
                             _columns.put(pivotName, pvt);
                         else
@@ -560,10 +560,9 @@ public class QueryPivot extends AbstractQueryRelation
                 }
             }
 
-            // Returning a silently short column list is harder to diagnose than the error that caused it, so
-            // surface the underlying parse error the way getSql() and getColMembers() do. Only fires when a
-            // column was actually dropped, so the complete-column path is unaffected. _columns is discarded
-            // first: it is cached, and a partial map would be handed out unguarded on any subsequent call.
+            // A silently short column list is harder to diagnose than the parse error behind it, so throw the way
+            // getSql() and getColMembers() do. Discard the cached _columns first, or the partial map gets handed
+            // out unguarded on the next call.
             if (droppedColumn && !getParseErrors().isEmpty())
             {
                 _columns = null;
@@ -845,12 +844,9 @@ public class QueryPivot extends AbstractQueryRelation
                 }
                 else
                 {
-                    // Bind the pivot value as a parameter instead of embedding it directly in the SQL.
-                    // This safely handles values containing characters like ';' or quotes.
-                    //
-                    // Use an explicit JdbcType so Postgres can determine the parameter type.
-                    // Prefer the pivot column's type, especially for date/timestamp columns, to avoid
-                    // type mismatch errors. Fall back to the constant's type if conversion isn't possible.
+                    // Bind rather than embed the source text: a value containing ';' or a quote trips SQLFragment's guardrail.
+                    // Postgres needs an explicit parameter type, and wrapConstant() types date/timestamp pivot values as
+                    // QString, so prefer the pivot column's type and fall back to the constant's if it won't convert.
                     Object bindValue = ((IConstant) value).getValue();
                     JdbcType bindType = ((QExpr) value).getJdbcType();
                     JdbcType columnType = _pivotColumn.getJdbcType();

--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.query.sql;
 
+import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -829,14 +830,29 @@ public class QueryPivot extends AbstractQueryRelation
                 }
                 else
                 {
-                    // Bind the pivot value as a parameter rather than embedding its source-text literal.
-                    // Embedding via getSourceText() trips SQLFragment's semicolon/quote guardrail when the
-                    // value contains ';' or unbalanced '"' (both legal inside SQL string literals, but the
-                    // guardrail can't distinguish them from unsafe raw SQL).
-                    // Bind with an explicit JdbcType so Postgres can resolve the parameter's type — an
-                    // untyped bind can trip "could not determine data type of parameter $N" in some plans.
+                    // Bind the pivot value as a parameter instead of embedding it directly in the SQL.
+                    // This safely handles values containing characters like ';' or quotes.
+                    //
+                    // Use an explicit JdbcType so Postgres can determine the parameter type.
+                    // Prefer the pivot column's type, especially for date/timestamp columns, to avoid
+                    // type mismatch errors. Fall back to the constant's type if conversion isn't possible.
+                    Object bindValue = ((IConstant) value).getValue();
+                    JdbcType bindType = ((QExpr) value).getJdbcType();
+                    JdbcType columnType = _pivotColumn.getJdbcType();
+                    if (null != columnType && JdbcType.OTHER != columnType && columnType != bindType)
+                    {
+                        try
+                        {
+                            bindValue = columnType.convert(bindValue);
+                            bindType = columnType;
+                        }
+                        catch (ConversionException ignored)
+                        {
+                            // keep the constant's own type and value
+                        }
+                    }
                     sql.append("=?");
-                    sql.add(((IConstant) value).getValue(), ((QExpr) value).getJdbcType());
+                    sql.add(bindValue, bindType);
                 }
                 sql.append(") THEN (").append(col.getValueSql()).append(") ELSE NULL END) AS ").appendIdentifier(alias);
                 comma = ",\n";

--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -539,6 +539,7 @@ public class QueryPivot extends AbstractQueryRelation
             }
 
             // Add the pivoted aggregate columns grouped by pivot value
+            boolean droppedColumn = false;
             if (!aggs.isEmpty())
             {
                 for (String pivotValue : pivotValues.keySet())
@@ -553,8 +554,22 @@ public class QueryPivot extends AbstractQueryRelation
                         // _makePivotedAggColumn() returns null when parse errors are present; don't store nulls
                         if (null != pvt)
                             _columns.put(pivotName, pvt);
+                        else
+                            droppedColumn = true;
                     }
                 }
+            }
+
+            // Returning a silently short column list is harder to diagnose than the error that caused it, so
+            // surface the underlying parse error the way getSql() and getColMembers() do. Only fires when a
+            // column was actually dropped, so the complete-column path is unaffected. _columns is discarded
+            // first: it is cached, and a partial map would be handed out unguarded on any subsequent call.
+            if (droppedColumn && !getParseErrors().isEmpty())
+            {
+                _columns = null;
+                QueryException qe = getParseErrors().get(0);
+                _query.decorateException(qe);
+                throw qe;
             }
         }
         return _columns;

--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -549,7 +549,9 @@ public class QueryPivot extends AbstractQueryRelation
 
                         String pivotName = makePivotAggName(name, pivotValue);
                         RelationColumn pvt = _makePivotedAggColumn(s, new FieldKey(null, pivotName), pivotValue);
-                        _columns.put(pivotName, pvt);
+                        // _makePivotedAggColumn() returns null when parse errors are present; don't store nulls
+                        if (null != pvt)
+                            _columns.put(pivotName, pvt);
                     }
                 }
             }
@@ -822,9 +824,20 @@ public class QueryPivot extends AbstractQueryRelation
                 String alias = makePivotColumnAlias(col.getAlias(), pivotValue.getKey());
                 sql.append(comma).append("MAX(CASE WHEN (").append(_pivotColumn.getValueSql());
                 if (value instanceof QNull)
+                {
                     sql.append(" IS NULL");
+                }
                 else
-                    sql.append("=").append(value.getSourceText());
+                {
+                    // Bind the pivot value as a parameter rather than embedding its source-text literal.
+                    // Embedding via getSourceText() trips SQLFragment's semicolon/quote guardrail when the
+                    // value contains ';' or unbalanced '"' (both legal inside SQL string literals, but the
+                    // guardrail can't distinguish them from unsafe raw SQL).
+                    // Bind with an explicit JdbcType so Postgres can resolve the parameter's type — an
+                    // untyped bind can trip "could not determine data type of parameter $N" in some plans.
+                    sql.append("=?");
+                    sql.add(((IConstant) value).getValue(), ((QExpr) value).getJdbcType());
+                }
                 sql.append(") THEN (").append(col.getValueSql()).append(") ELSE NULL END) AS ").appendIdentifier(alias);
                 comma = ",\n";
             }


### PR DESCRIPTION
#### Rationale

Migrating the SNPRC EHR deployment from SQL Server to Postgres called for a handful of adjustments in shared platform code so that LabKey SQL produces matching results on both databases. Where the two backends legitimately differ, nothing shared is redefined: `week()` still defers to the driver, with its two possible numbering schemes now available as explicit functions, and `isnumeric()` keeps its 1/0 contract. The PIVOT changes concern how a pivot value reaches the generated SQL rather than either database in particular. These came up through SNPRC's queries rather than through general use, and each change is a no-op for queries that already produce matching results.

#### Related Pull Requests
- https://github.com/LabKey/snprcEHRModules/pull/990
- https://github.com/LabKey/testAutomation/pull/3187
- https://github.com/LabKey/premiumModules/pull/745

#### Changes

- **Two explicit week numbering functions** — `weekiso()` (ISO 8601, 1 to 53) and `weekus()` (US, 1 to 54), defined by LabKey on both dialects instead of by whichever expression a driver picks for `{fn week(x)}`. `week()` itself is untouched: it has been a passthrough since 2010, and the shared `ehr_lookups.dateRange`, `ehr_lookups.next30Days` and `ldk.dateRange` lookups all read it, so redefining it would have silently shifted `WeekOfYear` for every existing Postgres deployment. SNPRC overrides its own copies of those three lookups to call `weekus()`. The SQL Server implementations live in `premiumModules`.
- **`isnumeric()` returns 1/0 on both databases** — SQL Server resolves it to the `mssqlMethods` passthrough, Postgres to a regex-based `CASE`, so callers compare it with `= 1`. Matching changes in `premiumModules` and `snprcEHRModules`.
- **A pivot value is emitted as a dialect-quoted literal** — the value is a constant, so it writes itself into the generated SQL the way every other expression node does, rather than having its LabKey SQL source text spliced in on the assumption that anything which parsed is safe to emit.
- **A pivot no longer stores a null column** — `_makePivotedAggColumn()` returns null whenever parse errors are present, and that null was going into the column map.
