### PR TITLE
GitHub 1397 and 1440: Custom view container permission checks

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2902,6 +2902,21 @@ public class QueryController extends SpringActionController
         }
     }
 
+    /**
+     * GitHub Issue #1397: QueryForm.getCustomView() also resolves shared views and views inherited from an ancestor
+     * folder or /Shared, so check user permissions on the view container
+     */
+    private static boolean canEditView(CustomView view, Container currentContainer, User user)
+    {
+        // Module and auto-generated views have no container of their own
+        Container viewContainer = view.getContainer() != null ? view.getContainer() : currentContainer;
+
+        if (!viewContainer.hasPermission(user, ReadPermission.class))
+            return false;
+
+        return !view.isShared() || viewContainer.hasPermission(user, EditSharedViewPermission.class);
+    }
+
     protected void renameCustomView(Container container, QueryDefinition queryDef, CustomView fromView, String newViewName, BindException errors)
     {
         if (newViewName != null && RESERVED_VIEW_NAMES.contains(newViewName.toLowerCase()))
@@ -2913,6 +2928,9 @@ public class QueryController extends SpringActionController
 
         if (errors.hasErrors())
             return;
+
+        if (!canEditView(fromView, container, getUser()))
+            throw new UnauthorizedException();
 
         User owner = getUser();
         boolean canSaveForAllUsers = container.hasPermission(getUser(), EditSharedViewPermission.class);
@@ -6118,22 +6136,19 @@ public class QueryController extends SpringActionController
                 throw new NotFoundException();
             }
 
-            if (getUser().isGuest())
+            if (view.isSession())
             {
-                // Guests can only delete session custom views.
-                if (!view.isSession())
+                // Session views live in the caller's own session, so guests may delete theirs
+                if (!getUser().isGuest() && !getContainer().hasPermission(getUser(), ReadPermission.class))
                     throw new UnauthorizedException();
+            }
+            else if (getUser().isGuest())
+            {
+                throw new UnauthorizedException();
             }
             else
             {
-                // Logged in users must have read permission
-                if (!getContainer().hasPermission(getUser(), ReadPermission.class))
-                    throw new UnauthorizedException();
-            }
-
-            if (view.isShared())
-            {
-                if (!getContainer().hasPermission(getUser(), EditSharedViewPermission.class))
+                if (!canEditView(view, getContainer(), getUser()))
                     throw new UnauthorizedException();
             }
 
@@ -6146,7 +6161,7 @@ public class QueryController extends SpringActionController
                 CustomView shadowed = form.getCustomView();
                 if (shadowed != null && shadowed.isEditable() && !(shadowed instanceof ModuleCustomView))
                 {
-                    if (!shadowed.isShared() || getContainer().hasPermission(getUser(), EditSharedViewPermission.class))
+                    if (canEditView(shadowed, getContainer(), getUser()))
                         shadowed.delete(getUser(), getViewContext().getRequest());
                 }
             }
@@ -8378,6 +8393,7 @@ public class QueryController extends SpringActionController
                 new ExportRowsTsvAction(),
                     new ExcelWebQueryDefinitionAction(),
                 controller.new SaveQueryViewsAction(),
+                controller.new RenameQueryViewAction(),
                 controller.new PropertiesQueryAction(),
                 controller.new SelectRowsAction(),
                 new GetDataAction(),
@@ -8406,6 +8422,11 @@ public class QueryController extends SpringActionController
 
             // submitter should be allowed for InsertRows
             assertForReadPermission(user, true, new InsertRowsAction());
+
+            // @RequiresNoPermission
+            assertForNoPermission(user,
+                new DeleteViewAction()
+            );
 
             // @RequiresPermission(DeletePermission.class)
             assertForUpdateOrDeletePermission(user,

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2595,6 +2595,11 @@ public class QueryController extends SpringActionController
         if (resolved.message() != null)
             errors.reject(ERROR_MSG, resolved.message());
 
+        // GitHub Issue #1440: check perm view's container
+        Container viewContainer = view != null ? view.getContainer() : null;
+        if (viewContainer != null && !viewContainer.equals(container) && !canEditView(view, viewContainer, getUser()))
+            throw new UnauthorizedException();
+
         // 11179: Allow editing the view if we're saving to session.
         // NOTE: Check for session flag first otherwise the call to canEdit() will add errors to the errors collection.
         boolean canEdit = view == null || session || view.canEdit(container, errors);
@@ -6266,9 +6271,6 @@ public class QueryController extends SpringActionController
             if (!view.isSession())
                 throw new IllegalArgumentException("This action only supports saving session views.");
 
-            //if (!getContainer().getId().equals(view.getContainer().getId()))
-            //    throw new IllegalArgumentException("View may only be saved from container it was created in.");
-
             assert !view.canInherit() && !view.isShared() && view.isEditable(): "Session view should never be inheritable or shared and always be editable";
 
             // Users may save views to a location other than the current container
@@ -6323,6 +6325,11 @@ public class QueryController extends SpringActionController
                 existingView = resolved.localView();
                 if (resolved.message() != null)
                     throw new IllegalArgumentException(resolved.message());
+
+                // GitHub Issue #1440: check perm existingView's container
+                Container viewContainer = existingView != null ? existingView.getContainer() : null;
+                if (viewContainer != null && !viewContainer.equals(container) && !canEditView(existingView, viewContainer, getUser()))
+                    throw new UnauthorizedException();
 
                 if (existingView == null || (existingView instanceof ModuleCustomView && existingView.isEditable()))
                 {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2597,7 +2597,8 @@ public class QueryController extends SpringActionController
 
         // GitHub Issue #1440: check perm view's container
         Container viewContainer = view != null ? view.getContainer() : null;
-        if (viewContainer != null && !viewContainer.equals(container) && !canEditView(view, viewContainer, getUser()))
+        boolean shadowsSharedView = owner != null && view != null && view.isShared();
+        if (viewContainer != null && !shadowsSharedView && !viewContainer.equals(container) && !canEditView(view, viewContainer, getUser()))
             throw new UnauthorizedException();
 
         // 11179: Allow editing the view if we're saving to session.
@@ -6151,10 +6152,9 @@ public class QueryController extends SpringActionController
             {
                 throw new UnauthorizedException();
             }
-            else
+            else if (!getContainer().hasPermission(getUser(), ReadPermission.class) || !canEditView(view, getContainer(), getUser()))
             {
-                if (!canEditView(view, getContainer(), getUser()))
-                    throw new UnauthorizedException();
+                throw new UnauthorizedException();
             }
 
             view.delete(getUser(), getViewContext().getRequest());


### PR DESCRIPTION
## Rationale
https://github.com/LabKey/internal-issues/issues/1397
https://github.com/LabKey/internal-issues/issues/1440

## Related Pull Requests
- https://github.com/LabKey/platform/pull/8001
- https://github.com/LabKey/testAutomation/pull/3178

## Changes
- Custom view fixes for checking canEditView based on view container for rename and delete cases