### PR TITLE
Wait for the job, not the whole queue

### DIFF
--- a/api/src/org/labkey/api/message/digest/MessageDigest.java
+++ b/api/src/org/labkey/api/message/digest/MessageDigest.java
@@ -35,6 +35,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -70,7 +71,7 @@ public abstract class MessageDigest
         AtomicReference<Exception> ref = new AtomicReference<>();
 
         // Issue 45978: Run in a background thread to better simulate being triggered by a timer
-        JobRunner.getDefault().execute(() -> {
+        Future<?> future = JobRunner.getDefault().execute(() -> {
             try
             {
                 Date prev = getLastSuccessful();
@@ -92,7 +93,8 @@ public abstract class MessageDigest
             }
         }, 0);
 
-        JobRunner.getDefault().waitForCompletion();
+        // Don't use JobRunner.waitForCompletion(); it blocks on every job queued on the shared default runner, including SimpleMetricsService's save, which is submitted with a 15 minute delay.
+        future.get();
 
         if (ref.get() != null)
         {

--- a/api/src/org/labkey/api/util/JobRunner.java
+++ b/api/src/org/labkey/api/util/JobRunner.java
@@ -98,7 +98,9 @@ public class JobRunner implements Executor
     }
 
     /**
-     * Waits for all submitted jobs to complete. Does not require shutdown.
+     * Waits for all submitted jobs to complete. Jobs can be scheduled in the future, so this can be a long wait.
+     * Does not require shutdown.
+     * Callers should prefer using Future.get() from the result of JobRunner.execute().
      */
     public void waitForCompletion()
     {


### PR DESCRIPTION
## Rationale
`JobRunner.waitForCompletion()` blocks until all jobs in the queue have completed, including those that are scheduled for future execution. That can be a long wait. Most callers want to wait until their job is complete.

## Changes
- Add JavaDoc describing the behavior
- Switch to waiting for the job of interest

## Tasks
- [x] Claude Code Review
- Manual Testing - N/A
- Test Automation - rely on existing coverage
