### PR TITLE
require browser developer permission in order to create and modify survey designs

### DIFF
--- a/api/src/org/labkey/api/security/permissions/AbstractContainerScopingTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractContainerScopingTest.java
@@ -29,7 +29,9 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.roles.Role;
+import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.JunitUtil;
+import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewServlet;
@@ -67,7 +69,7 @@ public abstract class AbstractContainerScopingTest extends Assert
 
     private final List<Container> _containers = new ArrayList<>();
     private final List<User> _users = new ArrayList<>();
-    private final List<User> _rootRoleGrants = new ArrayList<>();
+    private final List<Pair<User, Class<? extends Role>>> _rootRoleGrants = new ArrayList<>();
 
     /** The site-admin user (from {@link TestContext}) that owns the test fixtures. */
     protected User getAdmin()
@@ -145,7 +147,7 @@ public abstract class AbstractContainerScopingTest extends Assert
     protected void grantRootRole(User user, Class<? extends Role> role) throws Exception
     {
         grantRole(user, ContainerManager.getRoot(), role);
-        _rootRoleGrants.add(user);
+        _rootRoleGrants.add(new Pair<>(user, role));
     }
 
     /**
@@ -187,7 +189,9 @@ public abstract class AbstractContainerScopingTest extends Assert
             try
             {
                 MutableSecurityPolicy rootPolicy = new MutableSecurityPolicy(ContainerManager.getRoot().getPolicy());
-                _rootRoleGrants.forEach(rootPolicy::clearAssignedRoles);
+                // Remove only what grantRootRole added: clearAssignedRoles() would drop every root assignment the
+                // principal holds, which is site-wide and unrecoverable if the caller passed a pre-existing user.
+                _rootRoleGrants.forEach(grant -> rootPolicy.removeRoleAssignment(grant.getKey(), RoleManager.getRole(grant.getValue())));
                 SecurityPolicyManager.savePolicyForTests(rootPolicy, admin);
             }
             catch (Exception ignored)

--- a/api/src/org/labkey/api/security/permissions/AbstractContainerScopingTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractContainerScopingTest.java
@@ -52,6 +52,7 @@ import java.util.Set;
  *   <li>{@link #createContainer(String)} — make a throwaway child of the junit container (auto-cleaned).</li>
  *   <li>{@link #createUserInRole(Container, Class)} — make a user with a role assigned in <em>one</em> folder only
  *       (auto-cleaned). Use this to obtain a caller who is, say, admin in folder A but has no rights in folder B.</li>
+ *   <li>{@link #grantRootRole(User, Class)} — grant a site-wide role such as Platform Developer (auto-cleaned).</li>
  *   <li>{@link #get(ActionURL, User)} / {@link #post(ActionURL, User)} — dispatch an in-JVM request as a given user
  *       and inspect the {@link MockHttpServletResponse} status. Parameters travel on the {@link ActionURL}.</li>
  * </ul>
@@ -66,6 +67,7 @@ public abstract class AbstractContainerScopingTest extends Assert
 
     private final List<Container> _containers = new ArrayList<>();
     private final List<User> _users = new ArrayList<>();
+    private final List<User> _rootRoleGrants = new ArrayList<>();
 
     /** The site-admin user (from {@link TestContext}) that owns the test fixtures. */
     protected User getAdmin()
