### PR TITLE
Optimize sample and list operations, including auditing and user lookups

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditHandler.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditHandler.java
@@ -38,7 +38,7 @@ public abstract class AbstractAuditHandler implements AuditHandler
     /** Bounds both the JDBC batch and the events held in memory while a batch accumulates. */
     public static final int AUDIT_BATCH_SIZE = 2500;
 
-    protected abstract AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row);
+    protected abstract AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row, List<AuditTypeEvent> sideEffectEvents);
 
     @Override
     public void addSummaryAuditEvent(User user, Container c, TableInfo table, QueryService.AuditAction action, Integer dataRowCount, @Nullable AuditBehaviorType auditBehaviorType, @Nullable String userComment)
@@ -56,9 +56,11 @@ public abstract class AbstractAuditHandler implements AuditHandler
 
             if (auditType == SUMMARY || skipAuditLevelCheck)
             {
-                AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, userComment, dataRowCount, null);
+                List<AuditTypeEvent> sideEffectEvents = new ArrayList<>();
+                AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, userComment, dataRowCount, null, sideEffectEvents);
 
                 AuditLogService.get().addEvent(user, event);
+                addSideEffectEvents(AuditLogService.get(), user, sideEffectEvents, false);
             }
         }
     }
@@ -73,18 +75,10 @@ public abstract class AbstractAuditHandler implements AuditHandler
      * @param row            map of new data values
      * @param existingRow    map of data values
      * @param providedValues map of values provided by the user before conversion (e.g., for quantity values)
+     * @param sideEffectEvents collects audit events raised as a side effect of building this record, for the caller to flush through {@link #addSideEffectEvents}
      * @return DetailedAuditTypeEvent object describing audit record (NOTE: not committed to DB yet)
      */
-    protected abstract DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow, Map<String, Object> providedValues);
-
-    /**
-     * Overload for providers whose record construction produces audit events of its own. Events added to
-     * sideEffectEvents are batched by addAuditEvent() rather than inserted one per row.
-     */
-    protected DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow, Map<String, Object> providedValues, List<AuditTypeEvent> sideEffectEvents)
-    {
-        return createDetailedAuditRecord(user, c, tInfo, action, userComment, row, existingRow, providedValues);
-    }
+    protected abstract DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow, Map<String, Object> providedValues, List<AuditTypeEvent> sideEffectEvents);
 
     /**
      * Allow for adding fields that may be present in the updated row but not represented in the original row
@@ -117,8 +111,10 @@ public abstract class AbstractAuditHandler implements AuditHandler
 
                     case SUMMARY:
                     case DETAILED:
-                        AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, userComment, 0, null);
+                        List<AuditTypeEvent> truncateSideEffects = new ArrayList<>();
+                        AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, userComment, 0, null, truncateSideEffects);
                         AuditLogService.get().addEvent(user, event);
+                        addSideEffectEvents(AuditLogService.get(), user, truncateSideEffects, useTransactionAuditCache);
                         return;
                 }
             }
@@ -132,9 +128,11 @@ public abstract class AbstractAuditHandler implements AuditHandler
                 {
                     assert null != rows;
 
-                    AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, userComment, rows.size(), rows.getFirst());
+                    List<AuditTypeEvent> sideEffectEvents = new ArrayList<>();
+                    AuditTypeEvent event = createSummaryAuditRecord(user, c, auditConfigurable, action, userComment, rows.size(), rows.getFirst(), sideEffectEvents);
 
                     AuditLogService.get().addEvent(user, event);
+                    addSideEffectEvents(AuditLogService.get(), user, sideEffectEvents, useTransactionAuditCache);
 
                     return;
                 }
@@ -214,8 +212,12 @@ public abstract class AbstractAuditHandler implements AuditHandler
         }
     }
 
-    /** insertEvents() batches only a fully homogeneous list. Group by event type and container. Each type is stored its own provisioned table */
-    private void addSideEffectEvents(AuditLogService auditLog, User user, List<AuditTypeEvent> events, boolean useTransactionAuditCache)
+    /**
+     * The one place side-effect events are written, so they can't pick up different batching or transaction-cache
+     * behavior depending on which call path produced them. insertEvents() batches only a fully homogeneous list, so
+     * group by event type and container -- each type is stored in its own provisioned table.
+     */
+    public static void addSideEffectEvents(AuditLogService auditLog, User user, List<AuditTypeEvent> events, boolean useTransactionAuditCache)
     {
         events.stream()
                 .collect(Collectors.groupingBy(event -> Pair.of(event.getEventType(), event.getContainer()), LinkedHashMap::new, Collectors.toList()))

--- a/api/src/org/labkey/api/audit/AbstractAuditHandler.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditHandler.java
@@ -26,13 +26,18 @@ import org.labkey.api.util.Pair;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.labkey.api.gwt.client.AuditBehaviorType.SUMMARY;
 
 public abstract class AbstractAuditHandler implements AuditHandler
 {
+    /** Bounds both the JDBC batch and the events held in memory while a batch accumulates. */
+    public static final int AUDIT_BATCH_SIZE = 2500;
+
     protected abstract AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row);
 
     @Override
@@ -71,6 +76,15 @@ public abstract class AbstractAuditHandler implements AuditHandler
      * @return DetailedAuditTypeEvent object describing audit record (NOTE: not committed to DB yet)
      */
     protected abstract DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow, Map<String, Object> providedValues);
+
+    /**
+     * Overload for providers whose record construction produces audit events of its own. Events added to
+     * sideEffectEvents are batched by addAuditEvent() rather than inserted one per row.
+     */
+    protected DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow, Map<String, Object> providedValues, List<AuditTypeEvent> sideEffectEvents)
+    {
+        return createDetailedAuditRecord(user, c, tInfo, action, userComment, row, existingRow, providedValues);
+    }
 
     /**
      * Allow for adding fields that may be present in the updated row but not represented in the original row
@@ -130,13 +144,14 @@ public abstract class AbstractAuditHandler implements AuditHandler
 
                     AuditLogService auditLog = AuditLogService.get();
                     List<DetailedAuditTypeEvent> batch = new ArrayList<>();
+                    List<AuditTypeEvent> sideEffectEvents = new ArrayList<>();
 
                     for (int i=0; i < rows.size(); i++)
                     {
                         Map<String, Object> row = rows.get(i);
                         Map<String, Object> existingRow = null == existingRows ? Collections.emptyMap() : existingRows.get(i);
                         Map<String, Object> providedValueRow = null == providedValues || providedValues.size() <= i  ? null : providedValues.get(i);
-                        DetailedAuditTypeEvent event = createDetailedAuditRecord(user, c, auditConfigurable, action, userComment, row, existingRow, providedValueRow);
+                        DetailedAuditTypeEvent event = createDetailedAuditRecord(user, c, auditConfigurable, action, userComment, row, existingRow, providedValueRow, sideEffectEvents);
 
                         switch (action)
                         {
@@ -175,10 +190,16 @@ public abstract class AbstractAuditHandler implements AuditHandler
                             }
                         }
                         batch.add(event);
-                        if (batch.size() > 1000)
+                        if (batch.size() >= AUDIT_BATCH_SIZE)
                         {
                             auditLog.addEvents(user, batch, useTransactionAuditCache);
                             batch.clear();
+                        }
+                        // a row can contribute more than one side effect, so bound these separately from the row batch
+                        if (sideEffectEvents.size() >= AUDIT_BATCH_SIZE)
+                        {
+                            addSideEffectEvents(auditLog, user, sideEffectEvents, useTransactionAuditCache);
+                            sideEffectEvents.clear();
                         }
                     }
                     if (!batch.isEmpty())
@@ -186,10 +207,20 @@ public abstract class AbstractAuditHandler implements AuditHandler
                         auditLog.addEvents(user, batch, useTransactionAuditCache);
                         batch.clear();
                     }
+                    addSideEffectEvents(auditLog, user, sideEffectEvents, useTransactionAuditCache);
                     break;
                 }
             }
         }
+    }
+
+    /** insertEvents() batches only a fully homogeneous list. Group by event type and container. Each type is stored its own provisioned table */
+    private void addSideEffectEvents(AuditLogService auditLog, User user, List<AuditTypeEvent> events, boolean useTransactionAuditCache)
+    {
+        events.stream()
+                .collect(Collectors.groupingBy(event -> Pair.of(event.getEventType(), event.getContainer()), LinkedHashMap::new, Collectors.toList()))
+                .values()
+                .forEach(group -> auditLog.addEvents(user, group, useTransactionAuditCache));
     }
 
     private void setOldAndNewMapsForUpdate(DetailedAuditTypeEvent event, Container c, Map<String, Object> row, Map<String, Object> existingRow, TableInfo table)

--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -50,6 +50,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.util.DateUtil;
+import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 
@@ -288,6 +289,8 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
         TableInfo storageTableInfo = StorageProvisioner.createTableInfo(domain);
         // Shared across threads from here on
         storageTableInfo.setLocked(true);
+        // Held for the process lifetime, so stop tracking it; MemTracker reports every retained TableInfo as a leak.
+        MemTracker.getInstance().remove(storageTableInfo);
         _cachedStorageTable = new CachedStorageTable(schemaTableInfo, storageTableInfo);
 
         return storageTableInfo;

--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -31,6 +31,7 @@ import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.MultiChoice;
 import org.labkey.api.data.MutableColumnInfo;
+import org.labkey.api.data.SchemaTableInfo;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIterator;
@@ -84,6 +85,9 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
     public static final String COLUMN_NAME_DATA_CHANGES = "DataChanges";
 
     private final AbstractAuditDomainKind _domainKind;
+
+    private record CachedStorageTable(SchemaTableInfo schemaTableInfo, TableInfo storageTableInfo) {}
+    private volatile CachedStorageTable _cachedStorageTable;
 
     public AbstractAuditTypeProvider(@NotNull AbstractAuditDomainKind domainKind)
     {
@@ -264,6 +268,29 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
         if (null == domain)
             throw new NullPointerException("Could not find domain for " + getEventName());
         return StorageProvisioner.createTableInfo(domain);
+    }
+
+    @Override @NotNull
+    public TableInfo getStorageTableInfoForInsert()
+    {
+        Domain domain = getDomain();
+        if (null == domain)
+            throw new IllegalStateException("Could not find domain for audit event type " + getEventName());
+
+        // We want to reuse a cached provisioned TableInfo to avoid construction costs. Getting the SchemaTableInfo is
+        // cheap so use that as a guide for when the table has changed (primarily during startup as its shape may
+        // need to be updated based on current code expections) and when it's safe to reuse the previous copy.
+        SchemaTableInfo schemaTableInfo = StorageProvisioner.get().getSchemaTableInfo(domain);
+        CachedStorageTable cached = _cachedStorageTable;
+        if (null != cached && cached.schemaTableInfo() == schemaTableInfo)
+            return cached.storageTableInfo();
+
+        TableInfo storageTableInfo = StorageProvisioner.createTableInfo(domain);
+        // Shared across threads from here on
+        storageTableInfo.setLocked(true);
+        _cachedStorageTable = new CachedStorageTable(schemaTableInfo, storageTableInfo);
+
+        return storageTableInfo;
     }
 
     @Override

