### PR TITLE
Correctly associate async queries with the HTTP request for Datadog

### DIFF
--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -17,9 +17,12 @@
 package org.labkey.api.data;
 
 import datadog.trace.api.CorrelationIdentifier;
+import datadog.trace.api.DDTags;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
+import io.opentracing.log.Fields;
+import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -39,6 +42,7 @@ import jakarta.servlet.http.HttpServletResponseWrapper;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 public class AsyncQueryRequest<T>
@@ -52,16 +56,20 @@ public class AsyncQueryRequest<T>
     @Nullable
     private final StackTraceElement[] _creationStackTrace;
     private final HttpServletResponse _rootResponse;
+    /** Names the APM span; without it every async query aggregates under the bare operation name */
+    private final @Nullable String _resourceName;
 
     boolean _cancelled;
     @Nullable Statement _statement;
+    @Nullable Span _span;
 
     T _result;
     Throwable _exception;
 
-    public AsyncQueryRequest(HttpServletResponse response)
+    public AsyncQueryRequest(HttpServletResponse response, @Nullable String resourceName)
     {
         _creationStackTrace = MiniProfiler.getTroubleshootingStackTrace();
+        _resourceName = resourceName;
 
         _rootResponse = getRootResponse(response);
     }
@@ -103,29 +111,33 @@ public class AsyncQueryRequest<T>
         final Object state = qs.cloneEnvironment();
         final RequestInfo current = MemTracker.getInstance().current();
 
-        String traceId = CorrelationIdentifier.getTraceId();
-
         // Create the span, so we can connect the async query with its owning thread
         final Tracer tracer = GlobalTracer.get();
         final Span span = tracer.buildSpan("AsyncRequest").start();