@@ -136,6 +138,17 @@ public abstract class AbstractContainerScopingTest extends Assert
     }
 
     /**
+     * Grant {@code role} to {@code user} at the site level, for permissions that are only ever checked against the root
+     * container (Platform Developer and the other {@code User.isTrusted*} roles). Registered for cleanup: the root
+     * policy is site-wide, so an assignment left behind would outlive the test.
+     */
+    protected void grantRootRole(User user, Class<? extends Role> role) throws Exception
+    {
+        grantRole(user, ContainerManager.getRoot(), role);
+        _rootRoleGrants.add(user);
+    }
+
+    /**
      * Dispatch a GET to the action addressed by {@code url} as {@code user}. Put request parameters on the URL. No
      * request-body Content-Type is sent: a GET carries no body, and an "application/json" Content-Type would make an
      * API action ({@code ReadOnlyApiAction}) try to parse the empty body as JSON and fail with 400 before its
@@ -168,6 +181,20 @@ public abstract class AbstractContainerScopingTest extends Assert
     public void cleanupContainerScopingFixtures()
     {
         User admin = getAdmin();
+
+        if (!_rootRoleGrants.isEmpty())
+        {
+            try
+            {
+                MutableSecurityPolicy rootPolicy = new MutableSecurityPolicy(ContainerManager.getRoot().getPolicy());
+                _rootRoleGrants.forEach(rootPolicy::clearAssignedRoles);
+                SecurityPolicyManager.savePolicyForTests(rootPolicy, admin);
+            }
+            catch (Exception ignored)
+            {
+            }
+            _rootRoleGrants.clear();
+        }
 
         for (User user : _users)
         {

--- a/survey/src/org/labkey/survey/SurveyController.java
+++ b/survey/src/org/labkey/survey/SurveyController.java
@@ -58,6 +58,7 @@ import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.BrowserDeveloperPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
@@ -70,7 +71,6 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
-import org.labkey.api.view.UnauthorizedException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
@@ -88,8 +88,6 @@ import java.util.stream.Collectors;
 
 public class SurveyController extends SpringActionController implements SurveyUrls
 {
-    static final String TRUSTED_ANALYST_REQUIRED = "You must be either a PlatformDeveloper or TrustedAnalyst to create and edit survey designs.";
-
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(SurveyController.class);
 
     public SurveyController()
@@ -215,7 +213,7 @@ public class SurveyController extends SpringActionController implements SurveyUr
         }
     }
 
-    @RequiresPermission(InsertPermission.class)
+    @RequiresPermission(BrowserDeveloperPermission.class)
     public static class SurveyDesignAction extends SimpleViewAction<SurveyDesignForm>
     {
         private String _title = "Create Survey Design";
@@ -223,10 +221,6 @@ public class SurveyController extends SpringActionController implements SurveyUr
         @Override
         public ModelAndView getView(SurveyDesignForm form,BindException errors)
         {
-            // GH Issue 1526: the designer authors executable code, so don't render it for someone who cannot save it
-            if (!getUser().isTrustedAnalyst())
-                throw new UnauthorizedException(TRUSTED_ANALYST_REQUIRED);
-
             if (form.getRowId() != 0)
             {
                 SurveyDesign survey = SurveyManager.get().getSurveyDesignForWrite(getContainer(), getUser(), form.getRowId());
@@ -341,16 +335,12 @@ public class SurveyController extends SpringActionController implements SurveyUr
         }
     }
 
-    @RequiresPermission(InsertPermission.class)
+    @RequiresPermission(BrowserDeveloperPermission.class)
     public class SaveSurveyTemplateAction extends MutatingApiAction<SurveyDesignForm>
     {
         @Override
         public ApiResponse execute(SurveyDesignForm form, BindException errors) throws Exception
         {
-            // GH Issue 1526: treat survey designs as executable code
-            if (!getUser().isTrustedAnalyst())
-                throw new UnauthorizedException(TRUSTED_ANALYST_REQUIRED);
-
             ApiSimpleResponse response = new ApiSimpleResponse();
             // Updating the survey design. Resolve the design with container scoping.
             SurveyDesign survey = getSurveyDesign(form, id -> SurveyManager.get().getSurveyDesignForWrite(getContainer(), getUser(), id));

--- a/survey/src/org/labkey/survey/SurveyController.java
+++ b/survey/src/org/labkey/survey/SurveyController.java
@@ -88,6 +88,8 @@ import java.util.stream.Collectors;
 
 public class SurveyController extends SpringActionController implements SurveyUrls
 {
+    static final String TRUSTED_ANALYST_REQUIRED = "You must be either a PlatformDeveloper or TrustedAnalyst to create and edit survey designs.";
+
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(SurveyController.class);
 
     public SurveyController()
@@ -221,6 +223,10 @@ public class SurveyController extends SpringActionController implements SurveyUr
         @Override
         public ModelAndView getView(SurveyDesignForm form,BindException errors)
         {
+            // GH Issue 1526: the designer authors executable code, so don't render it for someone who cannot save it
+            if (!getUser().isTrustedAnalyst())
+                throw new UnauthorizedException(TRUSTED_ANALYST_REQUIRED);
+
             if (form.getRowId() != 0)
             {
                 SurveyDesign survey = SurveyManager.get().getSurveyDesignForWrite(getContainer(), getUser(), form.getRowId());
@@ -341,9 +347,9 @@ public class SurveyController extends SpringActionController implements SurveyUr
         @Override
         public ApiResponse execute(SurveyDesignForm form, BindException errors) throws Exception
         {
-            // GitHub Issue #1526 treat surveys as executable code.
+            // GH Issue 1526: treat survey designs as executable code
             if (!getUser().isTrustedAnalyst())
-                throw new UnauthorizedException("You must be either a PlatformDeveloper or TrustedAnalyst to create and edit surveys.");
+                throw new UnauthorizedException(TRUSTED_ANALYST_REQUIRED);
 
             ApiSimpleResponse response = new ApiSimpleResponse();
             // Updating the survey design. Resolve the design with container scoping.

--- a/survey/src/org/labkey/survey/SurveyController.java
+++ b/survey/src/org/labkey/survey/SurveyController.java
@@ -54,6 +54,7 @@ import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.RequiresAllOf;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
@@ -213,7 +214,7 @@ public class SurveyController extends SpringActionController implements SurveyUr
         }
     }
 
-    @RequiresPermission(BrowserDeveloperPermission.class)
+    @RequiresAllOf({InsertPermission.class, BrowserDeveloperPermission.class})
     public static class SurveyDesignAction extends SimpleViewAction<SurveyDesignForm>
     {
         private String _title = "Create Survey Design";
@@ -335,7 +336,7 @@ public class SurveyController extends SpringActionController implements SurveyUr
         }
     }
 
-    @RequiresPermission(BrowserDeveloperPermission.class)
+    @RequiresAllOf({InsertPermission.class, BrowserDeveloperPermission.class})
     public class SaveSurveyTemplateAction extends MutatingApiAction<SurveyDesignForm>
     {
         @Override

--- a/survey/src/org/labkey/survey/SurveyController.java
+++ b/survey/src/org/labkey/survey/SurveyController.java
@@ -70,6 +70,7 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
+import org.labkey.api.view.UnauthorizedException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
@@ -340,6 +341,10 @@ public class SurveyController extends SpringActionController implements SurveyUr
         @Override
         public ApiResponse execute(SurveyDesignForm form, BindException errors) throws Exception
         {
+            // GitHub Issue #1526 treat surveys as executable code.
+            if (!getUser().isTrustedAnalyst())
+                throw new UnauthorizedException("You must be either a PlatformDeveloper or TrustedAnalyst to create and edit surveys.");
+
             ApiSimpleResponse response = new ApiSimpleResponse();
             // Updating the survey design. Resolve the design with container scoping.
             SurveyDesign survey = getSurveyDesign(form, id -> SurveyManager.get().getSurveyDesignForWrite(getContainer(), getUser(), id));

--- a/survey/src/org/labkey/survey/SurveyManager.java
+++ b/survey/src/org/labkey/survey/SurveyManager.java
@@ -78,6 +78,7 @@ import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
 import org.labkey.survey.query.SurveyQuerySchema;
 import org.springframework.validation.BindException;
@@ -216,6 +217,11 @@ public class SurveyManager
 
     public SurveyDesign saveSurveyDesign(Container container, User user, SurveyDesign survey)
     {
+        // GH Issue 1526: a design's metadata is compiled and run in the viewer's browser. This is the chokepoint every
+        // caller reaches, including SurveyService; the query update path is gated separately in SurveyDesignTable.
+        if (!user.isTrustedAnalyst())
+            throw new UnauthorizedException(SurveyController.TRUSTED_ANALYST_REQUIRED);
+
         DbScope scope = SurveySchema.getInstance().getSchema().getScope();
 
         try (DbScope.Transaction transaction = scope.ensureTransaction())

--- a/survey/src/org/labkey/survey/SurveyManager.java
+++ b/survey/src/org/labkey/survey/SurveyManager.java
@@ -65,6 +65,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AbstractContainerScopingTest;
+import org.labkey.api.security.permissions.BrowserDeveloperPermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
@@ -219,8 +220,8 @@ public class SurveyManager
     {
         // GH Issue 1526: a design's metadata is compiled and run in the viewer's browser. This is the chokepoint every
         // caller reaches, including SurveyService; the query update path is gated separately in SurveyDesignTable.
-        if (!user.isTrustedAnalyst())
-            throw new UnauthorizedException(SurveyController.TRUSTED_ANALYST_REQUIRED);
+        if (!container.hasPermission(user, BrowserDeveloperPermission.class))
+            throw new UnauthorizedException("You must be either a PlatformDeveloper or TrustedAnalyst to create and edit survey designs.");
 
         DbScope scope = SurveySchema.getInstance().getSchema().getScope();
 
@@ -917,8 +918,8 @@ public class SurveyManager
                     "original description", after.getDescription());
         }
 
-        // GH Issue 1526: a design's metadata is compiled and run in the viewer's browser, so authoring one takes the
-        // same trust level as a script report. Insert permission in the folder is no longer enough on its own.
+        // GH Issue 1526: a design's metadata is compiled and run in the viewer's browser, so authoring one requires
+        // the BrowserDeveloperPermission. Both PlatformDeveloper and TrustedAnalyst are expected to satisfy the check.
         @Test
         public void testSurveyDesignAuthoringRequiresTrustedAnalyst() throws Exception
         {

--- a/survey/src/org/labkey/survey/SurveyManager.java
+++ b/survey/src/org/labkey/survey/SurveyManager.java
@@ -16,6 +16,7 @@
 
 package org.labkey.survey;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,6 +51,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.module.Module;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.ModuleResourceCache;
 import org.labkey.api.module.ModuleResourceCacheHandler;
 import org.labkey.api.module.ModuleResourceCaches;
@@ -63,8 +65,11 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AbstractContainerScopingTest;
+import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.AuthorRole;
+import org.labkey.api.security.roles.PlatformDeveloperRole;
 import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.survey.model.Survey;
 import org.labkey.api.survey.model.SurveyDesign;
@@ -74,6 +79,7 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
+import org.labkey.survey.query.SurveyQuerySchema;
 import org.springframework.validation.BindException;
 
 import java.io.IOException;
@@ -884,6 +890,9 @@ public class SurveyManager
 
             User attacker = createUserInRole(_projectA, ReaderRole.class);
             grantRole(attacker, _projectB, AuthorRole.class);
+            // GH Issue 1526 added a trusted analyst gate ahead of the container check, so the attacker needs
+            // that role for this test to still reach the scoping logic it was written to cover.
+            grantRootRole(attacker, PlatformDeveloperRole.class);
 
             ActionURL url = new ActionURL(SurveyController.SaveSurveyTemplateAction.class, _projectB)
                     .addParameter("rowId", designId)
@@ -900,6 +909,47 @@ public class SurveyManager
                     "Design owned by A", after.getLabel());
             assertEquals("Design description must NOT be overwritten from another container",
                     "original description", after.getDescription());
+        }
+
+        // GH Issue 1526: a design's metadata is compiled and run in the viewer's browser, so authoring one takes the
+        // same trust level as a script report. Insert permission in the folder is no longer enough on its own.
+        @Test
+        public void testSurveyDesignAuthoringRequiresTrustedAnalyst() throws Exception
+        {
+            activateModules(_projectA, ModuleLoader.getInstance().getModule("Survey"));
+            User author = createUserInRole(_projectA, AuthorRole.class);
+            assertFalse("Test author must not be a trusted analyst", author.isTrustedAnalyst());
+            assertTrue("Site admin is expected to satisfy the trusted analyst check", _user.isTrustedAnalyst());
+
+            TableInfo designs = QueryService.get()
+                    .getUserSchema(author, _projectA, SurveyQuerySchema.SCHEMA_NAME)
+                    .getTable(SurveyQuerySchema.SURVEY_DESIGN_TABLE_NAME);
+            assertNotNull("Survey designs table should resolve for an author", designs);
+
+            // The query update path is closed to an untrusted author, so query-insertRows.api cannot reach the metadata column
+            assertFalse("An untrusted author must not be able to insert a survey design",
+                    designs.hasPermission(author, InsertPermission.class));
+            assertFalse("An untrusted author must not be able to update a survey design",
+                    designs.hasPermission(author, UpdatePermission.class));
+            // ...but reading the designs grid is unaffected
+            assertTrue("An author must still be able to read survey designs",
+                    designs.hasPermission(author, ReadPermission.class));
+
+            // A trusted user keeps both write paths
+            TableInfo adminDesigns = QueryService.get()
+                    .getUserSchema(_user, _projectA, SurveyQuerySchema.SCHEMA_NAME)
+                    .getTable(SurveyQuerySchema.SURVEY_DESIGN_TABLE_NAME);
+            assertTrue("A trusted user must be able to insert a survey design",
+                    adminDesigns.hasPermission(_user, InsertPermission.class));
+            assertTrue("A trusted user must be able to update a survey design",
+                    adminDesigns.hasPermission(_user, UpdatePermission.class));
+
+            // The action rejects the same author. UnauthorizedException resolves to 403 rather than 401 for a logged-in user.
+            ActionURL url = new ActionURL(SurveyController.SaveSurveyTemplateAction.class, _projectA)
+                    .addParameter("label", "Untrusted design")
+                    .addParameter("metadata", "{\"survey\":{\"beforeLoad\":{\"fn\":\"function(){}\"},"
+                            + "\"sections\":[{\"title\":\"s\",\"questions\":[]}]}}");
+            assertStatus(HttpServletResponse.SC_FORBIDDEN, post(url, author));
         }
 
         @Test

--- a/survey/src/org/labkey/survey/SurveyManager.java
+++ b/survey/src/org/labkey/survey/SurveyManager.java
@@ -94,6 +94,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -220,8 +221,10 @@ public class SurveyManager
     {
         // GH Issue 1526: a design's metadata is compiled and run in the viewer's browser. This is the chokepoint every
         // caller reaches, including SurveyService; the query update path is gated separately in SurveyDesignTable.
-        if (!container.hasPermission(user, BrowserDeveloperPermission.class))
-            throw new UnauthorizedException("You must be either a PlatformDeveloper or TrustedAnalyst to create and edit survey designs.");
+        // BrowserDeveloperPermission is a site permission that root role assignments grant in every container, so it
+        // has to be required alongside the folder-scoped write check, never in place of it.
+        if (!container.hasPermissions(user, Set.of(InsertPermission.class, BrowserDeveloperPermission.class)))
+            throw new UnauthorizedException("You must be either a PlatformDeveloper or TrustedAnalyst with insert permission in this folder to create and edit survey designs.");
 
         DbScope scope = SurveySchema.getInstance().getSchema().getScope();
 
@@ -842,9 +845,12 @@ public class SurveyManager
         @Before
         public void setUp()
         {
+            // Every test here dispatches through SurveyController, and DefaultModule.dispatch 404s before the action
+            // runs unless the module is active in the container.
+            Module survey = ModuleLoader.getInstance().getModule("Survey");
             _user = getAdmin();
-            _projectA = createContainer("A");
-            _projectB = createContainer("B");
+            _projectA = createContainer("A", survey);
+            _projectB = createContainer("B", survey);
         }
 
         @Test
@@ -897,15 +903,16 @@ public class SurveyManager
 
             User attacker = createUserInRole(_projectA, ReaderRole.class);
             grantRole(attacker, _projectB, AuthorRole.class);
-            // GH Issue 1526 added a trusted analyst gate ahead of the container check, so the attacker needs
-            // that role for this test to still reach the scoping logic it was written to cover.
+            // GH Issue 1526 gates the action on BrowserDeveloperPermission, so the attacker needs a developer role
+            // to reach the container check this test covers.
             grantRootRole(attacker, PlatformDeveloperRole.class);
 
             ActionURL url = new ActionURL(SurveyController.SaveSurveyTemplateAction.class, _projectB)
                     .addParameter("rowId", designId)
                     .addParameter("label", "STOLEN")
                     .addParameter("description", "hijacked");
-            post(url, attacker);
+            // Container scoping rejects the cross-folder rowId before the design is touched
+            assertStatus(HttpServletResponse.SC_NOT_FOUND, post(url, attacker));
 
             // The design must still belong to folder A with its original field values: not reparented, not overwritten.
             SurveyDesign after = sm.getSurveyDesignForRead(_projectA, _user, designId);
@@ -923,7 +930,6 @@ public class SurveyManager
         @Test
         public void testSurveyDesignAuthoringRequiresTrustedAnalyst() throws Exception
         {
-            activateModules(_projectA, ModuleLoader.getInstance().getModule("Survey"));
             User author = createUserInRole(_projectA, AuthorRole.class);
             assertFalse("Test author must not be a trusted analyst", author.isTrustedAnalyst());
             assertTrue("Site admin is expected to satisfy the trusted analyst check", _user.isTrustedAnalyst());

--- a/survey/src/org/labkey/survey/query/SurveyDesignQueryView.java
+++ b/survey/src/org/labkey/survey/query/SurveyDesignQueryView.java
@@ -17,6 +17,7 @@ package org.labkey.survey.query;
 
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
@@ -52,7 +53,9 @@ public class SurveyDesignQueryView extends QueryView
     {
         super.populateButtonBar(view, bar);
 
-        if (getContainer().hasPermission(getUser(), InsertPermission.class))
+        // Authoring a design takes the trusted analyst role, which SurveyDesignTable enforces; ask the table, not the container.
+        TableInfo table = getTable();
+        if (table != null && table.hasPermission(getUser(), InsertPermission.class))
         {
             ActionURL insertURL = new ActionURL(SurveyController.SurveyDesignAction.class, getContainer());
             insertURL.addReturnUrl(getReturnUrl());

--- a/survey/src/org/labkey/survey/query/SurveyDesignQueryView.java
+++ b/survey/src/org/labkey/survey/query/SurveyDesignQueryView.java
@@ -17,11 +17,10 @@ package org.labkey.survey.query;
 
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
-import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.security.permissions.BrowserDeveloperPermission;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
 import org.labkey.survey.SurveyController;
@@ -53,9 +52,7 @@ public class SurveyDesignQueryView extends QueryView
     {
         super.populateButtonBar(view, bar);
 
-        // Authoring a design takes the trusted analyst role, which SurveyDesignTable enforces; ask the table, not the container.
-        TableInfo table = getTable();
-        if (table != null && table.hasPermission(getUser(), InsertPermission.class))
+        if (getContainer().hasPermission(getUser(), BrowserDeveloperPermission.class))
         {
             ActionURL insertURL = new ActionURL(SurveyController.SurveyDesignAction.class, getContainer());
             insertURL.addReturnUrl(getReturnUrl());

--- a/survey/src/org/labkey/survey/query/SurveyDesignQueryView.java
+++ b/survey/src/org/labkey/survey/query/SurveyDesignQueryView.java
@@ -21,10 +21,13 @@ import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.permissions.BrowserDeveloperPermission;
+import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
 import org.labkey.survey.SurveyController;
 import org.springframework.validation.BindException;
+
+import java.util.Set;
 
 /**
  * User: klum
@@ -52,7 +55,7 @@ public class SurveyDesignQueryView extends QueryView
     {
         super.populateButtonBar(view, bar);
 
-        if (getContainer().hasPermission(getUser(), BrowserDeveloperPermission.class))
+        if (getContainer().hasPermissions(getUser(), Set.of(InsertPermission.class, BrowserDeveloperPermission.class)))
         {
             ActionURL insertURL = new ActionURL(SurveyController.SurveyDesignAction.class, getContainer());
             insertURL.addReturnUrl(getReturnUrl());

--- a/survey/src/org/labkey/survey/query/SurveyDesignTable.java
+++ b/survey/src/org/labkey/survey/query/SurveyDesignTable.java
@@ -25,8 +25,11 @@ import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.view.ActionURL;
 import org.labkey.survey.SurveyController;
 
@@ -78,6 +81,12 @@ public class SurveyDesignTable extends FilteredTable<SurveyQuerySchema>
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
+        // GitHub Issue #1526 treat surveys as executable code.
+        if (perm.equals(InsertPermission.class) || perm.equals(UpdatePermission.class))
+        {
+            if (!(user instanceof User u) || !u.isTrustedAnalyst())
+                return false;
+        }
         return getContainer().hasPermission(user, perm);
     }
 

--- a/survey/src/org/labkey/survey/query/SurveyDesignTable.java
+++ b/survey/src/org/labkey/survey/query/SurveyDesignTable.java
@@ -25,8 +25,8 @@ import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryUpdateService;
-import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.BrowserDeveloperPermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.UpdatePermission;
@@ -84,7 +84,7 @@ public class SurveyDesignTable extends FilteredTable<SurveyQuerySchema>
         // GitHub Issue #1526 treat surveys as executable code.
         if (perm.equals(InsertPermission.class) || perm.equals(UpdatePermission.class))
         {
-            if (!(user instanceof User u) || !u.isTrustedAnalyst())
+            if (!getContainer().hasPermission(user, BrowserDeveloperPermission.class))
                 return false;
         }
         return getContainer().hasPermission(user, perm);


### PR DESCRIPTION
## Rationale
https://github.com/LabKey/internal-issues/issues/1526

Surveys have the ability to inject and execute javascript code onto the page previously insert permissions were required. This change raises that requirement to be similar to reports and other script authoring actions. 