--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -279,7 +279,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
 
         // We want to reuse a cached provisioned TableInfo to avoid construction costs. Getting the SchemaTableInfo is
         // cheap so use that as a guide for when the table has changed (primarily during startup as its shape may
-        // need to be updated based on current code expections) and when it's safe to reuse the previous copy.
+        // need to be updated based on current code expectations) and when it's safe to reuse the previous copy.
         SchemaTableInfo schemaTableInfo = StorageProvisioner.get().getSchemaTableInfo(domain);
         CachedStorageTable cached = _cachedStorageTable;
         if (null != cached && cached.schemaTableInfo() == schemaTableInfo)

--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -50,7 +50,6 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.util.DateUtil;
-import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 
@@ -286,11 +285,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
         if (null != cached && cached.schemaTableInfo() == schemaTableInfo)
             return cached.storageTableInfo();
 
-        TableInfo storageTableInfo = StorageProvisioner.createTableInfo(domain);
-        // Shared across threads from here on
-        storageTableInfo.setLocked(true);
-        // Held for the process lifetime, so stop tracking it; MemTracker reports every retained TableInfo as a leak.
-        MemTracker.getInstance().remove(storageTableInfo);
+        TableInfo storageTableInfo = StorageProvisioner.createSharedTableInfo(domain);
         _cachedStorageTable = new CachedStorageTable(schemaTableInfo, storageTableInfo);
 
         return storageTableInfo;

--- a/api/src/org/labkey/api/audit/AuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AuditTypeProvider.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.audit;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.property.Domain;
@@ -42,6 +43,14 @@ public interface AuditTypeProvider
     Domain getDomain(boolean forUpdate);
 
     TableInfo createTableInfo(UserSchema schema, ContainerFilter cf);
+
+    /**
+     * Provisioned storage TableInfo for the insert path. Implementations should cache - creating TableInfos is expensive.
+     * Never use this to read audit rows: it has no ContainerFilter and bypasses the CanSeeAuditLog check that
+     * {@link org.labkey.api.audit.query.DefaultAuditTypeTable} applies. Go through {@link #createTableInfo} for reads.
+     */
+    @NotNull
+    TableInfo getStorageTableInfoForInsert();
 
     <K extends AuditTypeEvent> Class<K> getEventClass();
 

--- a/api/src/org/labkey/api/data/MaterializedQueryHelper.java
+++ b/api/src/org/labkey/api/data/MaterializedQueryHelper.java
@@ -215,21 +215,18 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
          */
         private void createIndexes(List<String> indexes, boolean tolerateFailure)
         {
-            try (var ignored = SpringActionController.ignoreSqlUpdates())
+            for (String index : indexes)
             {
-                for (String index : indexes)
+                String sql = StringUtils.replace(index, "${NAME}", _tableName);
+                try
                 {
-                    String sql = StringUtils.replace(index, "${NAME}", _tableName);
-                    try
-                    {
-                        new SqlExecutor(_mqh._scope).execute(sql);
-                    }
-                    catch (RuntimeException x)
-                    {
-                        if (!tolerateFailure)
-                            throw x;
-                        LOG.error("Failed to create index on materialized table {}. The table is serving queries without it. DDL: {}", _tableName, sql, x);
-                    }
+                    new SqlExecutor(_mqh._scope).execute(sql);
+                }
+                catch (RuntimeException x)
+                {
+                    if (!tolerateFailure)
+                        throw x;
+                    LOG.error("Failed to create index on materialized table {}. The table is serving queries without it. DDL: {}", _tableName, sql, x);
                 }
             }
         }

--- a/api/src/org/labkey/api/data/MaterializedQueryHelper.java
+++ b/api/src/org/labkey/api/data/MaterializedQueryHelper.java
@@ -180,18 +180,17 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
                         selectInto.append("\n) _sql_");
                     }
                     new SqlExecutor(_mqh._scope).execute(selectInto);
-
-                    try (var ignored = SpringActionController.ignoreSqlUpdates())
-                    {
-                        for (String index : _mqh._indexes)
-                        {
-                            new SqlExecutor(_mqh._scope).execute(StringUtils.replace(index, "${NAME}", _tableName));
-                        }
-                    }
+                    createIndexes(_mqh._indexes, false);
                     analyze();
                 });
 
+                // Published here, not after the deferred indexes: those only make the table faster, and building them
+                // first keeps every reader on the unmaterialized query for the length of the slowest index.
                 _loadingState.set(LoadingState.LOADED);
+
+                if (!_mqh._deferredIndexes.isEmpty())
+                    traced("full.deferredIndexes", _mqh.getMaterializationName(), () -> createIndexes(_mqh._deferredIndexes, true));
+
                 return true;
             }
             catch (RuntimeException rex)
@@ -203,6 +202,31 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
             {
                 if (lockAcquired)
                     _loadingLock.unlock();
+            }
+        }
+
+        /**
+         * @param tolerateFailure true once the table is serving reads, where a missing index costs speed but nothing else,
+         *                        so the failure is logged and the remaining indexes are still attempted
+         */
+        private void createIndexes(List<String> indexes, boolean tolerateFailure)
+        {
+            try (var ignored = SpringActionController.ignoreSqlUpdates())
+            {
+                for (String index : indexes)
+                {
+                    String sql = StringUtils.replace(index, "${NAME}", _tableName);
+                    try
+                    {
+                        new SqlExecutor(_mqh._scope).execute(sql);
+                    }
+                    catch (RuntimeException x)
+                    {
+                        if (!tolerateFailure)
+                            throw x;
+                        LOG.error("Failed to create index on materialized table {}. The table is serving queries without it. DDL: {}", _tableName, sql, x);
+                    }
+                }
             }
         }
 
@@ -389,6 +413,7 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
     protected final SQLFragment _uptodateQuery;
     protected final Supplier<String> _supplier;
     private final List<String> _indexes = new ArrayList<>();
+    private final List<String> _deferredIndexes = new ArrayList<>();
     protected final long _maxTimeToCache;
     private final Map<String, Materialized> _map = Collections.synchronizedMap(new LinkedHashMap<>()
     {
@@ -410,7 +435,7 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
 
     private boolean _closed = false;
 
-    protected MaterializedQueryHelper(String prefix, DbScope scope, SQLFragment select, @Nullable SQLFragment uptodate, Supplier<String> supplier, @Nullable Collection<String> indexes, long maxTimeToCache,
+    protected MaterializedQueryHelper(String prefix, DbScope scope, SQLFragment select, @Nullable SQLFragment uptodate, Supplier<String> supplier, @Nullable Collection<String> indexes, @Nullable Collection<String> deferredIndexes, long maxTimeToCache,
                                     boolean isSelectIntoSql, boolean unlogged)
     {
         _prefix = Objects.toString(prefix,"mat");
@@ -421,6 +446,8 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
         _maxTimeToCache = maxTimeToCache;
         if (null != indexes)
             _indexes.addAll(indexes);
+        if (null != deferredIndexes)
+            _deferredIndexes.addAll(deferredIndexes);
         _isSelectIntoSql = isSelectIntoSql;
         _unlogged = unlogged;
         assert MemTracker.get().put(this);
@@ -769,14 +796,14 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
     @Deprecated // use Builder
     public static MaterializedQueryHelper create(String prefix, DbScope scope, SQLFragment select, @Nullable SQLFragment uptodate, Collection<String> indexes, long maxTimeToCache)
     {
-        return new MaterializedQueryHelper(prefix, scope, select, uptodate, null, indexes, maxTimeToCache, false, false);
+        return new MaterializedQueryHelper(prefix, scope, select, uptodate, null, indexes, null, maxTimeToCache, false, false);
     }
 
 
     @Deprecated // use Builder
     public static MaterializedQueryHelper create(String prefix, DbScope scope, SQLFragment select, Supplier<String> uptodate, Collection<String> indexes, long maxTimeToCache)
     {
-        return new MaterializedQueryHelper(prefix, scope, select, null, uptodate, indexes, maxTimeToCache, false, false);
+        return new MaterializedQueryHelper(prefix, scope, select, null, uptodate, indexes, null, maxTimeToCache, false, false);
     }
 
     public static class Builder implements org.labkey.api.data.Builder<MaterializedQueryHelper>
@@ -791,6 +818,7 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
         protected SQLFragment _uptodate = null;
         protected Supplier<String> _supplier = null;
         protected Collection<String> _indexes = new ArrayList<>();
+        protected Collection<String> _deferredIndexes = new ArrayList<>();
 
         public Builder(String prefix, DbScope scope, SQLFragment select)
         {
@@ -834,16 +862,24 @@ public class MaterializedQueryHelper implements CacheListener, AutoCloseable
             return this;
         }
 
+        /** Index built before the table is published, for anything a reader or the incremental maintenance SQL cannot go without. */
         public Builder addIndex(String index)
         {
             _indexes.add(index);
             return this;
         }
 
+        /** Index built after the table is published to readers; a failure is logged and the table serves without it. */
+        public Builder addDeferredIndex(String index)
+        {
+            _deferredIndexes.add(index);
+            return this;
+        }
+
         @Override
         public MaterializedQueryHelper build()
         {
-            return new MaterializedQueryHelper(_prefix, _scope, _select, _uptodate, _supplier, _indexes, _max, _isSelectInto, _unlogged);
+            return new MaterializedQueryHelper(_prefix, _scope, _select, _uptodate, _supplier, _indexes, _deferredIndexes, _max, _isSelectInto, _unlogged);
         }
     }
 

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -220,12 +220,22 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         public void setIncludePkLookup(boolean includePkLookup)
         {
             _includePkLookup = includePkLookup;
-            _maps = null;
         }
 
         public ColumnInfo getPkColumn()
         {
             return _targetTable.getPkColumns().getFirst();
+        }
+
+        private Pair<ColumnInfo, Map<?, ?>> pkLookupMap()
+        {
+            if (!_includePkLookup)
+                return null;
+
+            if (_pkColumnLookupMap == null)
+                _pkColumnLookupMap = Pair.of(getPkColumn(), new HashMap<>());
+
+            return _pkColumnLookupMap;
         }
 
         private List<Triple<ColumnInfo, ColumnInfo, MultiValuedMap<?, ?>>> getMaps()
@@ -271,11 +281,6 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                         _titleColumnLookupMap = Triple.of(pkCol, titleColumn, new ArrayListValuedHashMap());
                     }
                 }
-
-                if (_includePkLookup)
-                {
-                    _pkColumnLookupMap = Pair.of(pkCol, new HashMap<>());
-                }
             }
             return _maps;
         }
@@ -291,9 +296,10 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
 
             List<Triple<ColumnInfo, ColumnInfo, MultiValuedMap<?,?>>> maps = getMaps();
 
-            if (_pkColumnLookupMap != null)
+            Pair<ColumnInfo, Map<?, ?>> pkLookupMap = pkLookupMap();
+            if (pkLookupMap != null)
             {
-                Object v = fetch(_pkColumnLookupMap, k);
+                Object v = fetch(pkLookupMap, k);
                 if (v != null)
                     return v;
             }
@@ -2231,6 +2237,97 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                 }
             }
 
