### PR TITLE
Allow MaterializedQueryHelper.analyze() during GET requests

### DIFF
--- a/api/src/org/labkey/api/data/MaterializedQueryHelper.java
+++ b/api/src/org/labkey/api/data/MaterializedQueryHelper.java
@@ -187,8 +187,8 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
                         {
                             new SqlExecutor(_mqh._scope).execute(StringUtils.replace(index, "${NAME}", _tableName));
                         }
+                        analyze();
                     }
-                    analyze();
                 });
 
                 _loadingState.set(LoadingState.LOADED);
@@ -213,17 +213,12 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
             {
                 SQLFragment sql = _mqh._scope.getSqlDialect().getAnalyzeCommandForTable(_fromSql);
                 if (null != sql)
-                {
-                    try (var _ = SpringActionController.ignoreSqlUpdates())
-                    {
-                        new SqlExecutor(_mqh._scope).execute(sql);
-                    }
-                }
+                    new SqlExecutor(_mqh._scope).execute(sql);
             }
             catch (RuntimeException x)
             {
                 // Statistics are an optimization, so a dialect that can't analyze must not fail the materialization
-                LOG.warn("Failed to update statistics for materialized table {}", _tableName, x);
+                LOG.error("Failed to update statistics for materialized table {}", _tableName, x);
             }
         }
 

--- a/api/src/org/labkey/api/data/MaterializedQueryHelper.java
+++ b/api/src/org/labkey/api/data/MaterializedQueryHelper.java
@@ -213,7 +213,12 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
             {
                 SQLFragment sql = _mqh._scope.getSqlDialect().getAnalyzeCommandForTable(_fromSql);
                 if (null != sql)
-                    new SqlExecutor(_mqh._scope).execute(sql);
+                {
+                    try (var _ = SpringActionController.ignoreSqlUpdates())
+                    {
+                        new SqlExecutor(_mqh._scope).execute(sql);
+                    }
+                }
             }
             catch (RuntimeException x)
             {


### PR DESCRIPTION
## Rationale
Calls to `analyze()` on a GET request were always failing. Noticed locally while testing flow attributes.