### PR TITLE
JUnit runner page improvements

### DIFF
--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -1257,8 +1257,6 @@ public abstract class SpringActionController implements Controller, HasViewConte
         Class<?> actionClass = getActionForThread();
         if (null == actionClass)
             return;
-        if (actionClass.getName().contains("JunitController"))
-            return;
 
         ViewContext vc = HttpView.currentContext();
         boolean readonly = false;

--- a/api/src/org/labkey/api/view/ViewContext.java
+++ b/api/src/org/labkey/api/view/ViewContext.java
@@ -164,9 +164,14 @@ public class ViewContext implements MessageSource, ContainerContext, ContainerUs
         return new StackResetter(context, stackSize);
     }
 
+    /**
+     * Ensures a view context is available without disturbing one that's already there: if a view is
+     * already on the stack, returns it wrapped in a no-op resetter; otherwise pushes a new mock context
+     * via {@link #pushMockViewContext}.
+     */
     public static StackResetter ensureViewContext(User user, Container c, ActionURL url)
     {
-        if (!HttpView.hasCurrentView())
+        if (HttpView.hasCurrentView())
             return new StackResetter(HttpView.currentContext(), HttpView.getStackSize());
         else
             return pushMockViewContext(user, c, url);

--- a/api/src/org/labkey/api/view/ViewContext.java
+++ b/api/src/org/labkey/api/view/ViewContext.java
@@ -164,6 +164,13 @@ public class ViewContext implements MessageSource, ContainerContext, ContainerUs
         return new StackResetter(context, stackSize);
     }
 
+    public static StackResetter ensureViewContext(User user, Container c, ActionURL url)
+    {
+        if (!HttpView.hasCurrentView())
+            return new StackResetter(HttpView.currentContext(), HttpView.getStackSize());
+        else
+            return pushMockViewContext(user, c, url);
+    }
 
     // Needed by background threads that call entrypoints that require ViewContexts
     // TODO: Well-behaved interfaces should not take ViewContexts -- clean up query, et al to remove ViewContext params
@@ -178,7 +185,11 @@ public class ViewContext implements MessageSource, ContainerContext, ContainerUs
         if (null != url)
             context.setBindPropertyValues(url.getPropertyValues());
 
-        HttpServletRequest request = ViewServlet.mockRequest("GET", url, user, null, null);
+        // Inherit current request's method, if present.
+        HttpServletRequest currentRequest = HttpView.currentRequest();
+        String mockRequestMethod = pushViewContext && currentRequest != null ? currentRequest.getMethod() : "GET";
+
+        HttpServletRequest request = ViewServlet.mockRequest(mockRequestMethod, url, user, null, null);
         context.setRequest(request);
 
         // Major hack -- QueryView needs the context pushed onto the ViewContext stack in thread local 

--- a/core/src/org/labkey/core/junit/JunitController.java
+++ b/core/src/org/labkey/core/junit/JunitController.java
@@ -41,6 +41,7 @@ import org.labkey.api.action.StatusAppender;
 import org.labkey.api.action.StatusReportingRunnable;
 import org.labkey.api.action.StatusReportingRunnableAction;
 import org.labkey.api.jsp.JspTest;
+import org.labkey.api.security.MethodsAllowed;
 import org.labkey.api.security.RequiresNoPermission;
 import org.labkey.api.security.RequiresSiteAdmin;
 import org.labkey.api.security.User;
@@ -57,6 +58,8 @@ import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.template.PageConfig;
 import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
+
+import static org.labkey.api.util.HttpUtil.Method.POST;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -145,6 +148,7 @@ public class JunitController extends SpringActionController
 
 
     @RequiresSiteAdmin