+        }
+
+        /** Lookup fixture with one text alternate key (Value) over an integer pk (RowId); Ordinal is unique but not text, so it yields no map. */
+        private EnumTableInfo<LookupValues> remapLookupTable()
+        {
+            var core = QueryService.get().getUserSchema(TestContext.get().getUser(), JunitUtil.getTestContainer(), "core");
+            return new EnumTableInfo<>(LookupValues.class, core, "fake enum", true);
+        }
+
+        @Test
+        public void remapMemoizationSurvivesPkLookupToggle()
+        {
+            RemapConverter converter = new RemapConverter(remapLookupTable(), true, false, true);
+
+            // RemappingConvertColumn flips this before every row, so it must not discard what earlier rows resolved
+            converter.setIncludePkLookup(false);
+
+            List<Triple<ColumnInfo, ColumnInfo, MultiValuedMap<?, ?>>> maps = converter.getMaps();
+            assertEquals("expected one alternate-key map, on the Value column", 1, maps.size());
+
+            // Seed keys no enum value can supply, so anything but a memo hit resolves to null
+            MultiValuedMap memo = maps.getFirst().getRight();
+            Integer seeded = 42;
+            memo.put("seeded-hit", seeded);
+            memo.put("seeded-miss", converter.MISS);
+
+            assertEquals(seeded, converter.mappedValue("seeded-hit"));
+            assertNull(converter.mappedValue("seeded-miss"));
+
+            for (int i = 0; i < 3; i++)
+            {
+                converter.setIncludePkLookup(true);
+                converter.setIncludePkLookup(false);
+            }
+
+            assertSame("toggling includePkLookup discarded the memoization maps", maps, converter.getMaps());
+            assertEquals("resolved value was discarded, so every row re-queries it", seeded, converter.mappedValue("seeded-hit"));
+            assertNull("MISS marker was discarded, so every row re-queries the absent value", converter.mappedValue("seeded-miss"));
+        }
+
+        @Test
+        public void remapResolutionIsStableAcrossPkLookupToggle()
+        {
+            RemapConverter converter = new RemapConverter(remapLookupTable(), true, false, true);
+            converter.setIncludePkLookup(false);
+
+            Object resolved = converter.mappedValue(LookupValues.Two.name());
+            assertNotNull("expected " + LookupValues.Two + " to resolve by alternate key", resolved);
+
+            converter.setIncludePkLookup(true);
+            converter.setIncludePkLookup(false);
+
+            assertEquals(resolved, converter.mappedValue(LookupValues.Two.name()));
+        }
+
+        @Test
+        public void remapAlternateKeyWinsWhenPkLookupIsOff()
+        {
+            RemapConverter converter = new RemapConverter(remapLookupTable(), true, false, true);
+
+            // Seed the two maps to disagree on one key, so the resolved value says which map was consulted
+            Integer key = 7;
+            Integer pkResolution = 7;
+            Integer akResolution = 99;
+            Map pkMemo = converter.pkLookupMap().getValue();
+            MultiValuedMap akMemo = converter.getMaps().getFirst().getRight();
+            pkMemo.put(key, pkResolution);
+            akMemo.put(key, akResolution);
+
+            assertEquals("pk lookup should take precedence while includePkLookup is on", pkResolution, converter.mappedValue(key));
+
+            // The pk map survives the toggle, so this also pins that it is not consulted while the flag is off
+            converter.setIncludePkLookup(false);
+            assertEquals("alternate key should resolve while includePkLookup is off", akResolution, converter.mappedValue(key));
+        }
+
+        @Test
+        public void remapPkLookupMapIsRetained()
+        {
+            RemapConverter converter = new RemapConverter(remapLookupTable(), true, false, false);
+            assertNull("pk lookup map should not exist while includePkLookup is off", converter.pkLookupMap());
+
+            converter.setIncludePkLookup(true);
+            Pair<ColumnInfo, Map<?, ?>> pkMap = converter.pkLookupMap();
+            assertNotNull(pkMap);
+
+            converter.setIncludePkLookup(false);
+            assertNull(converter.pkLookupMap());
+
+            converter.setIncludePkLookup(true);
+            assertSame("pk lookup map was rebuilt rather than retained", pkMap, converter.pkLookupMap());
         }
 
         @Test

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -2247,7 +2247,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         }
 
         @Test
-        public void remapMemoizationSurvivesPkLookupToggle()
+        public void remapCacheSurvivesPkLookupToggle()
         {
             RemapConverter converter = new RemapConverter(remapLookupTable(), true, false, true);
 
@@ -2257,11 +2257,11 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             List<Triple<ColumnInfo, ColumnInfo, MultiValuedMap<?, ?>>> maps = converter.getMaps();
             assertEquals("expected one alternate-key map, on the Value column", 1, maps.size());
 
-            // Seed keys no enum value can supply, so anything but a memo hit resolves to null
-            MultiValuedMap memo = maps.getFirst().getRight();
+            // Seed keys no enum value can supply, so anything but a cache hit resolves to null
+            MultiValuedMap cache = maps.getFirst().getRight();
             Integer seeded = 42;
-            memo.put("seeded-hit", seeded);
-            memo.put("seeded-miss", converter.MISS);
+            cache.put("seeded-hit", seeded);
+            cache.put("seeded-miss", converter.MISS);
 
             assertEquals(seeded, converter.mappedValue("seeded-hit"));
             assertNull(converter.mappedValue("seeded-miss"));
@@ -2272,7 +2272,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                 converter.setIncludePkLookup(false);
             }
 
-            assertSame("toggling includePkLookup discarded the memoization maps", maps, converter.getMaps());
+            assertSame("toggling includePkLookup discarded the cached lookups", maps, converter.getMaps());
             assertEquals("resolved value was discarded, so every row re-queries it", seeded, converter.mappedValue("seeded-hit"));
             assertNull("MISS marker was discarded, so every row re-queries the absent value", converter.mappedValue("seeded-miss"));
         }
@@ -2301,10 +2301,10 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             Integer key = 7;
             Integer pkResolution = 7;
             Integer akResolution = 99;
-            Map pkMemo = converter.pkLookupMap().getValue();
-            MultiValuedMap akMemo = converter.getMaps().getFirst().getRight();
-            pkMemo.put(key, pkResolution);
-            akMemo.put(key, akResolution);
+            Map pkCache = converter.pkLookupMap().getValue();
+            MultiValuedMap akCache = converter.getMaps().getFirst().getRight();
+            pkCache.put(key, pkResolution);
+            akCache.put(key, akResolution);
 
             assertEquals("pk lookup should take precedence while includePkLookup is on", pkResolution, converter.mappedValue(key));
 

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -18,6 +18,7 @@ package org.labkey.api.exp.api;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.audit.SampleTimelineAuditEvent;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSequence;
@@ -248,6 +249,9 @@ public interface SampleTypeService
     void addAuditEvent(User user, Container container, String comment, String userComment, ExpMaterial sample, Map<String, Object> metadata, String updateType);
 
     void addAuditEvents(User user, Container container, String comment, String userComment, Collection<? extends ExpMaterial> samples, Map<String, Object> metadata);
+
+    /** Builds the same event addAuditEvent() would write, for callers on row-scaling paths that need to batch the inserts themselves. */
+    SampleTimelineAuditEvent createTimelineAuditRecord(Container container, String comment, String userComment, ExpMaterial sample, Map<String, Object> metadata, String updateType);
 
     // find the max sequence number with '${sampleName}-' prefix
     long getMaxAliquotId(@NotNull String sampleName, @NotNull String sampleTypeLsid, Container container);

--- a/api/src/org/labkey/api/exp/api/StorageProvisioner.java
+++ b/api/src/org/labkey/api/exp/api/StorageProvisioner.java
@@ -72,6 +72,20 @@ public interface StorageProvisioner
     TableInfo createTableInfoImpl(@NotNull Domain domain);
 
     /**
+     * Variant of {@link #createTableInfo} for callers that cache the result for the process lifetime. The table is
+     * locked for cross-thread sharing, and it plus the DomainDescriptor it retains are dropped from MemTracker, which
+     * would otherwise report both as leaks.
+     */
+    @NotNull
+    static TableInfo createSharedTableInfo(@NotNull Domain domain)
+    {
+        return get().createSharedTableInfoImpl(domain);
+    }
+
+    @NotNull
+    TableInfo createSharedTableInfoImpl(@NotNull Domain domain);
+
+    /**
      * This is really an internal method, use createTableInfo() in most scenarios
      * This is public to support upgrade scenarios only.
      */

--- a/api/src/org/labkey/api/exp/api/StorageProvisioner.java
+++ b/api/src/org/labkey/api/exp/api/StorageProvisioner.java
@@ -86,6 +86,7 @@ public interface StorageProvisioner
     void ensureTableIndices(@NotNull Domain domain);
     void ensureTableIndices(@NotNull Domain domain, Supplier<Boolean> afterAddSupplier);
 
+    @NotNull
     SchemaTableInfo getSchemaTableInfo(Domain domain);
 
     /**

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -45,6 +45,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.util.ContextListener;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StartupListener;
 import org.labkey.api.util.logging.LogHelper;
@@ -54,13 +55,17 @@ import org.labkey.audit.model.LogManager;
 import org.labkey.audit.query.AuditQuerySchema;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class AuditLogImpl implements AuditLogService, StartupListener
@@ -248,6 +253,31 @@ public class AuditLogImpl implements AuditLogService, StartupListener
         return new ActionURL(AuditController.ShowAuditLogAction.class, ContainerManager.getRoot());
     }
 
+    /**
+     * Mirrors {@link ContainerFilter}'s SQL: an event matches on its own container, or on being a child of an in-scope
+     * container whose type the filter includes. Cached events need this applied by hand -- reading them back from the
+     * database is what would otherwise apply it.
+     */
+    private static Predicate<AuditTypeEvent> inScope(User user, Container container, @Nullable ContainerFilter containerFilter)
+    {
+        Collection<GUID> ids = (null == containerFilter ? ContainerFilter.current(container, user) : containerFilter).getIds();
+        if (null == ids)
+            return event -> true;
+
+        Set<GUID> scope = new HashSet<>(ids);
+        Set<String> childTypes = null == containerFilter ? Collections.emptySet() : containerFilter.getIncludedChildTypes();
+
+        return event -> {
+            Container c = event.getContainer();
+            if (null == c)
+                return false;
+            if (scope.contains(c.getEntityId()))
+                return true;
+            Container parent = c.getParent();
+            return null != parent && childTypes.contains(c.getType()) && scope.contains(parent.getEntityId());
+        };
+    }
+
     public record TransactionRowIds(List<Long> rowIds, Map<Long, Long> dataTypeRowCounts) {}
 
     public TransactionRowIds getTransactionSampleIds(long transactionAuditId, User user, Container container, @Nullable ContainerFilter containerFilter)
@@ -265,6 +295,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
             events = transactionEvents.stream()
                     .filter(SampleTimelineAuditEvent.class::isInstance)
                     .map(SampleTimelineAuditEvent.class::cast)
+                    .filter(inScope(user, container, containerFilter))
                     .toList();
         }
         Map<Long, Long> dataTypeRowCounts = new HashMap<>();
@@ -287,6 +318,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
                 : transactionEvents.stream()
                         .filter(DetailedAuditTypeEvent.class::isInstance)
                         .map(DetailedAuditTypeEvent.class::cast)