-        String spanId = CorrelationIdentifier.getSpanId();
+        if (_resourceName != null)
+            span.setTag(DDTags.RESOURCE_NAME, _resourceName);
+        _span = span;
 
         Runnable runnable = () -> {
             if (current != null)
                  MemTracker.get().startProfiler("async query");
 
             assert ThreadContext.isEmpty();  // Prevent/detect leaks
-            // Connect log messages with the active trace and span
-            ThreadContext.put(CorrelationIdentifier.getTraceIdKey(), traceId);
-            ThreadContext.put(CorrelationIdentifier.getSpanIdKey(), spanId);
 
             qs.copyEnvironment(state);
-            try
+            // Activate on this thread, not the caller's, or the JDBC integration starts a new trace instead of parenting here
+            try (Scope ignored = tracer.activateSpan(span))
             {
+                // Connect log messages with the active trace and span
+                ThreadContext.put(CorrelationIdentifier.getTraceIdKey(), CorrelationIdentifier.getTraceId());
+                ThreadContext.put(CorrelationIdentifier.getSpanIdKey(), CorrelationIdentifier.getSpanId());
+
                 setResult(callable.call());
             }
             catch (Throwable t)
             {
+                Tags.ERROR.set(span, true);
+                span.log(Map.of(Fields.ERROR_OBJECT, t));
                 setException(t);
             }
             finally
@@ -150,8 +162,7 @@ public class AsyncQueryRequest<T>
         Thread thread = new Thread(runnable, threadName);
         // We want the async thread to use the same database connection, in case we have a transaction open, and
         // so that when the original thread finishes processing the results it ends up closing the right connection
-        try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(Thread.currentThread(), thread);
-             Scope ignore = tracer.activateSpan(span))
+        try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(Thread.currentThread(), thread))
         {
             thread.start();
 
@@ -237,6 +248,8 @@ public class AsyncQueryRequest<T>
     synchronized private void cancel()
     {
         _cancelled = true;
+        if (_span != null)
+            _span.setTag("labkey.async_query.cancelled", true);
         if (_statement != null)
         {
             try

--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -118,6 +118,8 @@ public class AsyncQueryRequest<T>
         // Create the span, so we can connect the async query with its owning thread
         final Tracer tracer = GlobalTracer.get();
         final Span span = tracer.buildSpan("AsyncRequest").start();
+        // Never a service-entry span, so Datadog computes no hits/duration/error metrics for it without this
+        span.setTag(DDTags.MEASURED, true);
         if (_resourceName != null)
             span.setTag(DDTags.RESOURCE_NAME, _resourceName);
         _spanTags.forEach(span::setTag);

--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -26,6 +26,7 @@ import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.miniprofiler.MiniProfiler;
 import org.labkey.api.miniprofiler.RequestInfo;
@@ -58,6 +59,8 @@ public class AsyncQueryRequest<T>
     private final HttpServletResponse _rootResponse;
     /** Names the APM span; without it every async query aggregates under the bare operation name */
     private final @Nullable String _resourceName;
+    /** Extra tags for APM search and grouping, beyond the resource name */
+    private final @NotNull Map<String, String> _spanTags;
 
     boolean _cancelled;
     @Nullable Statement _statement;
@@ -66,10 +69,11 @@ public class AsyncQueryRequest<T>
     T _result;
     Throwable _exception;
 
-    public AsyncQueryRequest(HttpServletResponse response, @Nullable String resourceName)
+    public AsyncQueryRequest(HttpServletResponse response, @Nullable String resourceName, @NotNull Map<String, String> spanTags)
     {
         _creationStackTrace = MiniProfiler.getTroubleshootingStackTrace();
         _resourceName = resourceName;
+        _spanTags = spanTags;
 
         _rootResponse = getRootResponse(response);
     }
@@ -116,6 +120,7 @@ public class AsyncQueryRequest<T>
         final Span span = tracer.buildSpan("AsyncRequest").start();
         if (_resourceName != null)
             span.setTag(DDTags.RESOURCE_NAME, _resourceName);
+        _spanTags.forEach(span::setTag);
         _span = span;
 
         Runnable runnable = () -> {
@@ -136,8 +141,12 @@ public class AsyncQueryRequest<T>
             }
             catch (Throwable t)
             {
-                Tags.ERROR.set(span, true);
-                span.log(Map.of(Fields.ERROR_OBJECT, t));
+                // Cancellation arrives here as a CancelledException or the driver's "statement cancelled" error; tagging that as an APM error makes every client disconnect look like a failure
+                if (!isCancelled())
+                {
+                    Tags.ERROR.set(span, true);
+                    span.log(Map.of(Fields.ERROR_OBJECT, t));
+                }
                 setException(t);
             }
             finally
@@ -162,9 +171,11 @@ public class AsyncQueryRequest<T>
         Thread thread = new Thread(runnable, threadName);
         // We want the async thread to use the same database connection, in case we have a transaction open, and
         // so that when the original thread finishes processing the results it ends up closing the right connection
+        boolean started = false;
         try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(Thread.currentThread(), thread))
         {
             thread.start();
+            started = true;
 
             // Stash the original disconnect exception if the client has dropped off
             IOException clientDisconnectException = null;
@@ -220,6 +231,12 @@ public class AsyncQueryRequest<T>
                 }
             }
         }
+        finally
+        {
+            // The runnable finishes the span; without a thread to run it the span stays open and its parent trace never completes
+            if (!started)
+                span.finish();
+        }
     }
 
     synchronized public void setResult(T result)
@@ -243,6 +260,11 @@ public class AsyncQueryRequest<T>
     {
         _exception = exception;
         notify();
+    }
+
+    synchronized private boolean isCancelled()
+    {
+        return _cancelled;
     }
 
     synchronized private void cancel()

--- a/api/src/org/labkey/api/data/MaterializedQueryHelper.java
+++ b/api/src/org/labkey/api/data/MaterializedQueryHelper.java
@@ -453,11 +453,14 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
 
                     getFromSql("_bg_");
                 }