+    @MethodsAllowed(POST)
     public class RunAction extends SimpleViewAction<TestForm>
     {
         @Override
@@ -220,6 +224,7 @@ public class JunitController extends SpringActionController
     private static final String RESULTS_SESSION_KEY = "JUnit_Results";
 
     @RequiresSiteAdmin
+    @MethodsAllowed(POST)
     public static class Run3Action extends SimpleViewAction<TestForm>
     {
         @Override
@@ -300,6 +305,7 @@ public class JunitController extends SpringActionController
 
 
     @RequiresSiteAdmin
+    @MethodsAllowed(POST)
     public static class Run2Action extends StatusReportingRunnableAction
     {
         private List<Class<?>> getTestClasses(TestForm form)

--- a/core/src/org/labkey/core/junit/JunitController.java
+++ b/core/src/org/labkey/core/junit/JunitController.java
@@ -32,7 +32,9 @@ import org.json.JSONObject;
 import org.junit.runner.notification.Failure;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
+import org.labkey.api.action.BaseViewAction;
 import org.labkey.api.action.MutatingApiAction;
+import org.labkey.api.action.NavTrailAction;
 import org.labkey.api.action.PermissionCheckableAction;
 import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.SimpleViewAction;
@@ -57,6 +59,7 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.template.PageConfig;
 import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
 import static org.labkey.api.util.HttpUtil.Method.POST;
@@ -147,9 +150,38 @@ public class JunitController extends SpringActionController
     }
 
 
-    @RequiresSiteAdmin
+    /**
+     * Like {@link SimpleViewAction} — one code path, no form redisplay — but POST-only and not one of
+     * the types {@link SpringActionController#checkForMutatingSql} treats as unconditionally read-only,
+     * so subclasses can legitimately run mutating SQL.
+     */
     @MethodsAllowed(POST)
-    public class RunAction extends SimpleViewAction<TestForm>
+    private abstract static class SimplePostViewAction<FORM> extends BaseViewAction<FORM> implements NavTrailAction
+    {
+        @Override
+        public final ModelAndView handleRequest() throws Exception
+        {
+            BindException errors = defaultBindParameters(getPropertyValues());
+            return getView((FORM) errors.getTarget(), errors);
+        }
+
+        @Override
+        protected final String getCommandClassMethodName()
+        {
+            return "getView";
+        }
+
+        @Override
+        public final void validate(Object target, Errors errors)
+        {
+        }
+
+        public abstract ModelAndView getView(FORM form, BindException errors) throws Exception;
+    }
+
+
+    @RequiresSiteAdmin
+    public class RunAction extends SimplePostViewAction<TestForm>
     {
         @Override
         public ModelAndView getView(TestForm form, BindException errors) throws Exception
@@ -224,8 +256,7 @@ public class JunitController extends SpringActionController
     private static final String RESULTS_SESSION_KEY = "JUnit_Results";
 
     @RequiresSiteAdmin
-    @MethodsAllowed(POST)
-    public static class Run3Action extends SimpleViewAction<TestForm>
+    public static class Run3Action extends SimplePostViewAction<TestForm>
     {
         @Override
         public ModelAndView getView(TestForm form, BindException errors) throws Exception

--- a/core/src/org/labkey/core/junit/runner.jsp
+++ b/core/src/org/labkey/core/junit/runner.jsp
@@ -27,25 +27,8 @@
 <%@ page import="org.labkey.core.junit.JunitController.Run3Action" %>
 <%@ page import="org.labkey.core.junit.JunitController.RunAction" %>
 <%@ page import="java.util.stream.Stream" %>
-<%@ page import="static DOM.A" %>
-<%@ page import="static DOM.DETAILS" %>
-<%@ page import="static DOM.DIV" %>
-<%@ page import="static DOM.HR" %>
-<%@ page import="static DOM.LI" %>
-<%@ page import="static DOM.LK" %>
-<%@ page import="static DOM.Renderable" %>
-<%@ page import="static DOM.SPAN" %>
-<%@ page import="static DOM.SUMMARY" %>
-<%@ page import="static DOM.UL" %>
-<%@ page import="static DOM.at" %>
-<%@ page import="static DOM.cl" %>
-<%@ page import="static DOM.createHtmlFragment" %>
-<%@ page import="static org.labkey.api.util.DOM.Attribute.action" %>
-<%@ page import="static org.labkey.api.util.DOM.Attribute.href" %>
-<%@ page import="static org.labkey.api.util.DOM.Attribute.method" %>
-<%@ page import="static org.labkey.api.util.DOM.Attribute.name" %>
-<%@ page import="static org.labkey.api.util.DOM.Attribute.open" %>
-<%@ page import="static org.labkey.api.util.DOM.Attribute.style" %>
+<%@ page import="static org.labkey.api.util.DOM.*" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.*" %>
 <%@ page import="static org.labkey.api.util.HtmlString.NBSP" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!

--- a/core/src/org/labkey/core/junit/runner.jsp
+++ b/core/src/org/labkey/core/junit/runner.jsp
@@ -42,7 +42,7 @@
     private Renderable renderLeaf(Description desc, ActionURL testCaseURL)
     {
         return LI(desc.getMethodName() != null
-                ? A(at(href, testCaseURL.clone().addParameter("methodName", desc.getMethodName())), desc.getMethodName())
+                ? simpleLink(desc.getMethodName(), testCaseURL.clone().addParameter("methodName", desc.getMethodName())).usePost()
                 : desc.toString());
     }
 %>
@@ -92,18 +92,18 @@
 
                     NBSP, "\u22EE", NBSP,
 
-                    button("Run All").href(new ActionURL(RunAction.class, getContainer())),
+                    button("Run All").href(new ActionURL(RunAction.class, getContainer())).usePost(),
                     NBSP,
-                    button("Run BVT").href(new ActionURL(RunAction.class, getContainer()).addParameter("when", "BVT")),
+                    button("Run BVT").href(new ActionURL(RunAction.class, getContainer()).addParameter("when", "BVT")).usePost(),
                     NBSP,
-                    button("Run DRT").href(new ActionURL(RunAction.class, getContainer()).addParameter("when", "DRT")),
+                    button("Run DRT").href(new ActionURL(RunAction.class, getContainer()).addParameter("when", "DRT")).usePost(),
 
                     NBSP, "\u22EE", NBSP,
 
                     LK.FORM(at(style, "display:inline-block;", name, "run2", action, new ActionURL(Run2Action.class, getContainer()), method, "POST"),
                             button("Run In Background #1 (Experimental)").submit(true)),
                     NBSP,
-                    button("Run In Background #2 (Experimental)").href(new ActionURL(Run3Action.class, getContainer()))
+                    button("Run In Background #2 (Experimental)").href(new ActionURL(Run3Action.class, getContainer())).usePost()
                 ),
             HR()).appendTo(out);
 
@@ -111,7 +111,7 @@
 
     DIV(testCases.keySet().stream().map(module ->
         DETAILS(at(open, true),
-            SUMMARY(A(at(href, new ActionURL(RunAction.class, getContainer()).addParameter("module", module)), module)),
+            SUMMARY(simpleLink(module, new ActionURL(RunAction.class, getContainer()).addParameter("module", module)).usePost()),
             DIV(cl("module-details"), testCases.get(module).stream().map(clazz -> {
                 Runner runner = Request.aClass(clazz).getRunner();
                 Description desc = runner.getDescription();
@@ -121,7 +121,7 @@
                 return DIV(cl("labkey-indented"),
                         DETAILS(
                                 SUMMARY(
-                                    A(at(href, testCaseURL.getLocalURIString()), displayName),
+                                    simpleLink(displayName, testCaseURL).usePost(),
                                     showRunButtons ? SPAN(cl("scope-tag", JunitController.getScope(clazz).name()), JunitController.getScope(clazz).name()) : null,
                                         (desc.testCount() > 1 ? SPAN(cl("test-count"), "(" + desc.testCount() + ")") : "")),
                                 UL(leafDescriptions(desc).map(child -> renderLeaf(child, testCaseURL)))

--- a/core/src/org/labkey/core/junit/runner.jsp
+++ b/core/src/org/labkey/core/junit/runner.jsp
@@ -26,10 +26,43 @@
 <%@ page import="org.labkey.core.junit.JunitController.Run2Action" %>
 <%@ page import="org.labkey.core.junit.JunitController.Run3Action" %>
 <%@ page import="org.labkey.core.junit.JunitController.RunAction" %>
-<%@ page import="static org.labkey.api.util.DOM.*" %>
-<%@ page import="static org.labkey.api.util.DOM.Attribute.*" %>
+<%@ page import="java.util.stream.Stream" %>
+<%@ page import="static DOM.A" %>
+<%@ page import="static DOM.DETAILS" %>
+<%@ page import="static DOM.DIV" %>
+<%@ page import="static DOM.HR" %>
+<%@ page import="static DOM.LI" %>
+<%@ page import="static DOM.LK" %>
+<%@ page import="static DOM.Renderable" %>
+<%@ page import="static DOM.SPAN" %>
+<%@ page import="static DOM.SUMMARY" %>
+<%@ page import="static DOM.UL" %>
+<%@ page import="static DOM.at" %>
+<%@ page import="static DOM.cl" %>
+<%@ page import="static DOM.createHtmlFragment" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.action" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.href" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.method" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.name" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.open" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.style" %>
 <%@ page import="static org.labkey.api.util.HtmlString.NBSP" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%!
+    // Parameterized (and other Suite-based) runners nest a level of per-invocation Descriptions between the
+    // class and its test methods; flatten to leaves so every test method renders at the same list level.
+    private Stream<Description> leafDescriptions(Description desc)
+    {
+        return desc.isTest() ? Stream.of(desc) : desc.getChildren().stream().flatMap(this::leafDescriptions);
+    }
+
+    private Renderable renderLeaf(Description desc, ActionURL testCaseURL)
+    {
+        return LI(desc.getMethodName() != null
+                ? A(at(href, testCaseURL.clone().addParameter("methodName", desc.getMethodName())), desc.getMethodName())
+                : desc.toString());
+    }
+%>
 <%
     JspView<JUnitViewBean> me = HttpView.currentView();
     JUnitViewBean bean = me.getModelBean();
@@ -108,10 +141,7 @@
                                     A(at(href, testCaseURL.getLocalURIString()), displayName),
                                     showRunButtons ? SPAN(cl("scope-tag", JunitController.getScope(clazz).name()), JunitController.getScope(clazz).name()) : null,
                                         (desc.testCount() > 1 ? SPAN(cl("test-count"), "(" + desc.testCount() + ")") : "")),
-                                UL(desc.getChildren().stream().map(
-                                        child -> LI(child.getMethodName() != null
-                                                ? A(at(href, testCaseURL.clone().addParameter("methodName", child.getMethodName())), child.getMethodName())
-                                                : child.toString())))
+                                UL(leafDescriptions(desc).map(child -> renderLeaf(child, testCaseURL)))
 
                         ));
             }))

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -1118,7 +1118,7 @@ public class StudyPublishManager implements StudyPublishService
         if (sampleType != null && sampleType.getAutoLinkTargetContainer() != null)
         {
             // Issue 51454 : QueryView needs a view context to initialize properly. Ensure a mock view context when running in the background
-            try (EnsureViewContext ignore = new EnsureViewContext(container, user))
+            try (ViewContext.StackResetter _ = ViewContext.ensureViewContext(user, container, new ActionURL()))
             {
                 // attempt to auto link the results
                 QuerySettings qs = new QuerySettings(new MutablePropertyValues(), QueryView.DATAREGIONNAME_DEFAULT);
@@ -1208,7 +1208,7 @@ public class StudyPublishManager implements StudyPublishService
                 if (validStudies.contains(study))
                 {
                     // Issue 49253 : QueryView needs a view context to initialize properly. Ensure a mock view context when running in the background
-                    try (EnsureViewContext ignore = new EnsureViewContext(container, user))
+                    try (ViewContext.StackResetter _ = ViewContext.ensureViewContext(user, container, new ActionURL()))
                     {
                         LOG.debug("Resolved target study in container {} for auto-linking with {} from container {}", targetContainerPath, sampleTypeName, containerPath);
                         List<Map<String, Object>> dataMaps = new ArrayList<>();
@@ -1751,25 +1751,4 @@ public class StudyPublishManager implements StudyPublishService
         }
     }
 
-    private static class EnsureViewContext implements Closeable
-    {
-        private final boolean _hasCurrentView;
-        private final int _stackSize;
-
-        private EnsureViewContext(Container container, User user)
-        {
-            _hasCurrentView =  HttpView.hasCurrentView();
-            _stackSize = HttpView.getStackSize();
-
-            if (!_hasCurrentView)
-                ViewContext.getMockViewContext(user, container, new ActionURL(), true);
-        }
-
-        @Override
-        public void close()
-        {
-            if (!_hasCurrentView)
-                HttpView.resetStackSize(_stackSize);
-        }
-    }
 }


### PR DESCRIPTION
## Rationale
For the most part, one is able to run individual server-side JUnit tests from `junit-begin.view`. This is not the case for parameterized test classes.
<img width="426" height="134" alt="image" src="https://github.com/user-attachments/assets/2e4751bc-3a42-46dc-8f37-b53d297620a3" />

A minor change to how the page iterates through tests makes it function correctly for these tests.
<img width="426" height="177" alt="image" src="https://github.com/user-attachments/assets/d77825f5-54b6-434d-8dc0-1bd30a6e7b3c" />

Separately, the actions that actually run tests accepted GET requests, so a test run (some of which are expensive or have side effects) could be triggered by simply visiting a link.

## Related Pull Requests
- N/A

## Changes
- Fix the JUnit runner page to list every test method of a parameterized test class, instead of one opaque, unclickable entry per parameter set.
- Require POST for the actions that execute tests (RunAction, Run2Action, Run3Action); GoAction already required it.