+                        .filter(inScope(user, container, containerFilter))
                         .toList();
 
         detailedEvents.forEach(event -> {

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -20,6 +20,11 @@ import jakarta.servlet.ServletContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.audit.AbstractAuditTypeProvider;
 import org.labkey.api.audit.AuditLogService;
@@ -27,6 +32,7 @@ import org.labkey.api.audit.AuditTypeEvent;
 import org.labkey.api.audit.AuditTypeProvider;
 import org.labkey.api.audit.DetailedAuditTypeEvent;
 import org.labkey.api.audit.SampleTimelineAuditEvent;
+import org.labkey.api.audit.permissions.CanSeeAuditLogPermission;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -37,17 +43,27 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.data.WorkbookContainerType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.query.AbstractQueryUpdateService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.LimitedUser;
+import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.CanSeeAuditLogRole;
+import org.labkey.api.security.roles.ReaderRole;
+import org.labkey.api.security.roles.Role;
+import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StartupListener;
+import org.labkey.api.util.TestContext;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
@@ -260,12 +276,13 @@ public class AuditLogImpl implements AuditLogService, StartupListener
      */
     private static Predicate<AuditTypeEvent> inScope(User user, Container container, @Nullable ContainerFilter containerFilter)
     {
-        Collection<GUID> ids = (null == containerFilter ? ContainerFilter.current(container, user) : containerFilter).getIds();
+        ContainerFilter cf = null == containerFilter ? ContainerFilter.current(container, user) : containerFilter;
+        Collection<GUID> ids = scopeIds(user, container, cf);
         if (null == ids)
             return event -> true;
 
         Set<GUID> scope = new HashSet<>(ids);
-        Set<String> childTypes = null == containerFilter ? Collections.emptySet() : containerFilter.getIncludedChildTypes();
+        Set<String> childTypes = cf.getIncludedChildTypes();
 
         return event -> {
             Container c = event.getContainer();
@@ -276,6 +293,21 @@ public class AuditLogImpl implements AuditLogService, StartupListener
             Container parent = c.getParent();
             return null != parent && childTypes.contains(c.getType()) && scope.contains(parent.getEntityId());
         };
+    }
+
+    /**
+     * Scopes by CanSeeAuditLogPermission the way {@link org.labkey.api.audit.query.DefaultAuditTypeTable} does, not by
+     * the ReadPermission that {@link ContainerFilter#getIds()} applies, so a folder the user can read but whose audit
+     * log they cannot see stays out of scope.
+     */
+    private static @Nullable Collection<GUID> scopeIds(User user, Container container, ContainerFilter cf)
+    {
+        if (!(cf instanceof ContainerFilter.ContainerFilterWithPermission cfp))
+            return cf.getIds();
+
+        Set<Role> roles = SecurityManager.canSeeAuditLog(user) ? RoleManager.roleSet(CanSeeAuditLogRole.class) : null;
+
+        return cfp.generateIds(container, CanSeeAuditLogPermission.class, roles);
     }
 
     public record TransactionRowIds(List<Long> rowIds, Map<Long, Long> dataTypeRowCounts) {}
@@ -345,5 +377,135 @@ public class AuditLogImpl implements AuditLogService, StartupListener
             sourceIds.addAll(selector.getArrayList(Long.class));
         }
         return new TransactionRowIds(sourceIds, dataTypeRowCounts);
+    }
+
+    /**
+     * {@link #inScope} reproduces {@link org.labkey.api.audit.query.DefaultAuditTypeTable}'s container filtering in
+     * memory, so the branch that reads cached transaction events has to agree with the branch that reads them back from
+     * the database. Two cases separate the two: a workbook, which is in scope only through its parent via
+     * {@link ContainerFilter#getIncludedChildTypes()}, and a user who can read a folder but not its audit log.
+     */
+    public static class TransactionScopeTestCase extends Assert
+    {
+        private static final String PROJECT_NAME = "AuditTransactionScopeTest Project";
+        private static final long SAMPLE_TYPE_ID = 4242;
+
+        private static User _user;
+        private static Container _project;
+        private static Container _workbook;
+        private static Container _subfolder;
+
+        @BeforeClass
+        public static void setup()
+        {
+            Assume.assumeTrue("The SampleTimelineEvent provider is registered by the experiment module",
+                    null != AuditLogService.get().getAuditProvider(SampleTimelineAuditEvent.EVENT_TYPE));
+
+            _user = TestContext.get().getUser();
+
+            deleteTestContainer();
+            _project = ContainerManager.createContainer(ContainerManager.getRoot(), PROJECT_NAME, _user);
+            _workbook = ContainerManager.createContainer(_project, null, "Workbook", null, WorkbookContainerType.NAME, _user);
+            _subfolder = ContainerManager.createContainer(_project, "Subfolder", _user);
+        }
+
+        @AfterClass
+        public static void cleanup()
+        {
+            _subfolder = null;
+            _workbook = null;
+            _project = null;
+            _user = null;
+
+            deleteTestContainer();
+        }
+
+        private static void deleteTestContainer()
+        {
+            Container project = ContainerManager.getForPath(PROJECT_NAME);
+
+            if (null != project)
+                ContainerManager.deleteAll(project, TestContext.get().getUser());
+        }
+
+        /** Unique per call, and from the sequence production draws transaction ids from. */
+        private static long newTransactionId()
+        {
+            return AbstractQueryUpdateService.createTransactionAuditEvent(_project, QueryService.AuditAction.INSERT).getRowId();
+        }
+
+        private static SampleTimelineAuditEvent timelineEvent(Container c, long transactionId, long sampleId)
+        {
+            SampleTimelineAuditEvent event = new SampleTimelineAuditEvent(c, "Sample inserted");
+            event.setTransactionId(transactionId);
+            event.setSampleId(sampleId);
+            event.setSampleTypeId(SAMPLE_TYPE_ID);
+
+            return event;
+        }
+
+        /** One event per container, all in one transaction. Written with the cache on, so both branches see them. */
+        private static long writeEvents(User user, long projectSampleId, long workbookSampleId, long subfolderSampleId)
+        {
+            long transactionId = newTransactionId();
+
+            AuditLogService.get().addEvents(user, List.of(
+                    timelineEvent(_project, transactionId, projectSampleId),
+                    timelineEvent(_workbook, transactionId, workbookSampleId),
+                    timelineEvent(_subfolder, transactionId, subfolderSampleId)), true);
+
+            assertFalse("expected addEvents() to populate the transaction event cache",
+                    TRANSACTION_EVENT_CACHE.get(transactionId).second.isEmpty());
+
+            return transactionId;
+        }
+
+        /** Emptying the cache entry is what sends getTransactionSampleIds() to the database. */
+        private static TransactionRowIds fromDatabase(long transactionId, User user)
+        {
+            TRANSACTION_EVENT_CACHE.get(transactionId).second.clear();
+
+            return get().getTransactionSampleIds(transactionId, user, _project, null);
+        }
+
+        @Test
+        public void workbookIsInScopeForBothBranches()
+        {
+            long transactionId = writeEvents(_user, 101, 102, 103);
+
+            TransactionRowIds cached = get().getTransactionSampleIds(transactionId, _user, _project, null);
+            TransactionRowIds database = fromDatabase(transactionId, _user);
+
+            assertEquals("the workbook is in scope through its parent, the subfolder is not in scope at all",
+                    Set.of(101L, 102L), Set.copyOf(cached.rowIds()));
+            assertEquals("cached and database branches disagreed on sample ids",
+                    Set.copyOf(cached.rowIds()), Set.copyOf(database.rowIds()));
+            assertEquals("cached and database branches disagreed on row counts",
+                    Map.of(SAMPLE_TYPE_ID, 2L), cached.dataTypeRowCounts());
+            assertEquals("cached and database branches disagreed on row counts",
+                    cached.dataTypeRowCounts(), database.dataTypeRowCounts());
+        }
+
+        @Test
+        public void auditLogPermissionIsAppliedByBothBranches()
+        {
+            // Read alone is not enough to see audit events; the production caller elevates with CanSeeAuditLogRole first
+            User reader = new LimitedUser(_user, ReaderRole.class);
+            assertTrue("expected the reader to be able to read the project", _project.hasPermission(reader, ReadPermission.class));
+            assertFalse("expected the reader to lack the audit log permission", _project.hasPermission(reader, CanSeeAuditLogPermission.class));
+
+            long transactionId = writeEvents(_user, 201, 202, 203);
+
+            TransactionRowIds cached = get().getTransactionSampleIds(transactionId, reader, _project, null);
+            TransactionRowIds database = fromDatabase(transactionId, reader);
+
+            assertEquals("a reader without the audit log permission should see no events", List.of(), cached.rowIds());
+            assertEquals("cached and database branches disagreed on sample ids", cached.rowIds(), database.rowIds());
+
+            // The same events are visible to a user who can see the audit log, so the empty results above are the
+            // permission check and not a fixture that failed to write
+            assertEquals("expected the admin to see the events the reader could not",
+                    Set.of(201L, 202L), Set.copyOf(get().getTransactionSampleIds(transactionId, _user, _project, null).rowIds()));
+        }
     }
 }

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -279,8 +279,9 @@ public class AuditLogImpl implements AuditLogService, StartupListener
         ContainerFilter cf = null == containerFilter ? ContainerFilter.current(container, user) : containerFilter;
         Collection<GUID> ids = scopeIds(user, container, cf);
         if (null == ids)
-            return event -> true;
+            return _ -> true;
 
+        // Ensure an O(1) lookup
         Set<GUID> scope = new HashSet<>(ids);
         Set<String> childTypes = cf.getIncludedChildTypes();
 

--- a/audit/src/org/labkey/audit/AuditModule.java
+++ b/audit/src/org/labkey/audit/AuditModule.java
@@ -85,6 +85,14 @@ public class AuditModule extends DefaultModule
     }
 
     @Override
