### PR TITLE
Don't use ExperimentException for invalid assay id

### DIFF
--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -206,7 +206,7 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
             WorkflowService workService = WorkflowService.get();
 
             if (workService != null && protocol != null && !workService.isTaskAssayType(workflowTaskId, protocol.getRowId()))
-                throw new ExperimentException("Invalid job task id " + workflowTaskId + ". Either the task does not exist or does not reference this assay type.");
+                throw new ValidationException("Invalid job task id " + workflowTaskId + ". Either the task does not exist or does not reference this assay type.");
         }
 
         if (reImportOption == null)


### PR DESCRIPTION
## Rationale
ExperimentException logs and error and sends a report to mothership. It is not appropriate for a failure due to API input.

## Related Pull Requests
- #8010

## Changes
- Change to ValidationException instead.

## Tasks
- [x] Claude Code Review

