### PR TITLE
Backporting "Samples grid insights panel load in background"

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleChangeNotify.java
+++ b/api/src/org/labkey/api/exp/api/SampleChangeNotify.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.api.exp.api;
+
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.admin.notification.NotificationService;
+import org.labkey.api.data.Container;
+import org.labkey.api.security.SecurityManager;
+import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.util.logging.LogHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public enum SampleChangeNotify
+{
+    SampleDataChanged;
+
+    private static final Logger LOG = LogHelper.getLogger(SampleChangeNotify.class, "Sample data change WebSocket notifications");
+
+    public static void fireSampleDataChanged(@Nullable Container container)
+    {
+        if (container == null)
+            return;
+
+        try
+        {
+            Set<Class<? extends Permission>> read = Collections.singleton(ReadPermission.class);
+            List<User> readers = SecurityManager.getUsersWithPermissions(container, read);
+            List<Integer> userIds = new ArrayList<>(readers.size());
+            for (User user : readers)
+                userIds.add(user.getUserId());
+
+            if (!userIds.isEmpty())
+                NotificationService.get().sendServerEvent(userIds, SampleChangeNotify.SampleDataChanged);
+        }
+        catch (Exception e)
+        {
+            LOG.warn("Failed to send sample data changed notification for container " + container.getPath(), e);
+        }
+    }
+}

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -152,6 +152,7 @@ import org.labkey.api.exp.api.NameExpressionOptionService;
 import org.labkey.api.exp.api.ObjectReferencer;
 import org.labkey.api.exp.api.ProtocolImplementation;
 import org.labkey.api.exp.api.ProvenanceService;
+import org.labkey.api.exp.api.SampleChangeNotify;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.api.SimpleRunRecord;
 import org.labkey.api.exp.list.ListService;
@@ -5077,6 +5078,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 // Use null as container because we want deletes to run even if the container is deleted
                 () -> SearchService.get().deleteResources(docids),
                 POSTCOMMIT);
+
+            // Notify connected clients that sample data changed so cached "insights" counts can be flagged stale.
+            // Deletes don't go through onSamplesChanged, so the notification is fired here.
+            transaction.addCommitTask(() -> SampleChangeNotify.fireSampleDataChanged(container), POSTCOMMIT);
 
             transaction.commit();
             if (timing != null)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -72,6 +72,7 @@ import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.NameExpressionOptionService;
+import org.labkey.api.exp.api.SampleChangeNotify;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
@@ -1223,6 +1224,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     {
         if (_sampleType != null)
             _sampleType.onSamplesChanged(getUser(), null, reason, changedSince);
+
+        // Notify connected clients so cached "insights" counts can be flagged stale (insert/update/merge).
+        // Deletes bypass this path -- see ExperimentServiceImpl.deleteMaterialByRowIds for that notification.
+        SampleChangeNotify.fireSampleDataChanged(getContainer());
     }
 
     static @Nullable Timestamp captureChangedSince()


### PR DESCRIPTION
## Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

## Related Pull Requests
- https://github.com/LabKey/platform/pull/7939
- https://github.com/LabKey/labkey-ui-premium/pull/1036
- https://github.com/LabKey/platform/pull/8018
- https://github.com/LabKey/limsModules/pull/2460

## Changes
- backport https://github.com/LabKey/platform/pull/7939 to 26.7

<!-- list of standard tasks (remove this comment to enable)
## Tasks
- [ ] Claude Code Review
- [ ] Manual Testing
- [ ] Test Automation
- [ ] Verify Fix
-->