### PR TITLE
Fix for AuthenticationProviderReorderTest.testReorderConfigurations

### DIFF
--- a/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
+++ b/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
@@ -212,7 +212,8 @@ class AuthenticationConfiguration extends PureComponent<{}, Partial<State>> {
                 const oldOrdering = state.dirtinessData[configType];
                 return !isEquivalent(newOrdering, oldOrdering);
             });
-            const dirty = dirtyStateAreas.length > 0 || !isEquivalent({ ...globalSettings }, dirtinessData);
+           // const dirty = dirtyStateAreas.length > 0 || !isEquivalent({ ...globalSettings }, dirtinessData);
+            const dirty = dirtyStateAreas.length > 0 || !isEquivalent({ ...globalSettings }, dirtinessData.globalSettings);
 
             return { ...newState, dirty };
         });

--- a/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
+++ b/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
@@ -212,7 +212,6 @@ class AuthenticationConfiguration extends PureComponent<{}, Partial<State>> {
                 const oldOrdering = state.dirtinessData[configType];
                 return !isEquivalent(newOrdering, oldOrdering);
             });
-           // const dirty = dirtyStateAreas.length > 0 || !isEquivalent({ ...globalSettings }, dirtinessData);
             const dirty = dirtyStateAreas.length > 0 || !isEquivalent({ ...globalSettings }, dirtinessData.globalSettings);
 
             return { ...newState, dirty };

--- a/devtools/test/src/org/labkey/test/tests/devtools/AuthenticationProviderReorderTest.java
+++ b/devtools/test/src/org/labkey/test/tests/devtools/AuthenticationProviderReorderTest.java
@@ -70,12 +70,11 @@ public class AuthenticationProviderReorderTest extends BaseWebDriverTest
         assertSsoLinkOrder(config_uncool, config_cool);
         simpleSignIn();
 
-        configurePage = LoginConfigurePage.beginAt(this);
-        WebElement uncoolRow = Locator.byClass("domain-row-handle").findElement(configurePage.getPrimaryConfigurationRow(config_uncool));
-        WebElement coolRow = Locator.byClass("domain-row-handle").findElement(configurePage.getPrimaryConfigurationRow(config_cool));
-        dragAndDrop(uncoolRow, coolRow);
-        BootstrapLocators.infoBanner.waitForElement(getDriver(), 2_000);
-        configurePage.clickSaveAndFinish();
+        LoginConfigurePage reorderPage = LoginConfigurePage.beginAt(this);
+        keyboardDragAndDrop(reorderPage.getPrimaryConfigurationRow(config_uncool).getDragHandle(),
+                reorderPage.getPrimaryConfigurationRow(config_cool).getDragHandle());
+        waitFor(() -> BootstrapLocators.infoBanner.existsIn(getDriver()), "Configurations were not reordered", 2_000);
+        reorderPage.clickSaveAndFinish();
 
         signOut();
         assertSsoLinkOrder(config_cool, config_uncool);


### PR DESCRIPTION
## Rationale
`onDragEnd` compared `globalSettings` against the whole `dirtinessData` object instead of `dirtinessData.globalSettings`, and `isEquivalent` compares key counts first, so `dirty` was unconditionally true after any drag-end — the unsaved-changes banner and navigate-away warning appeared even when a row was dropped back in place. `AuthenticationProviderReorderTest` relied on that banner to confirm the drag had landed, so it could not tell a failed drop from a successful one.

## Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/3183

## Changes
- `AuthenticationConfiguration.onDragEnd` compares against `dirtinessData.globalSettings`, matching how `globalAuthOnChange` already does it.
- `AuthenticationProviderReorderTest` reorders through `keyboardDragAndDrop` and waits for the now-meaningful unsaved-changes banner before saving.

<!-- list of standard tasks (remove this comment to enable)
## Tasks
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->