+    public @NotNull Set<Class<?>> getIntegrationTests()
+    {
+        return Set.of(
+            AuditLogImpl.TransactionScopeTestCase.class
+        );
+    }
+
+    @Override
     @NotNull
     public Set<String> getSchemaNames()
     {

--- a/audit/src/org/labkey/audit/model/LogManager.java
+++ b/audit/src/org/labkey/audit/model/LogManager.java
@@ -131,9 +131,9 @@ public class LogManager
         Logger auditLogger = getAuditLogger(type);
         SQLException sqlx = null;
 
-        try (Connection conn = dbTable.getSchema().getScope().getConnection())
+        try (Connection conn = dbTable.getSchema().getScope().getConnection();
+             ParameterMapStatement stmt = StatementUtils.insertStatement(conn, dbTable, c, user, false, true))
         {
-            ParameterMapStatement stmt = StatementUtils.insertStatement(conn, dbTable, c, user, false, true);
             for (var event : events)
             {
                 event = validateFields(provider, event);

--- a/audit/src/org/labkey/audit/model/LogManager.java
+++ b/audit/src/org/labkey/audit/model/LogManager.java
@@ -22,11 +22,9 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.AuditTypeEvent;
 import org.labkey.api.audit.AuditTypeProvider;
-import org.labkey.api.audit.query.DefaultAuditTypeTable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.ObjectFactory;
 import org.labkey.api.data.ParameterMapStatement;
@@ -81,23 +79,9 @@ public class LogManager
 
         if (provider != null)
         {
-            Container c = type.getContainer();
-
-            UserSchema schema = AuditLogService.getAuditLogSchema(user, c != null ? c : ContainerManager.getRoot());
-
-            if (schema != null)
-            {
-                TableInfo table = schema.getTable(provider.getEventName(), false);
-
-                if (table instanceof DefaultAuditTypeTable auditTypeTable)
-                {
-                    // consider using etl data iterator for inserts
-                    type = validateFields(provider, type);
-                    TableInfo dbTable = auditTypeTable.getRealTable();
-                    K ret = Table.insert(user, dbTable, type);
-                    return ret;
-                }
-            }
+            // consider using etl data iterator for inserts
+            type = validateFields(provider, type);
+            return Table.insert(user, provider.getStorageTableInfoForInsert(), type);
         }
         return null;
     }
@@ -142,33 +126,28 @@ public class LogManager
         if (null == provider)
             return;
         Container c = type.getContainer();
-        UserSchema schema = AuditLogService.getAuditLogSchema(user, c != null ? c : ContainerManager.getRoot());
-        TableInfo table = null==schema ? null : schema.getTable(provider.getEventName(), false);
-        TableInfo dbTable = table instanceof DefaultAuditTypeTable auditTypeTable ? auditTypeTable.getRealTable() : null;
+        TableInfo dbTable = provider.getStorageTableInfoForInsert();
 
         Logger auditLogger = getAuditLogger(type);
         SQLException sqlx = null;
 
-        if (null != dbTable)
+        try (Connection conn = dbTable.getSchema().getScope().getConnection())
         {
-            try (Connection conn = dbTable.getSchema().getScope().getConnection())
+            ParameterMapStatement stmt = StatementUtils.insertStatement(conn, dbTable, c, user, false, true);
+            for (var event : events)
             {
-                ParameterMapStatement stmt = StatementUtils.insertStatement(conn, dbTable, c, user, false, true);
-                for (var event : events)
-                {
-                    event = validateFields(provider, event);
-                    Map<String,Object> map = ObjectFactory.Registry.getFactory((Class<K>)event.getClass()).toMap(event, null);
-                    stmt.clearParameters();
-                    stmt.putAll(map);
-                    stmt.addBatch();
-                }
-                stmt.executeBatch();
+                event = validateFields(provider, event);
+                Map<String,Object> map = ObjectFactory.Registry.getFactory((Class<K>)event.getClass()).toMap(event, null);
+                stmt.clearParameters();
+                stmt.putAll(map);
+                stmt.addBatch();
             }
-            catch (SQLException x)
-            {
-                auditLogger.warn("Error occurred saving audit entries to database");
-                sqlx = x;
-            }
+            stmt.executeBatch();
+        }
+        catch (SQLException x)
+        {
+            auditLogger.warn("Error occurred saving audit entries to database");
+            sqlx = x;
         }
 
         if (auditLogger.isInfoEnabled())

--- a/experiment/src/org/labkey/experiment/CustomPropertiesView.java
+++ b/experiment/src/org/labkey/experiment/CustomPropertiesView.java
@@ -27,8 +27,8 @@ import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.SamplesSchema;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
@@ -155,7 +155,7 @@ public class CustomPropertiesView extends JspView<CustomPropertiesView.CustomPro
                     propertyUris.add(property.getPropertyURI());
                 }
 
-                SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("lsid"), parentLSID);
+                SimpleFilter filter = new SimpleFilter(ExpMaterialTable.Column.RowId.fieldKey(), m.getRowId());
                 Map<String,Object> tableProps = new TableSelector(queryTable, filter, null).getMap();
                 // include calculated fields from the domain / query as well
                 List<ColumnInfo> cols = queryTable.getColumns().stream()

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1265,7 +1265,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
     }
 
-    static final BlockingCache<String,_MaterializedQueryHelper> _materializedQueries = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, 12 * CacheManager.HOUR, "materialized sample types", null);
+    static final BlockingCache<String,_MaterializedQueryHelper> _materializedQueries = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, 8 * CacheManager.DAY, "materialized sample types", null);
     static final Map<String, InvalidationCounters> _invalidationCounters = Collections.synchronizedMap(new HashMap<>());
     static final AtomicBoolean initializedListeners = new AtomicBoolean(false);
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
@@ -1386,10 +1387,14 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
      * provisioned table's own indices, not {@link Domain#getPropertyIndices()} -- that set is only ever populated by
      * the caller that is saving a domain, so it is empty on a domain read back from the database. Never unique:
      * {@link #getJoinSQL} selects root-scoped columns from the root sample's row, so a value that is unique in the
-     * provisioned table repeats across every aliquot sharing that root.
+     * provisioned table repeats across every aliquot sharing that root. PostgreSQL only: SQL Server refuses an index
+     * over a column as wide as a default string property, so a mirrored index there would fail the materialization.
      */
     private List<String> getDomainIndexDdl()
     {
+        if (!getExpSchema().getDbSchema().getSqlDialect().isPostgreSQL())
+            return List.of();
+
         TableInfo provisioned = _ss.getTinfo();
         if (null == provisioned)
             return List.of();
@@ -2330,6 +2335,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         @Test
         public void testDomainIndexMirroredNonUnique() throws Exception
         {
+            Assume.assumeTrue("Domain indices are only mirrored on PostgreSQL", ExperimentService.get().getSchema().getSqlDialect().isPostgreSQL());
+
             ExpSampleType st = createSampleType("IncrUpdIndexed", List.of(new GWTIndex(List.of("rootProp"), true)));
             insertRoots(st, "R1");
             insertAliquots(st, "R1", 3);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -52,6 +52,7 @@ import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MaterializedQueryHelper;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.PHI;
+import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.Sort;
@@ -88,6 +89,7 @@ import org.labkey.api.exp.query.ExpSampleTypeTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.gwt.client.AuditBehaviorType;
+import org.labkey.api.gwt.client.model.GWTIndex;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.gwt.client.model.PropertyValidatorType;
 import org.labkey.api.inventory.InventoryService;
@@ -1365,15 +1367,60 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 .updateColumns(updateColumns)
                 .unlogged(true)
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_rowid ON temp.${NAME} (rowid)")
-                .addIndex("CREATE UNIQUE INDEX uq_${NAME}_lsid ON temp.${NAME} (lsid)")
                 .addIndex("CREATE INDEX idx_${NAME}_container ON temp.${NAME} (container)")
                 .addIndex("CREATE INDEX idx_${NAME}_root ON temp.${NAME} (rootmaterialrowid)");
+
+            getDomainIndexDdl().forEach(builder::addIndex);
 
             if (isIncrementalUpdateDisabled())
                 builder.addInvalidCheck(() -> String.valueOf(getInvalidateCounters(_ss.getLSID()).update.get()));
 
             return (_MaterializedQueryHelper) builder.build();
         });
+    }
+
+    /**
+     * DDL mirroring the sample type domain's admin-defined indices onto the materialized table. Never unique:
+     * {@link #getJoinSQL} selects root-scoped columns from the root sample's row, so a value that is unique in the
+     * provisioned table repeats across every aliquot sharing that root.
+     */
+    private List<String> getDomainIndexDdl()
+    {
+        TableInfo provisioned = _ss.getTinfo();
+        if (null == provisioned)
+            return List.of();
+
+        Domain domain = _ss.getDomain();
+
+        List<String> ddl = new ArrayList<>();
+        Set<String> distinctColumnLists = new HashSet<>();
+
+        for (PropertyStorageSpec.Index index : domain.getPropertyIndices())
+        {
+            List<String> columns = new ArrayList<>();
+
+            for (String storageName : index.translateToStorageNames(domain).columnNames)
+            {
+                ColumnInfo column = provisioned.getColumn(storageName);
+
+                if (null == column)
+                {
+                    _log.warn("Sample type {} is indexed on {}, which is not in its provisioned table; that index is not mirrored onto the materialized table.", _ss.getName(), storageName);
+                    columns.clear();
+                    break;
+                }
+
+                columns.add(column.getSelectIdentifier().getSql().getSQL());
+            }
+
+            if (columns.isEmpty() || !distinctColumnLists.add(String.join(",", columns)))
+                continue;
+
+            // Ordinal names because ${NAME} is already 33 of the 63 chars Postgres allows before it silently truncates and collides.
+            ddl.add("CREATE INDEX idx_${NAME}_d" + ddl.size() + " ON temp.${NAME} (" + String.join(", ", columns) + ")");
+        }
+
+        return ddl;
     }
 
     /* SELECT and JOIN, does not include WHERE, same as getJoinSQL() */
@@ -2259,7 +2306,28 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             assertCacheMatchesFreshDerivation(table, st.getLSID());
         }
 
+        @Test
+        public void testDomainIndexMirroredNonUnique() throws Exception
+        {
+            ExpSampleType st = createSampleType("IncrUpdIndexed", List.of(new GWTIndex(List.of("rootProp"), true)));
+            insertRoots(st, "R1");
+            insertAliquots(st, "R1", 3);
+
+            ExpMaterialTableImpl table = getSamplesTable(st);
+            List<String> ddl = table.getDomainIndexDdl();
+            assertEquals("Expected the domain's one index to be mirrored: " + ddl, 1, ddl.size());
+            assertFalse("Mirrored index must not be unique: " + ddl.getFirst(), ddl.getFirst().contains("UNIQUE"));
+
+            // All four rows share the root's rootProp, so mirroring the domain's unique index as-is would fail the build.
+            assertCacheMatchesFreshDerivation(table, st.getLSID());
+        }
+
         private ExpSampleType createSampleType(String name) throws Exception
+        {
+            return createSampleType(name, Collections.emptyList());
+        }
+
+        private ExpSampleType createSampleType(String name, List<GWTIndex> indices) throws Exception
         {
             List<GWTPropertyDescriptor> props = new ArrayList<>();
             props.add(new GWTPropertyDescriptor("name", "string"));
@@ -2269,7 +2337,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             GWTPropertyDescriptor aliquotProp = new GWTPropertyDescriptor("aliquotProp", "string");
             aliquotProp.setDerivationDataScope(ExpSchema.DerivationDataScopeType.ChildOnly.name()); // -> m_aliquot join
             props.add(aliquotProp);
-            return SampleTypeService.get().createSampleType(_c, _user, name, null, props, Collections.emptyList(), -1, -1, -1, -1, null);
+            return SampleTypeService.get().createSampleType(_c, _user, name, null, props, indices, -1, -1, -1, -1, null);
         }
 
         private ExpMaterialTableImpl getSamplesTable(ExpSampleType st)

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1369,11 +1369,15 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             MaterializedQueryHelper.Builder builder = new _MaterializedQueryHelper.Builder(_ss.getLSID(), "", getExpSchema().getDbSchema().getScope(), viewSql)
                 .updateColumns(updateColumns)
                 .unlogged(true)
+                // RowId and Container are used in many places so ensure they're created before use. Other indices can
+                // be added as a followup step
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_rowid ON temp.${NAME} (rowid)")
                 .addIndex("CREATE INDEX idx_${NAME}_container ON temp.${NAME} (container)")
-                .addIndex("CREATE INDEX idx_${NAME}_root ON temp.${NAME} (rootmaterialrowid)");
+                .addDeferredIndex("CREATE INDEX idx_${NAME}_root ON temp.${NAME} (rootmaterialrowid)")
+                // Deferred despite being UNIQUE. Source data guarantees uniqueness, and this is very expensive to build
+                .addDeferredIndex("CREATE UNIQUE INDEX uq_${NAME}_lsid ON temp.${NAME} (lsid)");
 
