### PR TITLE
GitHub Issue 1499: SpecialCharacterMetricsMaintenanceTask is throwing exceptions on specimen tables

### DIFF
--- a/study/resources/schemas/dbscripts/postgresql/study-26.000-26.001.sql
+++ b/study/resources/schemas/dbscripts/postgresql/study-26.000-26.001.sql
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 
--- Reset specimen base-column storage names that were uniquified with a numeric suffix but never became a physical column
+-- GitHub Issue 1499: Reset specimen base-column storage names that were uniquified with a numeric suffix but never became a physical column
 UPDATE exp.propertydescriptor
 SET storagecolumnname = exp.propertydescriptor.name
 FROM exp.propertydomain pdm, exp.domaindescriptor dd

--- a/study/resources/schemas/dbscripts/postgresql/study-26.000-26.001.sql
+++ b/study/resources/schemas/dbscripts/postgresql/study-26.000-26.001.sql
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+-- Reset specimen base-column storage names that were uniquified with a numeric suffix but never became a physical column
+UPDATE exp.propertydescriptor
+SET storagecolumnname = exp.propertydescriptor.name
+FROM exp.propertydomain pdm, exp.domaindescriptor dd
+WHERE pdm.propertyid = exp.propertydescriptor.propertyid
+  AND dd.domainid = pdm.domainid
+  AND LOWER(dd.storageschemaname) = 'specimentables'
+  AND LOWER(exp.propertydescriptor.storagecolumnname) = LOWER(exp.propertydescriptor.name) || '1';

--- a/study/resources/schemas/dbscripts/sqlserver/study-26.000-26.001.sql
+++ b/study/resources/schemas/dbscripts/sqlserver/study-26.000-26.001.sql
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 
--- Reset specimen base-column storage names that were uniquified with a numeric suffix but never became a physical column
+-- GitHub Issue 1499: Reset specimen base-column storage names that were uniquified with a numeric suffix but never became a physical column
 UPDATE exp.propertydescriptor
 SET storagecolumnname = exp.propertydescriptor.name
 FROM exp.propertydomain pdm, exp.domaindescriptor dd

--- a/study/resources/schemas/dbscripts/sqlserver/study-26.000-26.001.sql
+++ b/study/resources/schemas/dbscripts/sqlserver/study-26.000-26.001.sql
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+-- Reset specimen base-column storage names that were uniquified with a numeric suffix but never became a physical column
+UPDATE exp.propertydescriptor
+SET storagecolumnname = exp.propertydescriptor.name
+FROM exp.propertydomain pdm, exp.domaindescriptor dd
+WHERE pdm.propertyid = exp.propertydescriptor.propertyid
+  AND dd.domainid = pdm.domainid
+  AND LOWER(dd.storageschemaname) = 'specimentables'
+  AND LOWER(exp.propertydescriptor.storagecolumnname) = LOWER(exp.propertydescriptor.name) + '1';

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -229,7 +229,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     @Override
     public Double getSchemaVersion()
     {
-        return 26.000;
+        return 26.001;
     }
 
     @Override


### PR DESCRIPTION
## Rationale
Prior to https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=29047, when a domain field name matches domain base field name, the storagecolumnname for that field has a numeric suffix added to it. Specimen tables has provisioned table sharing columns with base fields, including rowId, Container, etc. The legacy specimen has exp.propertydescriptor.storagecolumnname as Container1 for container fields, while the actual provisioned table's column name is Container. This PR migrates legacy storagecolumnname to its proper value.

## Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

## Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

<!-- list of standard tasks (remove this comment to enable)
## Tasks
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->