### PR TITLE
Don't defer any index creations during materialization

### DIFF
--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -203,6 +203,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         private boolean _includePkLookup;               // if true, will perform an initial PK lookup before attempting the AK lookup
 
         private final boolean _allowBulkLoads;
+        private final boolean _cacheMisses;
         private final Set<Pair<ColumnInfo, ColumnInfo>> _bulkLoads = new HashSet<>();
 
         private List<Triple<ColumnInfo, ColumnInfo, MultiValuedMap<?, ?>>> _maps = null;
@@ -211,10 +212,17 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
 
         public RemapConverter(@NotNull TableInfo targetTable, boolean includeTitleColumn, boolean allowBulkLoads, boolean includePkLookup)
         {
+            this(targetTable, includeTitleColumn, allowBulkLoads, includePkLookup, true);
+        }
+
+        /** @param cacheMisses false when the same operation writes the lookup target, so an unresolved key must be re-queried instead of memoized */
+        public RemapConverter(@NotNull TableInfo targetTable, boolean includeTitleColumn, boolean allowBulkLoads, boolean includePkLookup, boolean cacheMisses)
+        {
             _targetTable = targetTable;
             _includeTitleColumn = includeTitleColumn;
             _allowBulkLoads = allowBulkLoads;
             _includePkLookup = includePkLookup;
+            _cacheMisses = cacheMisses;
         }
 
         public void setIncludePkLookup(boolean includePkLookup)
@@ -371,11 +379,14 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                     vs = bulkLoaded;
                 }
 
-                // ArrayListValuedHashMap returns an empty collection if 'k' is not in the map.
-                // If there are no values in the database, stash a MISS marker to avoid re-fetching.
                 assert vs != null;
                 if (vs.isEmpty())
+                {
+                    if (!_cacheMisses)
+                        return null;
+
                     map.put(k, MISS);
+                }
             }
 
             Object v = getSingleValue(k, vs);
@@ -414,6 +425,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                 {
                     if (k == null || (k instanceof String strKey && !GUID.isGUID(strKey)))
                     {
+                        // Not a data miss: a key that isn't a GUID can never become one, so memoize regardless of _cacheMisses
                         map.put(k, MISS);
                         return null;
                     }
@@ -434,7 +446,8 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                     return map.get(k);
                 else
                 {
-                    map.put(k, MISS);
+                    if (_cacheMisses)
+                        map.put(k, MISS);
                     return null;
                 }
             }
@@ -949,7 +962,8 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             _toCol = toCol;
             _missing = missing;
             _includeTitleColumn = includeTitleColumn;
-            _remapper = new RemapConverter(_toCol.getFkTableInfo(), _includeTitleColumn, false, true);
+            // The import can create the rows this resolves against, so a miss must not outlive the row that saw it
+            _remapper = new RemapConverter(_toCol.getFkTableInfo(), _includeTitleColumn, false, true, false);
             _lookupResolutionType = lookupResolutionType;
         }
 
@@ -2328,6 +2342,33 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
 
             converter.setIncludePkLookup(true);
             assertSame("pk lookup map was rebuilt rather than retained", pkMap, converter.pkLookupMap());
+        }
+
+        @Test
+        public void remapMissIsNotMemoizedWhenCacheMissesIsOff()
+        {
+            RemapConverter converter = new RemapConverter(remapLookupTable(), true, false, true, false);
+            MultiValuedMap cache = converter.getMaps().getFirst().getRight();
+
+            String absent = "no-enum-value-supplies-this";
+            assertNull(converter.mappedValue(absent));
+            assertFalse("miss was memoized, so a row the import adds later can never resolve", cache.containsKey(absent));
+
+            // Stands in for the row appearing after the first lookup
+            Integer added = 42;
+            cache.put(absent, added);
+            assertEquals(added, converter.mappedValue(absent));
+        }
+
+        @Test
+        public void remapMissIsMemoizedByDefault()
+        {
+            RemapConverter converter = new RemapConverter(remapLookupTable(), true, false, true);
+            MultiValuedMap cache = converter.getMaps().getFirst().getRight();
+
+            String absent = "no-enum-value-supplies-this";
+            assertNull(converter.mappedValue(absent));
+            assertTrue("callers that don't write the lookup target rely on the MISS marker to avoid re-querying", cache.containsKey(absent));
         }
 
         @Test

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1374,7 +1374,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_rowid ON temp.${NAME} (rowid)")
                 .addIndex("CREATE INDEX idx_${NAME}_container ON temp.${NAME} (container)")
                 .addIndex("CREATE INDEX idx_${NAME}_root ON temp.${NAME} (rootmaterialrowid)")
-                // Deferred despite being UNIQUE. Source data guarantees uniqueness, and this is very expensive to build
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_lsid ON temp.${NAME} (lsid)");
 
             getDomainIndexDdl().forEach(builder::addIndex);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1373,11 +1373,11 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 // be added as a followup step
                 .addIndex("CREATE UNIQUE INDEX uq_${NAME}_rowid ON temp.${NAME} (rowid)")
                 .addIndex("CREATE INDEX idx_${NAME}_container ON temp.${NAME} (container)")
-                .addDeferredIndex("CREATE INDEX idx_${NAME}_root ON temp.${NAME} (rootmaterialrowid)")
+                .addIndex("CREATE INDEX idx_${NAME}_root ON temp.${NAME} (rootmaterialrowid)")
                 // Deferred despite being UNIQUE. Source data guarantees uniqueness, and this is very expensive to build
-                .addDeferredIndex("CREATE UNIQUE INDEX uq_${NAME}_lsid ON temp.${NAME} (lsid)");
+                .addIndex("CREATE UNIQUE INDEX uq_${NAME}_lsid ON temp.${NAME} (lsid)");
 
-            getDomainIndexDdl().forEach(builder::addDeferredIndex);
+            getDomainIndexDdl().forEach(builder::addIndex);
 
             if (isIncrementalUpdateDisabled())
                 builder.addInvalidCheck(() -> String.valueOf(getInvalidateCounters(_ss.getLSID()).update.get()));


### PR DESCRIPTION
## Rationale
TeamCity has seen intermittent failures on the optimization work, seemingly related to samples being inserted but not showing up (or perhaps just not yet) in the materialized table.

The deferred index creation may be a contributing factor.

## Changes
- Switch back to creating all indices before considering the materialized table ready for use

## Tasks
- [x] Claude Code Review
- [ ] Revamping and retargeting
- [ ] Manual Testing
- Test Automation - N/A