-            getDomainIndexDdl().forEach(builder::addIndex);
+            getDomainIndexDdl().forEach(builder::addDeferredIndex);
 
             if (isIncrementalUpdateDisabled())
                 builder.addInvalidCheck(() -> String.valueOf(getInvalidateCounters(_ss.getLSID()).update.get()));
@@ -1407,9 +1411,11 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         List<String> ddl = new ArrayList<>();
         Set<String> distinctColumnLists = new HashSet<>();
 
-        // Seeded with the kind's own indices (rowid, name); the materialized table already indexes those.
+        // Seeded with the provisioned columns the builder already indexes above: the kind's own indices (rowid, name)
+        // and lsid. Its other indices are over exp.material columns, which cannot appear in a provisioned index.
         for (PropertyStorageSpec.Index index : kind.getPropertyIndices(domain))
             distinctColumnLists.add(indexKey(Arrays.asList(index.translateToStorageNames(domain).columnNames)));
+        distinctColumnLists.add(indexKey(List.of("lsid")));
 
         for (TableInfo.IndexDefinition index : StorageProvisioner.get().getSchemaTableInfo(domain).getAllIndices())
         {
@@ -1521,7 +1527,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             @Override
             public _MaterializedQueryHelper build()
             {
-                return new _MaterializedQueryHelper(_lsid, _updateColumns, _prefix, _scope, _select, _uptodate, _supplier, _indexes, _max, _isSelectInto, _unlogged);
+                return new _MaterializedQueryHelper(_lsid, _updateColumns, _prefix, _scope, _select, _uptodate, _supplier, _indexes, _deferredIndexes, _max, _isSelectInto, _unlogged);
             }
         }
 
@@ -1534,12 +1540,13 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             @Nullable SQLFragment uptodate,
             Supplier<String> supplier,
             @Nullable Collection<String> indexes,
+            @Nullable Collection<String> deferredIndexes,
             long maxTimeToCache,
             boolean isSelectIntoSql,
             boolean unlogged
         )
         {
-            super(prefix, scope, select, uptodate, supplier, indexes, maxTimeToCache, isSelectIntoSql, unlogged);
+            super(prefix, scope, select, uptodate, supplier, indexes, deferredIndexes, maxTimeToCache, isSelectIntoSql, unlogged);
             this._lsid = lsid;
             this._updateColumns = updateColumns;
         }
@@ -1565,6 +1572,14 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 lockAcquired = materialized.getLock().tryLock(1, TimeUnit.MINUTES);
                 if (Materialized.LoadingState.ERROR == materialized._loadingState.get())
                     throw materialized._loadException;
+
+                // The lock is held by a full rebuild (including its deferred indexes). Leave the counters untouched so
+                // readers stay on the live query and the next materializeAsync retries, rather than racing that rebuild.
+                if (!lockAcquired)
+                {
+                    _log.info("Skipping incremental update of {}; a rebuild still holds the lock.", getMaterializationName());
+                    return;
+                }
 
                 runIncremental("delete", materialized.incrementalDeleteCheck, this::executeIncrementalDelete);
                 runIncremental("update", materialized.incrementalUpdateCheck, this::executeIncrementalUpdate);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -79,6 +79,7 @@ import org.labkey.api.exp.api.NameExpressionOptionService;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.DefaultPropertyValidator;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.property.IPropertyValidator;
@@ -148,6 +149,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -1380,7 +1382,9 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     }
 
     /**
-     * DDL mirroring the sample type domain's admin-defined indices onto the materialized table. Never unique:
+     * DDL mirroring the sample type domain's admin-defined indices onto the materialized table. Read from the
+     * provisioned table's own indices, not {@link Domain#getPropertyIndices()} -- that set is only ever populated by
+     * the caller that is saving a domain, so it is empty on a domain read back from the database. Never unique:
      * {@link #getJoinSQL} selects root-scoped columns from the root sample's row, so a value that is unique in the
      * provisioned table repeats across every aliquot sharing that root.
      */
@@ -1391,36 +1395,53 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             return List.of();
 
         Domain domain = _ss.getDomain();
+        DomainKind<?> kind = domain.getDomainKind();
+        if (null == kind)
+            return List.of();
 
         List<String> ddl = new ArrayList<>();
         Set<String> distinctColumnLists = new HashSet<>();
 
-        for (PropertyStorageSpec.Index index : domain.getPropertyIndices())
-        {
-            List<String> columns = new ArrayList<>();
+        // Seeded with the kind's own indices (rowid, name); the materialized table already indexes those.
+        for (PropertyStorageSpec.Index index : kind.getPropertyIndices(domain))
+            distinctColumnLists.add(indexKey(Arrays.asList(index.translateToStorageNames(domain).columnNames)));
 
-            for (String storageName : index.translateToStorageNames(domain).columnNames)
+        for (TableInfo.IndexDefinition index : StorageProvisioner.get().getSchemaTableInfo(domain).getAllIndices())
+        {
+            if (TableInfo.IndexType.Primary == index.indexType())
+                continue;
+
+            List<String> names = new ArrayList<>();
+            List<String> identifiers = new ArrayList<>();
+
+            for (ColumnInfo indexColumn : index.columns())
             {
-                ColumnInfo column = provisioned.getColumn(storageName);
+                ColumnInfo column = provisioned.getColumn(indexColumn.getName());
 
                 if (null == column)
                 {
-                    _log.warn("Sample type {} is indexed on {}, which is not in its provisioned table; that index is not mirrored onto the materialized table.", _ss.getName(), storageName);
-                    columns.clear();
+                    _log.warn("Sample type {} is indexed on {}, which is not in its provisioned table; that index is not mirrored onto the materialized table.", _ss.getName(), indexColumn.getName());
+                    names.clear();
                     break;
                 }
 
-                columns.add(column.getSelectIdentifier().getSql().getSQL());
+                names.add(column.getName());
+                identifiers.add(column.getSelectIdentifier().getSql().getSQL());
             }
 
-            if (columns.isEmpty() || !distinctColumnLists.add(String.join(",", columns)))
+            if (names.isEmpty() || !distinctColumnLists.add(indexKey(names)))
                 continue;
 
             // Ordinal names because ${NAME} is already 33 of the 63 chars Postgres allows before it silently truncates and collides.
-            ddl.add("CREATE INDEX idx_${NAME}_d" + ddl.size() + " ON temp.${NAME} (" + String.join(", ", columns) + ")");
+            ddl.add("CREATE INDEX idx_${NAME}_d" + ddl.size() + " ON temp.${NAME} (" + String.join(", ", identifiers) + ")");
         }
 
         return ddl;
+    }
+
+    private static String indexKey(List<String> columnNames)
+    {
+        return columnNames.stream().map(name -> name.toLowerCase(Locale.ROOT)).collect(Collectors.joining(","));
     }
 
     /* SELECT and JOIN, does not include WHERE, same as getJoinSQL() */

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1368,19 +1368,37 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     @Override
     public void addAuditEvent(User user, Container container, String comment, String userComment, ExpMaterial sample, Map<String, Object> metadata, String updateType)
     {
+        AuditLogService.get().addEvent(user, createTimelineAuditRecord(container, comment, userComment, sample, metadata, updateType));
+    }
+
+    @Override
+    public SampleTimelineAuditEvent createTimelineAuditRecord(Container container, String comment, String userComment, ExpMaterial sample, Map<String, Object> metadata, String updateType)
+    {
         SampleTimelineAuditEvent event = createAuditRecord(container, comment, userComment, sample, metadata);
         event.setInventoryUpdateType(updateType);
         event.setUserComment(userComment);
-        AuditLogService.get().addEvent(user, event);
+        return event;
     }
 
     @Override
     public void addAuditEvents(User user, Container container, String comment, String userComment, Collection<? extends ExpMaterial> samples, Map<String, Object> metadata)
     {
-        List<SampleTimelineAuditEvent> events = samples.stream()
-                .map(sample -> createAuditRecord(container, comment, userComment, sample, metadata))
-                .collect(Collectors.toList());
-        AuditLogService.get().addEvents(user, events);
+        AuditLogService auditLog = AuditLogService.get();
+        List<SampleTimelineAuditEvent> events = new ArrayList<>(Math.min(samples.size(), AUDIT_BATCH_SIZE));
+
+        for (ExpMaterial sample : samples)
+        {
+            events.add(createAuditRecord(container, comment, userComment, sample, metadata));
+
+            if (events.size() >= AUDIT_BATCH_SIZE)
+            {
+                auditLog.addEvents(user, events);
+                events.clear();
+            }
+        }
+
+        if (!events.isEmpty())
+            auditLog.addEvents(user, events);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1231,13 +1231,13 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     @Override
-    public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow, Map<String, Object> providedValues)
+    public DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> row, Map<String, Object> existingRow, Map<String, Object> providedValues, List<AuditTypeEvent> sideEffectEvents)
     {
         return createAuditRecord(c, tInfo, getCommentDetailed(action, !existingRow.isEmpty()), userComment, action, row, existingRow, providedValues);
     }
 
     @Override
-    protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row)
+    protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row, List<AuditTypeEvent> sideEffectEvents)
     {
         return createAuditRecord(c, tInfo, String.format(action.getCommentSummary(), rowCount), userComment, row);
     }

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -1049,7 +1049,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
         return CoreSchema.getInstance().getSqlDialect();
     }
 
-    @Override
+    @Override @NotNull
     public SchemaTableInfo getSchemaTableInfo(Domain domain)
     {
         DomainKind<?> kind = getDomainKind(domain);

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -87,6 +87,7 @@ import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JunitUtil;
+import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.TestContext;
@@ -648,6 +649,19 @@ public class StorageProvisionerImpl implements StorageProvisioner
         _ProvisionedTable wrapper = new _ProvisionedTable(sti.getSchema(), sti.getName(), sti, domain);
         wrapper.wrapAllColumns();
         return wrapper;
+    }
+
+    @Override
+    @NotNull
+    public TableInfo createSharedTableInfoImpl(@NotNull Domain domain)
+    {
+        TableInfo table = createTableInfoImpl(domain);
+        table.setLocked(true);
+        MemTracker.getInstance().remove(table);
+        // The table holds the Domain, which holds a DomainDescriptor that MemTracker tracks separately
+        if (domain instanceof DomainImpl di)
+            MemTracker.getInstance().remove(di._dd);
+        return table;
     }
 
     @NotNull

--- a/list/src/org/labkey/list/ListModule.java
+++ b/list/src/org/labkey/list/ListModule.java
@@ -58,6 +58,7 @@ import org.labkey.list.model.ListDef;
 import org.labkey.list.model.ListManager;
 import org.labkey.list.model.ListManagerSchema;
 import org.labkey.list.model.ListQuerySchema;
+import org.labkey.list.model.ListQueryUpdateService;
 import org.labkey.list.model.ListSchema;
 import org.labkey.list.model.ListServiceImpl;
 import org.labkey.list.model.ListWriter;
@@ -234,6 +235,14 @@ public class ListModule extends SpringModule
             ListManager.TestCase.class,
             ListWriter.TestCase.class,
             ListAuditProvider.TestCase.class
