### PR TITLE
Make materialized query more helpful

### DIFF
--- a/api/src/org/labkey/api/data/MaterializedQueryHelper.java
+++ b/api/src/org/labkey/api/data/MaterializedQueryHelper.java
@@ -177,6 +177,7 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
                     {
                         new SqlExecutor(_mqh._scope).execute(StringUtils.replace(index, "${NAME}", _tableName));
                     }
+                    analyze();
                 }
 
                 _loadingState.set(LoadingState.LOADED);
@@ -191,6 +192,22 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
             {
                 if (lockAcquired)
                     _loadingLock.unlock();
+            }
+        }
+
+        /** SELECT INTO leaves the table with no statistics, so the planner guesses until autovacuum eventually analyzes it. */
+        private void analyze()
+        {
+            try
+            {
+                SQLFragment sql = _mqh._scope.getSqlDialect().getAnalyzeCommandForTable(_fromSql);
+                if (null != sql)
+                    new SqlExecutor(_mqh._scope).execute(sql);
+            }
+            catch (RuntimeException x)
+            {
+                // Statistics are an optimization, so a dialect that can't analyze must not fail the materialization
+                LOG.warn("Failed to update statistics for materialized table {}", _tableName, x);
             }
         }
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1260,7 +1260,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
     }
 
-    static final BlockingCache<String,_MaterializedQueryHelper> _materializedQueries = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, CacheManager.HOUR, "materialized sample types", null);
+    // TTL is a backstop for missed invalidations. Admins can manually clear via Admin Console->Caches
+    static final BlockingCache<String,_MaterializedQueryHelper> _materializedQueries = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, 12 * CacheManager.HOUR, "materialized sample types", null);
     static final Map<String, InvalidationCounters> _invalidationCounters = Collections.synchronizedMap(new HashMap<>());
     static final AtomicBoolean initializedListeners = new AtomicBoolean(false);
 


### PR DESCRIPTION
## Rationale
Analysis shows that our current 1 hour retention for materialized tables is way too short for sample type scenarios. Additionally, without doing an analyze the DB may not be making good query plan choices.

## Changes
- Update retention from 1->12 hours as an incremental testing step
- `ANALYZE` materialized table as part of its creation

## Tasks
- [ ] Claude Code Review
- [ ] Manual Testing
- Test Automation - N/A