-                catch (Exception e)
+                catch (Throwable t)
                 {
                     Tags.ERROR.set(span, true);
-                    span.log(Map.of(Fields.ERROR_OBJECT, e));
-                    LOG.warn("Background materialization failed.", e);
+                    span.log(Map.of(Fields.ERROR_OBJECT, t));
+                    LOG.warn("Background materialization failed.", t);
+                    // Broad enough to tag an Error on the span, but only Exceptions are swallowed
+                    if (t instanceof Error e)
+                        throw e;
                 }
                 finally
                 {

--- a/api/src/org/labkey/api/data/MaterializedQueryHelper.java
+++ b/api/src/org/labkey/api/data/MaterializedQueryHelper.java
@@ -15,9 +15,18 @@
  */
 package org.labkey.api.data;
 
+import datadog.trace.api.CorrelationIdentifier;
+import datadog.trace.api.DDTags;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.log.Fields;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.After;
@@ -422,17 +431,39 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
     {
         if (_backgroundTaskRunning.compareAndSet(false, true))
         {
+            String triggeringTraceId = CorrelationIdentifier.getTraceId();
+            String triggeringSpanId = CorrelationIdentifier.getSpanId();
+
             _materializationRunner.execute(() -> {
-                try
+                // Materialization outlives the request that triggers it and then serves every later request, so it gets its own trace; the trigger is recorded as tags rather than as a parent
+                Tracer tracer = GlobalTracer.get();
+                Span span = tracer.buildSpan("MaterializeAsync").ignoreActiveSpan().start();
+                span.setTag(DDTags.RESOURCE_NAME, StringUtils.defaultIfEmpty(_prefix, getClass().getSimpleName()));
+                if (!"0".equals(triggeringTraceId))
                 {
+                    span.setTag("labkey.triggering_trace_id", triggeringTraceId);
+                    span.setTag("labkey.triggering_span_id", triggeringSpanId);
+                }
+
+                try (Scope ignored = tracer.activateSpan(span))
+                {
+                    // Connect log messages with the active trace and span
+                    ThreadContext.put(CorrelationIdentifier.getTraceIdKey(), CorrelationIdentifier.getTraceId());
+                    ThreadContext.put(CorrelationIdentifier.getSpanIdKey(), CorrelationIdentifier.getSpanId());
+
                     getFromSql("_bg_");
                 }
                 catch (Exception e)
                 {
+                    Tags.ERROR.set(span, true);
+                    span.log(Map.of(Fields.ERROR_OBJECT, e));
                     LOG.warn("Background materialization failed.", e);
                 }
                 finally
                 {
+                    span.finish();
+                    ThreadContext.remove(CorrelationIdentifier.getTraceIdKey());
+                    ThreadContext.remove(CorrelationIdentifier.getSpanIdKey());
                     _backgroundTaskRunning.set(false);
                 }
             });

--- a/api/src/org/labkey/api/data/MaterializedQueryHelper.java
+++ b/api/src/org/labkey/api/data/MaterializedQueryHelper.java
@@ -162,31 +162,33 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
                 DbSchema temp = DbSchema.getTemp();
                 TempTableTracker.track(_tableName, this);
 
-                SQLFragment selectInto;
-                if (isSelectInto)
-                {
-                    String sql = selectQuery.getSQL().replace("${NAME}", _tableName);
-                    List<Object> params = selectQuery.getParams();
-                    selectInto = new SQLFragment(sql,params);
-                }
-                else
-                {
-                    // UNLOGGED skips WAL when populating and indexing the table; only supported in PostgreSQL.
-                    selectInto = new SQLFragment("SELECT * INTO ")
-                            .append(_mqh._unlogged && _mqh._scope.getSqlDialect().isPostgreSQL() ? "UNLOGGED " : "")
-                            .appendIdentifier(temp.getName()).append(".").appendIdentifier(_tableName).append("\nFROM (\n");
-                    selectInto.append(selectQuery);
-                    selectInto.append("\n) _sql_");
-                }
-                new SqlExecutor(_mqh._scope).execute(selectInto);
-
-                try (var ignored = SpringActionController.ignoreSqlUpdates())
-                {
-                    for (String index : _mqh._indexes)
+                traced("full", _mqh.getMaterializationName(), () -> {
+                    SQLFragment selectInto;
+                    if (isSelectInto)
                     {
-                        new SqlExecutor(_mqh._scope).execute(StringUtils.replace(index, "${NAME}", _tableName));
+                        String sql = selectQuery.getSQL().replace("${NAME}", _tableName);
+                        List<Object> params = selectQuery.getParams();
+                        selectInto = new SQLFragment(sql,params);
                     }
-                }
+                    else
+                    {
+                        // UNLOGGED skips WAL when populating and indexing the table; only supported in PostgreSQL.
+                        selectInto = new SQLFragment("SELECT * INTO ")
+                                .append(_mqh._unlogged && _mqh._scope.getSqlDialect().isPostgreSQL() ? "UNLOGGED " : "")
+                                .appendIdentifier(temp.getName()).append(".").appendIdentifier(_tableName).append("\nFROM (\n");
+                        selectInto.append(selectQuery);
+                        selectInto.append("\n) _sql_");
+                    }
+                    new SqlExecutor(_mqh._scope).execute(selectInto);
+
+                    try (var ignored = SpringActionController.ignoreSqlUpdates())
+                    {
+                        for (String index : _mqh._indexes)
+                        {
+                            new SqlExecutor(_mqh._scope).execute(StringUtils.replace(index, "${NAME}", _tableName));
+                        }
+                    }
+                });
 
                 _loadingState.set(LoadingState.LOADED);
                 return true;
@@ -439,6 +441,7 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
                 Tracer tracer = GlobalTracer.get();
                 Span span = tracer.buildSpan("MaterializeAsync").ignoreActiveSpan().start();
                 span.setTag(DDTags.RESOURCE_NAME, StringUtils.defaultIfEmpty(_prefix, getClass().getSimpleName()));
+                span.setTag("labkey.materialized_view", getMaterializationName());
                 if (!"0".equals(triggeringTraceId))
                 {
                     span.setTag("labkey.triggering_trace_id", triggeringTraceId);
@@ -584,6 +587,41 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
 
     protected void incrementalUpdateBeforeSelect(Materialized m)
     {
+    }
+
+    /**
+     * Runs DB work inside its own Datadog APM span so each kind of materialization is a separate resource. Nests under
+     * MaterializeAsync on the background thread and under the HTTP request when a stale view is rebuilt inline.
+     */
+    protected static void traced(String resource, String viewName, Runnable work)
+    {
+        Tracer tracer = GlobalTracer.get();
+        Span span = tracer.buildSpan("labkey.materialize").start();
+        span.setTag(DDTags.RESOURCE_NAME, resource);
+        // Never a service-entry span, so Datadog computes no hits/duration/error metrics for it without this
+        span.setTag(DDTags.MEASURED, true);
+        span.setTag("labkey.materialized_view", viewName);
+
+        try (Scope ignored = tracer.activateSpan(span))
+        {
+            work.run();
+        }
+        catch (Throwable t)
+        {
+            Tags.ERROR.set(span, true);
+            span.log(Map.of(Fields.ERROR_OBJECT, t));
+            throw t;
+        }
+        finally
+        {
+            span.finish();
+        }
+    }
+
+    /** Identifies the view in APM. Carried as a tag, never a resource name, to keep per-view cardinality out of trace metrics. */
+    protected String getMaterializationName()
+    {
+        return StringUtils.defaultIfEmpty(_prefix, getClass().getSimpleName());
     }
 
     /**

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -379,10 +379,23 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
         return new ResultsImpl(rs, tableSqlFactory.getSelectedColumns());
     }
 
+    /** Names the APM span for an async query. Public schema/query name when there is one, otherwise the DB table. */
+    private String getAsyncResourceName(String operation)
+    {
+        String schema = _table.getPublicSchemaName();
+        String name = _table.getPublicName();
+        if (null == schema || null == name)
+        {
+            schema = null != _table.getSchema() ? _table.getSchema().getName() : null;
+            name = _table.getName();
+        }
+        return operation + " " + (null != schema ? schema + "." : "") + name;
+    }
+
     public Results getResultsAsync(final boolean cache, final boolean scrollable, HttpServletResponse response) throws SQLException
     {
         setLogger(ConnectionWrapper.getConnectionLogger());
-        AsyncQueryRequest<Results> asyncRequest = new AsyncQueryRequest<>(response);
+        AsyncQueryRequest<Results> asyncRequest = new AsyncQueryRequest<>(response, getAsyncResourceName("getResults"));
         setAsyncRequest(asyncRequest);
 
         try
@@ -554,7 +567,7 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
     public Map<String, List<Result>> getAggregatesAsync(final List<Aggregate> aggregates, HttpServletResponse response)
     {
         setLogger(ConnectionWrapper.getConnectionLogger());
-        AsyncQueryRequest<Map<String, List<Result>>> asyncRequest = new AsyncQueryRequest<>(response);
+        AsyncQueryRequest<Map<String, List<Result>>> asyncRequest = new AsyncQueryRequest<>(response, getAsyncResourceName("getAggregates"));
         setAsyncRequest(asyncRequest);
 
         try

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -393,11 +393,27 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
         return (null != schema ? schema + "." : "") + name;
     }
 
-    /** Extra APM span tags. resource.name concatenates the operation, so these are what let one query be grouped across getResults and getAggregates. */
-    private Map<String, String> getAsyncSpanTags(String queryName)
+    /** @return the schema name, preferring the public (Query) name over the DB schema, or null if the table has neither */
+    private @Nullable String getAsyncSchemaName()
+    {
+        String schema = _table.getPublicSchemaName();
+        if (null == schema && null != _table.getSchema())
+            schema = _table.getSchema().getName();
+        return schema;
+    }
+
+    /** Query names are user-defined and unbounded, and resource.name is a trace-metric dimension, so the resource stops at the schema and the query goes in a tag. */
+    private String getAsyncResourceName(String operation)
+    {
+        String schema = getAsyncSchemaName();
+        return null != schema ? operation + " " + schema : operation;
+    }
+
+    /** APM span tags. The only place the query being run is identified, since resource.name deliberately stops at the schema. */
+    private Map<String, String> getAsyncSpanTags()
     {
         Map<String, String> tags = new HashMap<>();
-        tags.put("labkey.query", queryName);
+        tags.put("labkey.query", getAsyncQueryName());
         if (null != _table.getSchema())
             tags.put("labkey.db_schema", _table.getSchema().getName());
         return tags;
@@ -406,8 +422,7 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
     public Results getResultsAsync(final boolean cache, final boolean scrollable, HttpServletResponse response) throws SQLException
     {
         setLogger(ConnectionWrapper.getConnectionLogger());
-        String queryName = getAsyncQueryName();
-        AsyncQueryRequest<Results> asyncRequest = new AsyncQueryRequest<>(response, "getResults " + queryName, getAsyncSpanTags(queryName));
+        AsyncQueryRequest<Results> asyncRequest = new AsyncQueryRequest<>(response, getAsyncResourceName("getResults"), getAsyncSpanTags());
         setAsyncRequest(asyncRequest);
 
         try
@@ -579,8 +594,7 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
     public Map<String, List<Result>> getAggregatesAsync(final List<Aggregate> aggregates, HttpServletResponse response)
     {
         setLogger(ConnectionWrapper.getConnectionLogger());
-        String queryName = getAsyncQueryName();
-        AsyncQueryRequest<Map<String, List<Result>>> asyncRequest = new AsyncQueryRequest<>(response, "getAggregates " + queryName, getAsyncSpanTags(queryName));
+        AsyncQueryRequest<Map<String, List<Result>>> asyncRequest = new AsyncQueryRequest<>(response, getAsyncResourceName("getAggregates"), getAsyncSpanTags());
         setAsyncRequest(asyncRequest);
 
         try

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -36,6 +36,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -379,8 +380,8 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
         return new ResultsImpl(rs, tableSqlFactory.getSelectedColumns());
     }
 
-    /** Names the APM span for an async query. Public schema/query name when there is one, otherwise the DB table. */
-    private String getAsyncResourceName(String operation)
+    /** @return "schema.query", using the public (Query) names when the table has them, otherwise the DB schema and table */
+    private String getAsyncQueryName()
     {
         String schema = _table.getPublicSchemaName();
         String name = _table.getPublicName();
@@ -389,13 +390,24 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
             schema = null != _table.getSchema() ? _table.getSchema().getName() : null;
             name = _table.getName();
         }
-        return operation + " " + (null != schema ? schema + "." : "") + name;
+        return (null != schema ? schema + "." : "") + name;
+    }
+
+    /** Extra APM span tags. resource.name concatenates the operation, so these are what let one query be grouped across getResults and getAggregates. */
+    private Map<String, String> getAsyncSpanTags(String queryName)
+    {
+        Map<String, String> tags = new HashMap<>();
+        tags.put("labkey.query", queryName);
+        if (null != _table.getSchema())
+            tags.put("labkey.db_schema", _table.getSchema().getName());
+        return tags;
     }
 
     public Results getResultsAsync(final boolean cache, final boolean scrollable, HttpServletResponse response) throws SQLException
     {
         setLogger(ConnectionWrapper.getConnectionLogger());
-        AsyncQueryRequest<Results> asyncRequest = new AsyncQueryRequest<>(response, getAsyncResourceName("getResults"));
+        String queryName = getAsyncQueryName();
+        AsyncQueryRequest<Results> asyncRequest = new AsyncQueryRequest<>(response, "getResults " + queryName, getAsyncSpanTags(queryName));
         setAsyncRequest(asyncRequest);
 
         try
@@ -567,7 +579,8 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
     public Map<String, List<Result>> getAggregatesAsync(final List<Aggregate> aggregates, HttpServletResponse response)
     {
         setLogger(ConnectionWrapper.getConnectionLogger());
-        AsyncQueryRequest<Map<String, List<Result>>> asyncRequest = new AsyncQueryRequest<>(response, getAsyncResourceName("getAggregates"));
+        String queryName = getAsyncQueryName();
+        AsyncQueryRequest<Map<String, List<Result>>> asyncRequest = new AsyncQueryRequest<>(response, "getAggregates " + queryName, getAsyncSpanTags(queryName));
         setAsyncRequest(asyncRequest);
 
         try

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1493,10 +1493,10 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 if (Materialized.LoadingState.ERROR == materialized._loadingState.get())
                     throw materialized._loadException;
 
-                runIncremental(materialized.incrementalDeleteCheck, this::executeIncrementalDelete);
-                runIncremental(materialized.incrementalUpdateCheck, this::executeIncrementalUpdate);
-                runIncremental(materialized.incrementalRollupCheck, this::executeIncrementalRollup);
-                runIncremental(materialized.incrementalInsertCheck, this::executeIncrementalInsert);
+                runIncremental("delete", materialized.incrementalDeleteCheck, this::executeIncrementalDelete);
+                runIncremental("update", materialized.incrementalUpdateCheck, this::executeIncrementalUpdate);
+                runIncremental("rollup", materialized.incrementalRollupCheck, this::executeIncrementalRollup);
+                runIncremental("insert", materialized.incrementalInsertCheck, this::executeIncrementalInsert);
             }
             catch (RuntimeException|InterruptedException ex)
             {
@@ -1524,13 +1524,19 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
          * reflects the change, instead of briefly serving a stale materialized view. Must be called while holding the
          * materialized's loading lock so only one updater runs at a time.
          */
-        private static void runIncremental(MaterializedQueryHelper.SupplierInvalidator check, Runnable work)
+        private void runIncremental(String kind, MaterializedQueryHelper.SupplierInvalidator check, Runnable work)
         {
             if (check.peekValid())
                 return;
             String token = check.current();
-            work.run();
+            traced("incremental." + kind, getMaterializationName(), work);
             check.markValidAs(token);
+        }
+
+        @Override
+        protected String getMaterializationName()
+        {
+            return StringUtils.defaultIfEmpty(Lsid.parse(_lsid).getObjectId(), _lsid);
         }
 
         void upsertWithRetry(SQLFragment sql)


### PR DESCRIPTION
## Rationale
Datadog tracks queries executed for an HTTP request. We don't have the proper wiring to make the async query and aggregates connect to their HTTP request.

## Changes
- Switch how the spans are tracked
- Improve naming for the spans
- Intentionally keep materializing queries separate from the event that invoked them
- Track errors and cancellations separately

## Tasks
- [x] Claude Code Review
- Manual Testing - N/A
- Test Automation - N/A