+        );
+    }
+
+    @Override
+    public @NotNull Set<Class<?>> getIntegrationTests()
+    {
+        return Set.of(
+            ListQueryUpdateService.AuditBatchTestCase.class
         );
     }
 }

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -33,6 +33,7 @@ import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.data.*;
 import org.labkey.api.data.Selector.ForEachBlock;
@@ -1203,78 +1204,111 @@ public class ListManager implements SearchService.DocumentProvider
 
     void addAuditEvent(ListDefinitionImpl list, User user, Container c, String comment, String entityId, @Nullable String oldRecord, @Nullable String newRecord)
     {
+        AuditLogService.get().addEvent(user, createAuditEvent(list, c, comment, entityId, oldRecord, newRecord));
+    }
+
+    ListAuditProvider.ListAuditEvent createAuditEvent(ListDefinitionImpl list, Container c, String comment, String entityId, @Nullable String oldRecord, @Nullable String newRecord)
+    {
         ListAuditProvider.ListAuditEvent event = new ListAuditProvider.ListAuditEvent(c, comment, list);
 
         event.setListItemEntityId(entityId);
         if (oldRecord != null) event.setOldRecordMap(oldRecord);
         if (newRecord != null) event.setNewRecordMap(newRecord);
 
-        AuditLogService.get().addEvent(user, event);
+        return event;
     }
 
     String formatAuditItem(ListDefinitionImpl list, User user, Map<String, Object> props)
     {
-        String itemRecord = "";
-        TableInfo ti = list.getTable(user);
+        return getAuditItemFormatter(list, user).format(props);
+    }
 
-        if (null != ti)
+    AuditItemFormatter getAuditItemFormatter(ListDefinitionImpl list, User user)
+    {
+        return new AuditItemFormatter(list, user);
+    }
+
+    /**
+     * Builds the audit record map for list rows. Resolve one instance per operation, not per row: the table, the
+     * reserved property names, and the name resolution for a given key are identical for every row of a list.
+     */
+    static class AuditItemFormatter
+    {
+        private final TableInfo _table;
+        private final Domain _domain;
+        private final Set<String> _reserved;
+        private final Map<String, String> _resolvedNames = new CaseInsensitiveHashMap<>();
+
+        AuditItemFormatter(ListDefinitionImpl list, User user)
         {
-            Map<String, Object> recordChangedMap = new CaseInsensitiveHashMap<>();
-            Set<String> reserved = list.getDomain().getDomainKind().getReservedPropertyNames(list.getDomain(), user);
+            _table = list.getTable(user);
+            _domain = list.getDomain();
+            _reserved = null == _table ? Set.of() : new CaseInsensitiveHashSet(_domain.getDomainKind().getReservedPropertyNames(_domain, user));
+        }
 
-            // Match props to columns
+        String format(Map<String, Object> props)
+        {
+            if (null == _table)
+                return "";
+
+            Map<String, Object> recordChangedMap = new CaseInsensitiveHashMap<>();
+
             for (Map.Entry<String, Object> entry : props.entrySet())
             {
-                String baseKey = entry.getKey();
+                Object value = entry.getValue();
 
-                boolean isReserved = false;
-                for (String res : reserved)
-                {
-                    if (res.equalsIgnoreCase(baseKey))
-                    {
-                        isReserved = true;
-                        break;
-                    }
-                }
-
-                if (isReserved)
+                if (null == value)
                     continue;
 
-                ColumnInfo col = ti.getColumn(FieldKey.fromParts(baseKey));
-                Object value = entry.getValue();
-                String key = null;
+                String key = resolveName(entry.getKey());
 
-                if (null != col)
-                {
-                    // Found the column
-                    key = col.getName(); // best good
-                }
-                else
-                {
-                    // See if there is a match in the domain properties
-                    for (DomainProperty dp : list.getDomain().getProperties())
-                    {
-                        if (dp.getName().equalsIgnoreCase(baseKey))
-                        {
-                            key = dp.getName(); // middle good
-                        }
-                    }
-
-                    // Try by name
-                    DomainProperty dp = list.getDomain().getPropertyByName(baseKey);
-                    if (null != dp)
-                        key = dp.getName();
-                }
-
-                if (null != key && null != value)
+                if (null != key)
                     recordChangedMap.put(key, value);
             }
 
-            if (!recordChangedMap.isEmpty())
-                itemRecord = ListAuditProvider.encodeForDataMap(recordChangedMap);
+            return recordChangedMap.isEmpty() ? "" : ListAuditProvider.encodeForDataMap(recordChangedMap);
         }
 
-        return itemRecord;
+        /** @return the canonical property name to audit under, or null if the key is reserved or unknown */
+        private String resolveName(String baseKey)
+        {
+            if (_resolvedNames.containsKey(baseKey))
+                return _resolvedNames.get(baseKey);
+
+            String key = computeName(baseKey);
+            _resolvedNames.put(baseKey, key);
+
+            return key;
+        }
+
+        private String computeName(String baseKey)
+        {
+            if (_reserved.contains(baseKey))
+                return null;
+
+            ColumnInfo col = _table.getColumn(FieldKey.fromParts(baseKey));
+
+            if (null != col)
+                return col.getName(); // best good
+
+            String key = null;
+
+            // See if there is a match in the domain properties
+            for (DomainProperty dp : _domain.getProperties())
+            {
+                if (dp.getName().equalsIgnoreCase(baseKey))
+                {
+                    key = dp.getName(); // middle good
+                }
+            }
+
+            // Try by name
+            DomainProperty dp = _domain.getPropertyByName(baseKey);
+            if (null != dp)
+                key = dp.getName();
+
+            return key;
+        }
     }
 
     boolean importListSchema(

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -18,10 +18,15 @@ package org.labkey.list.model;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.attachments.AttachmentParent;
 import org.labkey.api.attachments.AttachmentParentFactory;
 import org.labkey.api.attachments.AttachmentService;
+import org.labkey.api.audit.AbstractAuditHandler;
 import org.labkey.api.audit.AbstractAuditTypeProvider;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.TransactionAuditProvider;
@@ -52,6 +57,7 @@ import org.labkey.api.exp.list.ListService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.IPropertyValidator;
+import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.property.ValidatorContext;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.lists.permissions.ManagePicklistsPermission;
@@ -73,11 +79,13 @@ import org.labkey.api.security.permissions.MoveEntitiesPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.EditorRole;
+import org.labkey.api.test.TestTimeout;
 import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
+import org.labkey.api.util.TestContext;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.writer.VirtualFile;
@@ -102,6 +110,12 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
 {
     private final ListDefinitionImpl _list;
     private static final String ID = "entityId";
+    private static final String AUDIT_COMMENT_INSERT = "A new list record was inserted";
+    private static final String AUDIT_COMMENT_UPDATE = "An existing list record was modified";
+    private static final String AUDIT_COMMENT_DELETE = "An existing list record was deleted";
+
+    /** Non-null while a multi-row operation is in flight; see {@link RowAuditBatch}. */
+    private RowAuditBatch _auditBatch;
 
     public ListQueryUpdateService(ListTable queryTable, TableInfo dbTable, @NotNull ListDefinition list)
     {
@@ -179,25 +193,105 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
 
         if (null != result)
         {
-            ListManager mgr = ListManager.get();
-
-            for (Map<String, Object> row : result)
+            try (RowAuditBatch ignored = beginAuditBatch(user))
             {
-                if (null != row.get(ID))
+                for (Map<String, Object> row : result)
                 {
-                    // Audit each row
-                    String entityId = (String) row.get(ID);
-                    String newRecord = mgr.formatAuditItem(_list, user, row);
+                    if (null != row.get(ID))
+                    {
+                        // Audit each row
+                        String entityId = (String) row.get(ID);
 
-                    mgr.addAuditEvent(_list, user, container, "A new list record was inserted", entityId, null, newRecord);
+                        auditRowChange(user, container, AUDIT_COMMENT_INSERT, entityId, null, row);
+                    }
                 }
             }
 
             if (!result.isEmpty() && !errors.hasErrors())
-                mgr.indexList(_list);
+                ListManager.get().indexList(_list);
         }
 
         return result;
+    }
+
+    /**
+     * Accumulates row audit events so one operation writes them with a single batched statement.
+     */
+    private class RowAuditBatch implements AutoCloseable
+    {
+        private final User _user;
+        private final ListManager.AuditItemFormatter _formatter;
+        private final List<ListAuditProvider.ListAuditEvent> _events = new ArrayList<>();
+
+        RowAuditBatch(User user)
+        {
+            _user = user;
+            _formatter = ListManager.get().getAuditItemFormatter(_list, user);
+        }
+
+        String format(Map<String, Object> props)
+        {
+            return _formatter.format(props);
+        }
+
+        void add(Container c, String comment, String entityId, @Nullable String oldRecord, @Nullable String newRecord)
+        {
+            _events.add(ListManager.get().createAuditEvent(_list, c, comment, entityId, oldRecord, newRecord));
+
+            if (_events.size() >= AbstractAuditHandler.AUDIT_BATCH_SIZE)
+                flush();
+        }
+
+        void flush()
+        {
+            if (_events.isEmpty())
+                return;
+
+            // close() flushes again on the way out of a failed operation, so hand off before writing to avoid re-inserting
+            List<ListAuditProvider.ListAuditEvent> toWrite = new ArrayList<>(_events);
+            _events.clear();
+
+            AuditLogService.get().addEvents(_user, toWrite);
+        }
+
+        @Override
+        public void close()
+        {
+            flush();
+
+            if (this == _auditBatch)
+                _auditBatch = null;
+        }
+    }
+
+    /** @return a batch to close when the operation completes, or null if an enclosing operation already owns one */
+    private @Nullable RowAuditBatch beginAuditBatch(User user)
+    {
+        if (null != _auditBatch)
+            return null;
+
+        _auditBatch = new RowAuditBatch(user);
+
+        return _auditBatch;
+    }
+
+    private void auditRowChange(User user, Container container, String comment, String entityId, @Nullable Map<String, Object> oldRow, @Nullable Map<String, Object> newRow)
+    {
+        RowAuditBatch batch = _auditBatch;
+
+        if (null == batch)
+        {
+            ListManager mgr = ListManager.get();
+            mgr.addAuditEvent(_list, user, container, comment, entityId,
+                    null == oldRow ? null : mgr.formatAuditItem(_list, user, oldRow),
+                    null == newRow ? null : mgr.formatAuditItem(_list, user, newRow));
+        }
+        else
+        {
+            batch.add(container, comment, entityId,
+                    null == oldRow ? null : batch.format(oldRow),
+                    null == newRow ? null : batch.format(newRow));
+        }
     }
 
     private User getListUser(User user, Container container)
@@ -306,7 +400,15 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         if (!_list.isVisible(user))
             throw new UnauthorizedException("You do not have permission to update data into this table.");
 
-        List<Map<String, Object>> result = super.updateRows(getListUser(user, container), container, rows, oldKeys, errors, configParameters, extraScriptContext);
+        List<Map<String, Object>> result;
+        User listUser = getListUser(user, container);
+
+        // updateRow() audits as the list user, so the batch must format and log as that user too
+        try (RowAuditBatch ignored = beginAuditBatch(listUser))
+        {
+            result = super.updateRows(listUser, container, rows, oldKeys, errors, configParameters, extraScriptContext);
+        }
+
         if (!result.isEmpty())
             ListManager.get().indexList(_list);
         return result;
@@ -394,7 +496,6 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
 
             if (null != result && null != result.get(ID))
             {
-                ListManager mgr = ListManager.get();
                 String entityId = (String) result.get(ID);
 
                 try
@@ -430,11 +531,8 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
                     }
                 }
 
-                String oldRecord = mgr.formatAuditItem(_list, user, oldRow);
-                String newRecord = mgr.formatAuditItem(_list, user, result);
-
                 // Audit
-                mgr.addAuditEvent(_list, user, container, "An existing list record was modified", entityId, oldRecord, newRecord);
+                auditRowChange(user, container, AUDIT_COMMENT_UPDATE, entityId, oldRow, result);
             }
         }
 
