### PR TITLE
Improve health checking and avoid leaking unwrapped connections

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1435,29 +1435,43 @@ public class DbScope
             throw new ConfigurationException("Can't create a database connection for data source " + getDbScopeLoader().getDsName(), e);
         }
 
-        if (!conn.getAutoCommit())
-            throw new ConfigurationException("A database connection is in an unexpected state: auto-commit is false. This indicates a configuration problem with the datasource definition or the database connection pool.");
+        // Until the ConnectionWrapper exists, nothing tracks the raw connection. Close it here if we fail to create a wrapper
+        boolean wrapped = false;
 
-        //
-        // Handle one time per-connection setup
-        // relies on pool implementation reusing same connection/wrapper instances
-        //
-
-        Connection delegate = getDelegate(conn);
-        Integer spid = _initializedConnections.get(delegate);
-
-        if (null == spid)
+        try
         {
-            if (null != _dialect)
+            if (!conn.getAutoCommit())
+                throw new ConfigurationException("A database connection is in an unexpected state: auto-commit is false. This indicates a configuration problem with the datasource definition or the database connection pool.");
+
+            //
+            // Handle one time per-connection setup
+            // relies on pool implementation reusing same connection/wrapper instances
+            //
+
+            Connection delegate = getDelegate(conn);
+            Integer spid = _initializedConnections.get(delegate);
+
+            if (null == spid)
             {
-                _dialect.prepareConnection(conn);
-                spid = _dialect.getSPID(delegate);
+                if (null != _dialect)
+                {
+                    _dialect.prepareConnection(conn);
+                    spid = _dialect.getSPID(delegate);
+                }
+
+                _initializedConnections.put(delegate, spid == null ? spidUnknown : spid);
             }
 
-            _initializedConnections.put(delegate, spid == null ? spidUnknown : spid);
-        }
+            ConnectionWrapper result = new ConnectionWrapper(conn, this, spid, type, log);
+            wrapped = true;
 
-        return new ConnectionWrapper(conn, this, spid, type, log);
+            return result;
+        }
+        finally
+        {
+            if (!wrapped)
+                releaseConnection(conn);
+        }
     }
 
     /**

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1435,9 +1435,6 @@ public class DbScope
             throw new ConfigurationException("Can't create a database connection for data source " + getDbScopeLoader().getDsName(), e);
         }
 
-        // Until the ConnectionWrapper exists, nothing tracks the raw connection. Close it here if we fail to create a wrapper
-        boolean wrapped = false;
-
         try
         {
             if (!conn.getAutoCommit())
@@ -1462,15 +1459,13 @@ public class DbScope
                 _initializedConnections.put(delegate, spid == null ? spidUnknown : spid);
             }
 
-            ConnectionWrapper result = new ConnectionWrapper(conn, this, spid, type, log);
-            wrapped = true;
-
-            return result;
+            return new ConnectionWrapper(conn, this, spid, type, log);
         }
-        finally
+        catch (Throwable t)
         {
-            if (!wrapped)
-                releaseConnection(conn);
+            // If the ConnectionWrapper didn't get created and returned, nothing else can close the connection
+            closeQuietly(conn, t);
+            throw t;
         }
     }
 
@@ -1486,6 +1481,22 @@ public class DbScope
         catch (SQLException e)
         {
             LOG.warn("Error releasing connection", e);
+        }
+    }
+
+    /**
+     * Release a connection while an exception is already propagating. Pool implementations can throw unchecked from
+     * close(), which would otherwise replace the failure we're unwinding from.
+     **/
+    public void closeQuietly(Connection conn, Throwable propagating)
+    {
+        try
+        {
+            releaseConnection(conn);
+        }
+        catch (Throwable t)
+        {
+            propagating.addSuppressed(t);
         }
     }
 

--- a/api/src/org/labkey/api/data/dialect/StandardJdbcMetaDataLocator.java
+++ b/api/src/org/labkey/api/data/dialect/StandardJdbcMetaDataLocator.java
@@ -37,12 +37,26 @@ public class StandardJdbcMetaDataLocator implements JdbcMetaDataLocator
     {
         _scope = scope;
         _connection = getConnection();
-        _dbmd = _connection.getMetaData();
 
-        _schemaName = schemaName;
-        _schemaNamePattern = schemaNamePattern;
-        _tableName = tableName;
-        _tableNamePattern = tableNamePattern;
+        // Ensure we close the connection if we're going to throw from the constructor
+        boolean constructed = false;
+
+        try
+        {
+            _dbmd = _connection.getMetaData();
+
+            _schemaName = schemaName;
+            _schemaNamePattern = schemaNamePattern;
+            _tableName = tableName;
+            _tableNamePattern = tableNamePattern;
+
+            constructed = true;
+        }
+        finally
+        {
+            if (!constructed)
+                scope.releaseConnection(_connection);
+        }
     }
 
     protected Connection getConnection() throws SQLException

--- a/api/src/org/labkey/api/data/dialect/StandardJdbcMetaDataLocator.java
+++ b/api/src/org/labkey/api/data/dialect/StandardJdbcMetaDataLocator.java
@@ -38,9 +38,6 @@ public class StandardJdbcMetaDataLocator implements JdbcMetaDataLocator
         _scope = scope;
         _connection = getConnection();
 
-        // Ensure we close the connection if we're going to throw from the constructor
-        boolean constructed = false;
-
         try
         {
             _dbmd = _connection.getMetaData();
@@ -49,13 +46,12 @@ public class StandardJdbcMetaDataLocator implements JdbcMetaDataLocator
             _schemaNamePattern = schemaNamePattern;
             _tableName = tableName;
             _tableNamePattern = tableNamePattern;
-
-            constructed = true;
         }
-        finally
+        catch (Throwable t)
         {
-            if (!constructed)
-                scope.releaseConnection(_connection);
+            // Nobody else can close the connection for us if we throw from the constructor
+            scope.closeQuietly(_connection, t);
+            throw t;
         }
     }
 

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -360,6 +360,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -579,6 +580,9 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
 
     private void registerHealthChecks()
     {
+        // Data sources that were unreachable on the previous check, so we can log transitions instead of every poll
+        Set<String> failedDataSources = ConcurrentHashMap.newKeySet();
+
         HealthCheckRegistry.get().registerHealthCheck("database",  HealthCheckRegistry.DEFAULT_CATEGORY, () ->
             {
                 Map<String, Object> healthValues = new HashMap<>();
@@ -592,11 +596,15 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                     }
                     // Some failures come as ConfigurationException, not SQLException. Cast a wide net to ensure
                     // we return a 200 saying we're not healthy instead of a 500
-                    catch (Throwable e)
+                    catch (Exception e)
                     {
-                        LOG.debug("Failed to get connection for data source " + dbScope.getDataSourceName(), e);
+                        if (failedDataSources.add(dbScope.getDataSourceName()))
+                            LOG.warn("Failed to get connection for data source {}", dbScope.getDataSourceName(), e);
                         dbConnected = false;
                     }
+
+                    if (dbConnected && failedDataSources.remove(dbScope.getDataSourceName()))
+                        LOG.info("Reconnected to data source {}", dbScope.getDataSourceName());
 
                     healthValues.put(dbScope.getDatabaseName(), dbConnected);
                     allConnected &= dbConnected;

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -79,6 +79,7 @@ import org.labkey.api.data.WorkbookContainerType;
 import org.labkey.api.data.dialect.BasePostgreSqlDialect;
 import org.labkey.api.data.dialect.PostgreSqlService;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.data.dialect.SqlDialect.DataSourcePropertyReader;
 import org.labkey.api.data.dialect.SqlDialectManager;
 import org.labkey.api.data.dialect.SqlDialectRegistry;
 import org.labkey.api.data.statistics.StatsService;
@@ -344,7 +345,6 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.Connection;
-import java.sql.SQLException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -590,8 +590,11 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                     {
                         dbConnected = conn != null;
                     }
-                    catch (SQLException e)
+                    // Some failures come as ConfigurationException, not SQLException. Cast a wide net to ensure
+                    // we return a 200 saying we're not healthy instead of a 500
+                    catch (Throwable e)
                     {
+                        LOG.debug("Failed to get connection for data source " + dbScope.getDataSourceName(), e);
                         dbConnected = false;
                     }
 


### PR DESCRIPTION
## Rationale
Health checks can pile up and start returning 500s instead of 200s and leak connections when an external data source has gotten itself into a bad state.

## Changes
- Release a fetched connection if we're unable to create a wrapper, preventing it from leaking
- Handle `Throwable` when we fail to get a connection during health check, as some problems manifest as `ConfigurationException` etc instead of `SQLException`

## Tasks
- [x] Claude Code Review
- Manual Testing - N/A
- Test Automation - N/A