@@ -729,6 +827,16 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
     }
 
     @Override
+    public List<Map<String, Object>> deleteRows(User user, Container container, List<Map<String, Object>> keys, @Nullable Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext)
+            throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
+    {
+        try (RowAuditBatch ignored = beginAuditBatch(user))
+        {
+            return super.deleteRows(user, container, keys, configParameters, extraScriptContext);
+        }
+    }
+
+    @Override
     protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRowMap) throws InvalidKeyException, QueryUpdateServiceException, SQLException
     {
         if (!_list.isVisible(user))
@@ -743,10 +851,9 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
             if (null != entityId)
             {
                 ListManager mgr = ListManager.get();
-                String deletedRecord = mgr.formatAuditItem(_list, user, result);
 
                 // Audit
-                mgr.addAuditEvent(_list, user, container, "An existing list record was deleted", entityId, deletedRecord, null);
+                auditRowChange(user, container, AUDIT_COMMENT_DELETE, entityId, result, null);
 
                 // Remove attachments
                 if (hasAttachmentProperties())
@@ -875,5 +982,112 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         return _list != null?
                 _list.getDomain() :
                 super.getDomain();
+    }
+
+    /**
+     * RowAuditBatch accumulates row audit events and flushes in AUDIT_BATCH_SIZE chunks, so an operation has to
+     * cross that boundary for the mid-operation flush to run at all. A batch that gets dropped, or replayed by the
+     * flush in close(), changes the audit row count - which is what these assertions watch.
+     */
+    @TestTimeout(TestTimeout.DEFAULT * 5)
+    public static class AuditBatchTestCase extends Assert
+    {
+        private static final String PROJECT_NAME = "ListAuditBatchTest Project";
+        private static final String LIST_NAME = "Audit batch list";
+        private static final String KEY_NAME = "Key";
+        private static final String VALUE_FIELD = "value";
+
+        // Enough to force one flush from add() and leave a partial batch for close()
+        private static final int ROW_COUNT = AbstractAuditHandler.AUDIT_BATCH_SIZE + 7;
+
+        private static User _user;
+        private static Container _container;
+        private static ListDefinition _list;
+
+        @BeforeClass
+        public static void setup() throws Exception
+        {
+            _user = TestContext.get().getUser();
+
+            deleteTestContainer();
+            _container = ContainerManager.ensureContainer(PROJECT_NAME, _user);
+
+            _list = ListService.get().createList(_container, LIST_NAME, ListDefinition.KeyType.AutoIncrementInteger);
+            _list.setKeyName(KEY_NAME);
+
+            DomainProperty dp = _list.getDomain().addProperty();
+            dp.setName(VALUE_FIELD);
+            dp.setType(PropertyService.get().getType(_container, PropertyType.STRING.getXmlName()));
+            dp.setPropertyURI(ListDomainKind.createPropertyURI(LIST_NAME, VALUE_FIELD, _container, _list.getKeyType()).toString());
+            _list.save(_user);
+        }
+
+        @AfterClass
+        public static void cleanup()
+        {
+            _list = null;
+            _container = null;
+            _user = null;
+
+            deleteTestContainer();
+        }
+
+        private static void deleteTestContainer()
+        {
+            Container project = ContainerManager.getForPath(PROJECT_NAME);
+
+            if (null != project)
+                ContainerManager.deleteAll(project, TestContext.get().getUser());
+        }
+
+        private int auditCount(String comment)
+        {
+            SimpleFilter filter = new SimpleFilter(FieldKey.fromParts(ListAuditProvider.COLUMN_NAME_LIST_ID), _list.getListId());
+            filter.addCondition(FieldKey.fromParts("Comment"), comment);
+
+            return AuditLogService.get().getAuditEvents(_container, _user, ListManager.LIST_AUDIT_EVENT, filter, null).size();
+        }
+
+        @Test
+        public void auditsEveryRowAcrossTheBatchBoundary() throws Exception
+        {
+            TableInfo table = _list.getTable(_user);
+            assertNotNull("expected the list table to resolve", table);
+
+            List<Map<String, Object>> rows = new ArrayList<>(ROW_COUNT);
+            for (int i = 0; i < ROW_COUNT; i++)
+                rows.add(CaseInsensitiveHashMap.<Object>of(VALUE_FIELD, "row-" + i));
+
+            BatchValidationException errors = new BatchValidationException();
+            List<Map<String, Object>> inserted;
+
+            // Without a transaction LogManager declines to batch, so the batched insert path only runs inside one
+            try (DbScope.Transaction tx = table.getSchema().getScope().ensureTransaction())
+            {
+                inserted = table.getUpdateService().insertRows(_user, _container, rows, errors, null, null);
+                if (errors.hasErrors())
+                    throw errors.getLastRowError();
+                tx.commit();
+            }
+
+            assertEquals("expected every row to be inserted", ROW_COUNT, inserted.size());
+            assertEquals("one insert audit event per row", ROW_COUNT, auditCount(AUDIT_COMMENT_INSERT));
+
+            List<Map<String, Object>> keys = new ArrayList<>(ROW_COUNT);
+            for (Map<String, Object> row : inserted)
+                keys.add(CaseInsensitiveHashMap.<Object>of(KEY_NAME, row.get(KEY_NAME)));
+
+            List<Map<String, Object>> deleted;
+
+            try (DbScope.Transaction tx = table.getSchema().getScope().ensureTransaction())
+            {
+                deleted = table.getUpdateService().deleteRows(_user, _container, keys, null, null);
+                tx.commit();
+            }
+
+            assertEquals("expected every row to be deleted", ROW_COUNT, deleted.size());
+            assertEquals("one delete audit event per row", ROW_COUNT, auditCount(AUDIT_COMMENT_DELETE));
+            assertEquals("deleting rows must not emit insert events", ROW_COUNT, auditCount(AUDIT_COMMENT_INSERT));
+        }
     }
 }

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -257,10 +257,15 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         @Override
         public void close()
         {
-            flush();
-
-            if (this == _auditBatch)
-                _auditBatch = null;
+            try
+            {
+                flush();
+            }
+            finally
+            {
+                if (this == _auditBatch)
+                    _auditBatch = null;
+            }
         }
     }
 

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3083,7 +3083,7 @@ public class QueryServiceImpl implements QueryService
         return new AbstractAuditHandler()
         {
             @Override
-            protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tinfo, AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row)
+            protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tinfo, AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row, List<AuditTypeEvent> sideEffectEvents)
             {
                 DetailedAuditTypeEvent event = createAuditRecord(c, tinfo, String.format(action.getCommentSummary(), rowCount), row, null);
                 event.setUserComment(userComment);
@@ -3091,7 +3091,7 @@ public class QueryServiceImpl implements QueryService
             }
 
             @Override
-            protected DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tinfo, AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> updatedRow, Map<String, Object> existingRow, @Nullable Map<String, Object> providedValues)
+            protected DetailedAuditTypeEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tinfo, AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> updatedRow, Map<String, Object> existingRow, @Nullable Map<String, Object> providedValues, List<AuditTypeEvent> sideEffectEvents)
             {
                 DetailedAuditTypeEvent event = createAuditRecord(c, tinfo, action.getCommentDetailed(), updatedRow, existingRow);
                 event.setUserComment(userComment);

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1790,7 +1790,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
                         Map<String, Object> row = rows.get(i);
                         Map<String, Object> existingRow = null==existingRows ? null : existingRows.get(i);
                         // note switched order (oldRecord, newRecord)
-                        var event = createDetailedAuditRecord(user, c, (AuditConfigurable)table, action, userComment, row, existingRow, null);
+                        var event = createDetailedAuditRecord(user, c, (AuditConfigurable)table, action, userComment, row, existingRow, null, List.of());
                         batch.add(event);
                         if (batch.size() > 1000)
                         {
@@ -1808,7 +1808,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
         }
 
         @Override
-        protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row)
+        protected AuditTypeEvent createSummaryAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, int rowCount, @Nullable Map<String, Object> row, List<AuditTypeEvent> sideEffectEvents)
         {
             throw new UnsupportedOperationException();
         }
@@ -1817,7 +1817,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
          * NOTE: userComment field is not supported for this domain and will be ignored
          */
         @Override
-        protected DatasetAuditProvider.DatasetAuditEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> record, Map<String, Object> existingRecord, Map<String, Object> providedValues)
+        protected DatasetAuditProvider.DatasetAuditEvent createDetailedAuditRecord(User user, Container c, AuditConfigurable tInfo, QueryService.AuditAction action, @Nullable String userComment, @Nullable Map<String, Object> record, Map<String, Object> existingRecord, Map<String, Object> providedValues, List<AuditTypeEvent> sideEffectEvents)
         {
             String auditComment = switch (action)
                     {

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1792,7 +1792,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
                         // note switched order (oldRecord, newRecord)
                         var event = createDetailedAuditRecord(user, c, (AuditConfigurable)table, action, userComment, row, existingRow, null, List.of());
                         batch.add(event);
-                        if (batch.size() > 1000)
+                        if (batch.size() > AbstractAuditHandler.AUDIT_BATCH_SIZE)
                         {
                             auditLog.addEvents(user, batch);
                             batch.clear();


### PR DESCRIPTION
## Rationale
Speed up sample and list operations by taking per-row work out of the audit write path, the list audit formatter, and import lookup resolution. Create custom sample type indices in the materialized tables so that grids over large sample types stop scanning.

## Related Pull Requests
- https://github.com/LabKey/platform/pull/8020
- https://github.com/LabKey/limsModules/pull/2461

## Changes
- Collect audit events raised while building another audit record and write them in batches rather than one insert each                                                                                                                  
- Cache each audit type's provisioned storage table instead of rebuilding a schema and table for every event inserted                                                                                                                    
- Resolve the list audit formatter once per operation instead of once per row, and batch the row events it produces                                                                                                                      
- Stop discarding import lookup memoization mid import so a repeated value resolves once                                                                                                                                                 
- Mirror a sample type's admin defined indices onto its materialized table, and add a name index                                                                                                                                         
- Build the materialized table's non essential indices after it is published to readers so queries are not held behind the slowest index                                                                                                 
- Scope cached transaction audit events by container and audit log permission so they match what a database read returns                                                                                                                 
- Add integration tests for the list audit batch boundary, the mirrored domain index, lookup memoization, and cached transaction event scoping     

## Tasks
- [ ] Claude Code Review
- [ ] Manual Testing
- [x] Test Automation
